### PR TITLE
Update ecal

### DIFF
--- a/detector/calorimeter/SEcal05_Barrel.cpp
+++ b/detector/calorimeter/SEcal05_Barrel.cpp
@@ -57,9 +57,15 @@ using namespace DD4hep::Geometry;
  *              along tower index
  *   F.Gaede: 03/2015:
  *            create the envelope volume with create_placed_envelope() using the xml
+ *
+ *  D. Jeans: 03/2015:
+ *             generalise to non-octagonal barrel shape
+ *             allow dead region between end of each slab and the module edge (e.g. for the slab fastening system)
  */
 
 /*
+
+
 
 
   y
@@ -121,11 +127,6 @@ static Ref_t create_detector(LCDD& lcdd, xml_h element, SensitiveDetector sens) 
 
   xml_comp_t    x_dim     = x_det.dimensions();
   int           nsides    = x_dim.numsides();
-
-  // this code assumes octagon in several places
-  //  would need work to make it general
-  //  assert( nsides==8 );
-
 
   double        dphi      = (2*M_PI/nsides);
   double        hphi      = dphi/2;

--- a/detector/calorimeter/SEcal05_Helpers.h
+++ b/detector/calorimeter/SEcal05_Helpers.h
@@ -83,7 +83,7 @@ class SEcal05_Helpers {
   SEcal05_Helpers();
 
   ~SEcal05_Helpers() {
-    delete _layering;
+    if ( _layering ) delete _layering; _layering=NULL;
   }
 
   // SET THE PARAMETERS
@@ -180,6 +180,9 @@ class SEcal05_Helpers {
 		   DD4hep::Geometry::SensitiveDetector & sens
 		   );
 
+  void setPlugLength( float ll ) { _plugLength = ll; }
+
+
  private:
 
   void printSEcal05LayerInfo( DDRec::LayeredCalorimeterData::Layer & caloLayer);
@@ -212,7 +215,7 @@ class SEcal05_Helpers {
   };
 
   xml_det_t* _x_det;
-  Layering* _layering=NULL;
+  Layering* _layering;
   std::string _det_name;
 
   std::vector <dimposXYStruct> getAbsPlateXYDimensions( double ztop=-999 );
@@ -295,6 +298,10 @@ class SEcal05_Helpers {
   DD4hep::Geometry::Position _trans;
 
   std::vector <dimposXYStruct> _constantSlabXYDimensions;
+
+
+  float _plugLength;
+
 
 };
 

--- a/detector/calorimeter/SEcal05_Helpers.h
+++ b/detector/calorimeter/SEcal05_Helpers.h
@@ -74,6 +74,11 @@ local position: 0,0 defined as -veX,Y,Z corner
 
 we start building from Z=0, the face nearest IP, moving in the +ve Z direction
 
+
+D.Jeans update: 03/2015
+dead space between slab end and module edge
+other than 8-fold symmetry for barrel
+
  */
 
 class SEcal05_Helpers {


### PR DESCRIPTION
by popular request, allow ECAL barrel with symmetry other than 8.

In the ECAL barrel, add possibility to include dead volume at the "inside" end of slabs (i.e. not at position of readout electronics) to simulate effect of slab retention system ("plug"), via optional parameter Ecal_Slab_Plug_length. (length of 0 used if not specified, so default behaviour should be unchanged).