### PR TITLE
 Updated parameter 'Hcal_modules_gap' value from '0*mm' to '0.001*mm'…

### DIFF
--- a/ILD/compact/ILD_l1_v01/model_parameters_ILD_l1_v01.xml
+++ b/ILD/compact/ILD_l1_v01/model_parameters_ILD_l1_v01.xml
@@ -187,7 +187,7 @@
   <constant name="Hcal_layer_pattern" value="11111111111111111111111111111111111111"/>
   <constant name="Hcal_layer_support_length" value="0*mm"/>
   <constant name="Hcal_middle_stave_gaps" value="10*mm"/>
-  <constant name="Hcal_modules_gap" value="0*mm"/>
+  <constant name="Hcal_modules_gap" value="0.001*mm"/>
   <constant name="Hcal_nlayers" value="48"/>
 
   <!-- <constant name="Hcal_outer_radius" value="3000.0*mm"/> -->

--- a/ILD/compact/ILD_s1_v01/model_parameters_ILD_s1_v01.xml
+++ b/ILD/compact/ILD_s1_v01/model_parameters_ILD_s1_v01.xml
@@ -187,7 +187,7 @@
   <constant name="Hcal_layer_pattern" value="11111111111111111111111111111111111111"/>
   <constant name="Hcal_layer_support_length" value="0*mm"/>
   <constant name="Hcal_middle_stave_gaps" value="10*mm"/>
-  <constant name="Hcal_modules_gap" value="0*mm"/>
+  <constant name="Hcal_modules_gap" value="0.001*mm"/>
   <constant name="Hcal_nlayers" value="48"/>
 
   <!-- <constant name="Hcal_outer_radius" value="3000.0*mm"/> -->


### PR DESCRIPTION
… to avoid GEANT4 touch surface in the HCAL barrel middle.