### PR TITLE
 Commented out unused parameter 'Yoke_barrel_inner_radius'.

### DIFF
--- a/ILD/compact/ILD_l1_v01/ILD_l1_v01.xml
+++ b/ILD/compact/ILD_l1_v01/ILD_l1_v01.xml
@@ -156,7 +156,7 @@
         <constant name="TUBE_IPOuterTube_start_radius" type="string" value="25" />
         <constant name="TUBE_IPOuterTube_start_z" type="string" value="220" />
         <constant name="Yoke_Z_start_endcaps" type="string" value="4072" />
-        <constant name="Yoke_barrel_inner_radius" type="string" value="4424.9599609375" />
+        <!--constant name="Yoke_barrel_inner_radius" type="string" value="4424.9599609375" /-->
         <constant name="calorimeter_region_rmax" type="string" value="3395.46" />
         <constant name="calorimeter_region_zmax" type="string" value="3937" />
         <!-- <constant name="tracker_region_rmax" type="string" value="1842.9" /> -->

--- a/ILD/compact/ILD_l1_v01/ILD_l1_v01.xml
+++ b/ILD/compact/ILD_l1_v01/ILD_l1_v01.xml
@@ -243,12 +243,6 @@
 	<constant name="Hcal_half_length"     value="TPC_Ecal_Hcal_barrel_halfZ"/>
 	<constant name="Hcal_inner_symmetry"  value="Ecal_Hcal_symmetry"/>
 
-	<!-- Should we define every sub-detector envelope parameters explicity -->
-	<constant name="Yoke_inner_radius"    value="4424.0*mm"/>      <!-- explicity Fundamental -->
-	<constant name="Yoke_outer_radius"    value="7725.0*mm"/>      <!-- explicity Fundamental -->
-	<constant name="Yoke_half_length"     value="4047.0*mm"/>      <!-- explicity Fundamental -->
-	<constant name="Yoke_symmetry"        value="12"/>             <!-- explicity Fundamental -->
-
 	<constant name="EcalEndcap_inner_radius"    value="Ecal_endcap_center_box_size/2.0"/>
 	<constant name="EcalEndcap_outer_radius"    value="Ecal_outer_radius+Ecal_endcap_extra_size"/>
 	<constant name="EcalEndcap_min_z"           value="Ecal_endcap_zmin"/>
@@ -266,6 +260,18 @@
 	<constant name="HcalEndcapRing_max_z"           value="EcalEndcap_max_z"/>
 	<constant name="HcalEndcapRing_symmetry"        value="Ecal_Hcal_symmetry"/>
 	
+	<constant name="Coil_inner_radius"            value="Hcal_outer_radius+Hcal_Coil_additional_gap"/> 
+	<constant name="Coil_outer_radius"            value="Hcal_outer_radius+Hcal_Coil_additional_gap+Coil_thickness"/>
+	<constant name="Coil_half_length"             value="TPC_Ecal_Hcal_barrel_halfZ+Coil_extra_size"/>      
+
+	<constant name="Coil_Yoke_gap"                value="249.0*mm"/>
+	<constant name="Yoke_barrel_inner_radius"     value="Coil_outer_radius+Coil_Yoke_gap"/>
+
+	<constant name="Yoke_inner_radius"            value="Yoke_barrel_inner_radius"/>
+	<constant name="Yoke_outer_radius"            value="Yoke_inner_radius+Yoke_thickness"/>
+	<constant name="Yoke_half_length"             value="4047.0*mm"/>
+	<constant name="Yoke_symmetry"                value="12"/>
+
 	<!-- Yoke05_Endcaps geometry driver include Yoke endcap plug -->
 	<constant name="YokeEndcap_inner_radius"    value="Yoke_endcap_inner_radius"/>
 	<constant name="YokeEndcap_outer_radius"    value="Yoke_outer_radius"/>
@@ -302,10 +308,6 @@
 	<constant name="BeamCal_tubeIncoming_radius"   value="15.0*mm"/>
 
  
-
-	<constant name="Coil_inner_radius"    value="Hcal_outer_radius+Hcal_Coil_additional_gap"/> 
-	<constant name="Coil_outer_radius"    value="Hcal_outer_radius+Hcal_Coil_additional_gap+Coil_thickness"/>
-	<constant name="Coil_half_length"     value="TPC_Ecal_Hcal_barrel_halfZ+Coil_extra_size"/>      
 
 	<!-- ########### END ENVELOPE PARAMETERS ############################################################## -->
 

--- a/ILD/compact/ILD_l1_v01/Yoke05_Endcaps.xml
+++ b/ILD/compact/ILD_l1_v01/Yoke05_Endcaps.xml
@@ -22,7 +22,7 @@
 
     <type_flags type=" DetType_CALORIMETER + DetType_ENDCAP + DetType_MUON " />
    
-    <dimensions numsides="12" rmin="Yoke_barrel_inner_radius" z="Yoke_barrel_halfZ" />
+    <dimensions numsides="12" rmin="Yoke_inner_radius" z="Yoke_barrel_halfZ" />
     <material name="Iron"/> 
     <layer repeat="12" vis="SeeThrough">
         <slice material = "Air"            thickness = "15.0*mm"                    vis="YellowVis" />

--- a/ILD/compact/ILD_l1_v01/model_parameters_ILD_l1_v01.xml
+++ b/ILD/compact/ILD_l1_v01/model_parameters_ILD_l1_v01.xml
@@ -323,7 +323,7 @@
   <!-- <constant name="Yoke_Z_start_endcaps" value="6625*mm"/> -->
   <!-- has been updated by driver SCoil02 to the following value -->
   <constant name="Yoke_Z_start_endcaps" value="4072.0*mm"/>
-  <constant name="Yoke_barrel_inner_radius" value="4450.00*mm"/>
+  <!--constant name="Yoke_barrel_inner_radius" value="4450.00*mm"/-->
   <constant name="Yoke_endcap_inner_radius" value="300*mm"/>
   <constant name="Yoke_thickness" value="3300*mm"/>
   <constant name="Yoke_with_plug" value="1"/>

--- a/ILD/compact/ILD_o1_v05/ILD_o1_v05.xml
+++ b/ILD/compact/ILD_o1_v05/ILD_o1_v05.xml
@@ -241,12 +241,6 @@
 	<constant name="Hcal_half_length"     value="TPC_Ecal_Hcal_barrel_halfZ"/>
 	<constant name="Hcal_inner_symmetry"  value="Ecal_Hcal_symmetry"/>
 
-	<!-- Should we define every sub-detector envelope parameters explicity -->
-	<constant name="Yoke_inner_radius"    value="4424.0*mm"/>      <!-- explicity Fundamental -->
-	<constant name="Yoke_outer_radius"    value="7725.0*mm"/>      <!-- explicity Fundamental -->
-	<constant name="Yoke_half_length"     value="4047.0*mm"/>      <!-- explicity Fundamental -->
-	<constant name="Yoke_symmetry"        value="12"/>             <!-- explicity Fundamental -->
-
 	<constant name="EcalEndcap_inner_radius"    value="Ecal_endcap_center_box_size/2.0"/>
 	<constant name="EcalEndcap_outer_radius"    value="Ecal_outer_radius+Ecal_endcap_extra_size"/>
 	<constant name="EcalEndcap_min_z"           value="Ecal_endcap_zmin"/>
@@ -263,6 +257,18 @@
 	<constant name="HcalEndcapRing_min_z"           value="EcalEndcap_min_z"/>
 	<constant name="HcalEndcapRing_max_z"           value="EcalEndcap_max_z"/>
 	<constant name="HcalEndcapRing_symmetry"        value="Ecal_Hcal_symmetry"/>
+
+	<constant name="Coil_inner_radius"            value="Hcal_outer_radius+Hcal_Coil_additional_gap"/> 
+	<constant name="Coil_outer_radius"            value="Hcal_outer_radius+Hcal_Coil_additional_gap+Coil_thickness"/>
+	<constant name="Coil_half_length"             value="TPC_Ecal_Hcal_barrel_halfZ+Coil_extra_size"/>      
+
+	<constant name="Coil_Yoke_gap"                value="249.0*mm"/>
+	<constant name="Yoke_barrel_inner_radius"     value="Coil_outer_radius+Coil_Yoke_gap"/>
+
+	<constant name="Yoke_inner_radius"            value="Yoke_barrel_inner_radius"/>
+	<constant name="Yoke_outer_radius"            value="Yoke_inner_radius+Yoke_thickness"/>
+	<constant name="Yoke_half_length"             value="4047.0*mm"/>
+	<constant name="Yoke_symmetry"                value="12"/>
 	
 	<!-- Yoke05_Endcaps geometry driver include Yoke endcap plug -->
 	<constant name="YokeEndcap_inner_radius"    value="Yoke_endcap_inner_radius"/>
@@ -272,7 +278,7 @@
 	<constant name="YokeEndcap_symmetry"        value="Yoke_symmetry"/>
 	<constant name="YokeEndcapPlug_inner_radius"    value="YokeEndcap_inner_radius"/>
 	<constant name="YokeEndcapPlug_outer_radius"    value="Hcal_outer_radius"/>
-	<constant name="YokeEndcapPlug_min_z"           value="3981.5*mm"/> <!-- FixMe! Trap. and Mokka hardcode number -->
+	<constant name="YokeEndcapPlug_min_z"           value="3981.5*mm"/>
 	<constant name="YokeEndcapPlug_max_z"           value="YokeEndcap_min_z"/>
 	<constant name="YokeEndcapPlug_symmetry"        value="Yoke_symmetry"/>
 
@@ -306,10 +312,6 @@
 	<constant name="LumiCal_min_z"                 value="2500*mm"/>
 	<constant name="LumiCal_max_z"                 value="LumiCal_min_z+LumiCal_thickness"/>
 
-
-	<constant name="Coil_inner_radius"    value="Hcal_outer_radius+Hcal_Coil_additional_gap"/> 
-	<constant name="Coil_outer_radius"    value="Hcal_outer_radius+Hcal_Coil_additional_gap+Coil_thickness"/>
-	<constant name="Coil_half_length"     value="TPC_Ecal_Hcal_barrel_halfZ+Coil_extra_size"/>      
 
 	<!-- ########### END ENVELOPE PARAMETERS ############################################################## -->
 

--- a/ILD/compact/ILD_o1_v05/ILD_o1_v05.xml
+++ b/ILD/compact/ILD_o1_v05/ILD_o1_v05.xml
@@ -154,7 +154,7 @@
         <constant name="TUBE_IPOuterTube_start_radius" type="string" value="25" />
         <constant name="TUBE_IPOuterTube_start_z" type="string" value="220" />
         <constant name="Yoke_Z_start_endcaps" type="string" value="4072" />
-        <constant name="Yoke_barrel_inner_radius" type="string" value="4424.9599609375" />
+        <!--constant name="Yoke_barrel_inner_radius" type="string" value="4424.9599609375" /-->
         <constant name="calorimeter_region_rmax" type="string" value="3395.46" />
         <constant name="calorimeter_region_zmax" type="string" value="3937" />
         <!-- <constant name="tracker_region_rmax" type="string" value="1842.9" /> -->

--- a/ILD/compact/ILD_o1_v05/Yoke05_Endcaps.xml
+++ b/ILD/compact/ILD_o1_v05/Yoke05_Endcaps.xml
@@ -22,7 +22,7 @@
 
     <type_flags type=" DetType_CALORIMETER + DetType_ENDCAP + DetType_MUON " />
    
-    <dimensions numsides="12" rmin="Yoke_barrel_inner_radius" z="Yoke_barrel_halfZ" />
+    <dimensions numsides="12" rmin="Yoke_inner_radius" z="Yoke_barrel_halfZ" />
     <material name="Iron"/> 
     <layer repeat="12" vis="SeeThrough">
         <slice material = "Air"            thickness = "15.0*mm"                    vis="YellowVis" />

--- a/ILD/compact/ILD_o1_v05/model_parameters_ILD_o1_v05.xml
+++ b/ILD/compact/ILD_o1_v05/model_parameters_ILD_o1_v05.xml
@@ -282,7 +282,7 @@
   <!-- <constant name="Yoke_Z_start_endcaps" value="6625*mm"/> -->
   <!-- has been updated by driver SCoil02 to the following value -->
   <constant name="Yoke_Z_start_endcaps" value="4072.0*mm"/>
-  <constant name="Yoke_barrel_inner_radius" value="4450.00*mm"/>
+  <!--constant name="Yoke_barrel_inner_radius" value="4450.00*mm"/-->
   <constant name="Yoke_endcap_inner_radius" value="300*mm"/>
   <constant name="Yoke_thickness" value="3300*mm"/>
   <constant name="Yoke_with_plug" value="1"/>

--- a/ILD/compact/ILD_s1_v01/Yoke05_Endcaps.xml
+++ b/ILD/compact/ILD_s1_v01/Yoke05_Endcaps.xml
@@ -22,7 +22,7 @@
 
     <type_flags type=" DetType_CALORIMETER + DetType_ENDCAP + DetType_MUON " />
    
-    <dimensions numsides="12" rmin="Yoke_barrel_inner_radius" z="Yoke_barrel_halfZ" />
+    <dimensions numsides="12" rmin="Yoke_inner_radius" z="Yoke_barrel_halfZ" />
     <material name="Iron"/> 
     <layer repeat="12" vis="SeeThrough">
         <slice material = "Air"            thickness = "15.0*mm"                    vis="YellowVis" />

--- a/ILD/compact/ILD_s1_v01/model_parameters_ILD_s1_v01.xml
+++ b/ILD/compact/ILD_s1_v01/model_parameters_ILD_s1_v01.xml
@@ -321,7 +321,7 @@
   <!-- <constant name="Yoke_Z_start_endcaps" value="6625*mm"/> -->
   <!-- has been updated by driver SCoil02 to the following value -->
   <constant name="Yoke_Z_start_endcaps" value="4072.0*mm"/>
-  <constant name="Yoke_barrel_inner_radius" value="4450.00*mm"/>
+  <!--constant name="Yoke_barrel_inner_radius" value="4450.00*mm"/-->
   <constant name="Yoke_endcap_inner_radius" value="300*mm"/>
   <constant name="Yoke_thickness" value="3300*mm"/>
   <constant name="Yoke_with_plug" value="1"/>

--- a/detector/calorimeter/SHcalSc04_Endcaps.cpp
+++ b/detector/calorimeter/SHcalSc04_Endcaps.cpp
@@ -72,7 +72,6 @@ static Ref_t create_detector(LCDD& lcdd, xml_h element, SensitiveDetector sens) 
   double      Hcal_lateral_structure_thickness = lcdd.constant<double>("Hcal_lateral_structure_thickness");
   double      Hcal_endcap_layer_air_gap        = lcdd.constant<double>("Hcal_endcap_layer_air_gap");
   double      Hcal_layer_air_gap               = lcdd.constant<double>("Hcal_layer_air_gap");
-  double      Hcal_endcap_zmin                 = lcdd.constant<double>("Hcal_endcap_zmin");
 
   //double      Hcal_cells_size                  = lcdd.constant<double>("Hcal_cells_size");
   double      HcalEndcap_inner_radius          = lcdd.constant<double>("HcalEndcap_inner_radius");
@@ -266,7 +265,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h element, SensitiveDetector sens) 
 	  //-----------------------------------------------------------------------------------------
 	  if ( caloData->layers.size() < (unsigned int)repeat ) {
 
-	    caloLayer.distance = Hcal_endcap_zmin + box_half_y + layer_pos_y
+	    caloLayer.distance = HcalEndcap_min_z + box_half_y + layer_pos_y
 	      - caloLayer.inner_thickness ; // Will be added later at "DDMarlinPandora/DDGeometryCreator.cc:226" to get center of sensitive element
 	    caloLayer.absorberThickness = Hcal_radiator_thickness ;
 	    
@@ -305,7 +304,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h element, SensitiveDetector sens) 
 	double EndcapModule_pos_z = 0;
 	double rot_EM = 0;
 
-	double EndcapModule_center_pos_z = Hcal_endcap_zmin + box_half_y;
+	double EndcapModule_center_pos_z = HcalEndcap_min_z + box_half_y;
 	
 	switch (stave_num)
 	  {


### PR DESCRIPTION
 use 'Yoke_inner_radius' and its configuration value for yoke barrel and endcaps.