### PR TITLE
LHCal placement fix

### DIFF
--- a/ILD/compact/ILD_common_v01/LHCal01.xml
+++ b/ILD/compact/ILD_common_v01/LHCal01.xml
@@ -13,8 +13,9 @@
 	<shape type="Box" dx="LHCal_outer_radius + env_safety" 
 	       dy="LHCal_outer_radius + env_safety" 
 	       dz="LHCal_max_z + env_safety"/>
-	<shape type="Tube" rmin="0.0" rmax="LHCal_inner_radius - env_safety" 
-	       dz="LHCal_max_z + 2.0*env_safety"/>
+	<shape type="PolyhedraRegular" numsides="8"
+	       phi_start="22.5*deg" rmin="0.0" rmax="LHCal_inner_radius - env_safety" dz="LHCal_max_z + 2.0*env_safety"/>
+        <position x="20*mm" y="0" z="0" />
       </shape>
       <shape type="Box" dx="LHCal_outer_radius + 1.5*env_safety"
 	     dy="LHCal_outer_radius + 1.5*env_safety"

--- a/ILD/compact/ILD_common_v01/LHCal01.xml
+++ b/ILD/compact/ILD_common_v01/LHCal01.xml
@@ -31,7 +31,7 @@
 	/>          
 
   
-  <layer repeat="29" vis="SeeThrough">
+  <layer repeat="30" vis="SeeThrough">
     <slice material = "TungstenDens24" thickness = "13.8*mm" 		   vis="BCLayerVis1" />
     <slice material = "Air"     thickness = "0.1*mm"   vis="Invisible" />
     <slice material = "Silicon" thickness = "1.0*mm" 	sensitive = "yes"  vis="BCLayerVis2"/>

--- a/ILD/compact/ILD_common_v01/fcal_defs.xml
+++ b/ILD/compact/ILD_common_v01/fcal_defs.xml
@@ -19,16 +19,18 @@
 
   <constant name="Lcal_services_rmax" value="EcalEndcapRing_inner_radius-1.0*mm"/>
 
-  <constant name="LumiCal_thickness"             value="128.7*mm"/> <!--"130.65*mm"/-->
-  <constant name="LumiCal_max_z"                 value="Ecal_endcap_zmax"/>
-  <constant name="LumiCal_min_z"                 value="LumiCal_max_z - LumiCal_thickness"/>
-
   <constant name="Lcal_tungsten_thickness" value="3.5*mm"/>
   <constant name="Lcal_silicon_thickness" value="0.32*mm"/>
   <constant name="Lcal_support_thickness" value="0.22*mm"/>
   <constant name="Lcal_layer_gap" value="0.25*mm"/>
 
+  <constant name="LumiCal_thickness"    value="128.7*mm"/> <!--"130.65*mm"/-->
+  <constant name="LumiCal_min_z"        value="top_Lcal_z_begin" /> <!--LumiCal_max_z - LumiCal_thickness"/-->
+  <constant name="LumiCal_max_z"        value="LumiCal_min_z + LumiCal_thickness" /> <!--Ecal_endcap_zmax"/-->
 
+
+  <constant name="ECal_LHcal_clearance" value="45*mm"/>
+  <constant name="LHcal_min_z" value="Ecal_endcap_zmax+ECal_LHcal_clearance"/>
   <constant name="LHcal_cell_size" value="10*mm"/>
 
 

--- a/ILD/compact/ILD_common_v01/top_defs_common_v01.xml
+++ b/ILD/compact/ILD_common_v01/top_defs_common_v01.xml
@@ -85,11 +85,11 @@ subdetector-specific ones are in separate files
   <constant name="top_Lcal_inner_radius" value="80.0*mm"/>
   <constant name="Lcal_outer_radius"     value="195.2*mm"/>
   <constant name="LumiCal_tubebulge_overshoot"   value="11.2*mm"/>
-  <constant name="top_Lcal_z_begin"      value="2505.0*mm"/>
+  <constant name="top_Lcal_z_begin"      value="Ecal_endcap_zmin" /> <!--"2505.0*mm"/-->
 
   <!-- lhcal -->
-  <constant name="top_LHCal_thickness"               value="464.0*mm"/>
-  <constant name="top_LHCal_inner_radius"            value="150*mm"/>
+  <constant name="top_LHCal_thickness"               value="480*mm"/> <!--464.0*mm"/-->
+  <constant name="top_LHCal_inner_radius"            value="130*mm"/>
   <constant name="top_LHCal_outer_radius"            value="315*mm"/>
   <constant name="top_LHCal_min_z"                   value="2680*mm"/>
   <constant name="LHcal_zend"           value="top_LHCal_min_z + top_LHCal_thickness"/>

--- a/detector/fcal/LumiCal_o1_v03_geo.cpp
+++ b/detector/fcal/LumiCal_o1_v03_geo.cpp
@@ -71,6 +71,7 @@ static DD4hep::Geometry::Ref_t create_detector(DD4hep::Geometry::LCDD& lcdd,
     const double staggerPhi    = layerStagger*cellPhiSize;   
     const double lcalThickness = DD4hep::Layering(xmlLumiCal).totalThickness();
     const double lcalCentreZ   = lcalInnerZ+lcalThickness*0.5;
+    const double lcalXoffset = lcalCentreZ * std::tan( fullCrossingAngle/2. );
 
     // inner/outer radii are not the sensor dims, these we have to compute
     const double sensInnerR = lcalInnerR/cos( lcalSectors*cellPhiSize/2. ) + lcalRGap;
@@ -95,6 +96,8 @@ static DD4hep::Geometry::Ref_t create_detector(DD4hep::Geometry::LCDD& lcdd,
 
     std::cout << " The crossing angle is:  " << fullCrossingAngle << " radian"  << std::endl;
     std::cout << "     "<< detName << " z-begin : " << lcalInnerZ/dd4hep::mm << " mm" << std::endl;
+    std::cout << "     "<< detName << " z-end   : " << (lcalInnerZ+lcalThickness)/dd4hep::mm << " mm" << std::endl;
+    std::cout << "   (x,y,z)-center : " << "( " << lcalXoffset/dd4hep::mm << ",0 ,+- " << lcalCentreZ/dd4hep::mm << " ) mm" << std::endl;
     std::cout << "     sensorInnerR : " << sensInnerR/dd4hep::mm << " mm" << std::endl;
     std::cout << "     sensorouterR : " << sensOuterR/dd4hep::mm << " mm" << std::endl;
     std::cout << "        thickness : " << lcalThickness/dd4hep::mm << " mm" << std::endl;
@@ -321,8 +324,8 @@ static DD4hep::Geometry::Ref_t create_detector(DD4hep::Geometry::LCDD& lcdd,
 	     << " ( rad. length X0: "<< mtotalRadLen << "   )"<<std::endl;
     std::cout << "-----------------------------------------------------------------"  << std::endl<<std::endl;;
     
-    const DD4hep::Geometry::Position bcForwardPos (std::tan(0.5*fullCrossingAngle)*lcalCentreZ,0.0, lcalCentreZ);
-    const DD4hep::Geometry::Position bcBackwardPos(std::tan(0.5*fullCrossingAngle)*lcalCentreZ,0.0,-lcalCentreZ);
+    const DD4hep::Geometry::Position bcForwardPos ( lcalXoffset,0.0, lcalCentreZ);
+    const DD4hep::Geometry::Position bcBackwardPos( lcalXoffset,0.0,-lcalCentreZ);
     const DD4hep::Geometry::RotationY bcForwardRot ( fullCrossingAngle*0.5  );
     const DD4hep::Geometry::RotationY bcBackwardRot( M_PI-fullCrossingAngle*0.5 );
     


### PR DESCRIPTION
Following changes were done,
 1. LCal moved toward IP aligned with front of ECalPlug to leave space for mounting support
 2. LHCal position depends on EcalPlug z-end and is controlled via new  ECal_LHcal_clearance
     parameter
 3. LHCal inner cutout becomes asymetric ( ie. centered on outgoing beam ) no x-angle rotation.
     After this LHCal haa no phi-symetry - copy positioned with RotZ( 180 deg)
 4. Minor printout modification
Position of LHCal z-begin is set to 2680 mm, 30 mm in front left for support front wall. If support tube
will be implemented then  front wall of support will became absorber plate for first LHCal sensor plane
and LHCal z-begin will be 2650 mm.   