### PR TITLE
Travis: Keep compilation going after error

### DIFF
--- a/.travis-ci.d/compile_and_test.sh
+++ b/.travis-ci.d/compile_and_test.sh
@@ -7,6 +7,6 @@ cd /Package
 mkdir build
 cd build
 cmake -C$ILCSOFT/ILCSoft.cmake -GNinja -DUSE_CXX11=ON -DCMAKE_CXX_FLAGS="-fdiagnostics-color=always" .. && \
-    ninja && \
+    ninja -k 0 && \
     ninja install && \
     ctest --output-on-failure


### PR DESCRIPTION
that way we can at least see if other things are failing as well as known problems due to upstream changes. 0 means unlimited like `make -k`. Also useful when we add Werror to the flags for travis.