### PR TITLE
Initialise a combined RPC/Scintillator HcalBarrel simulation module. …

### DIFF
--- a/ILD/compact/ILD_o4_v01/HCalBarrel_o4_v01_01.xml
+++ b/ILD/compact/ILD_o4_v01/HCalBarrel_o4_v01_01.xml
@@ -1,0 +1,70 @@
+<lccdd>
+    <!--  Definition of global dictionary constants          -->
+    <define>
+        <constant name="HCalBarrel_layers" value="(int) 48"/>
+        <constant name="HCalBarrel_layer_thickness" value="2.0*cm + 0.65*cm"/>
+        <constant name="AHCal_cell_size" value="3.0*cm"/>
+        <constant name="SDHCal_cell_size" value="1.0*cm"/>
+        
+    </define>
+    
+    <!--  Definition of the used visualization attributes    -->
+    <display>
+        <vis name="HCalBarrelVis"    alpha="1" r="0.0"  g="0.3"  b="0.8" showDaughters="true" visible="true"/>
+        <vis name="HCalStavesVis"    alpha="1" r="0.0"  g="0.0"  b="0.1" showDaughters="true" visible="true"/>
+        <vis name="HCalLayerVis"     alpha="1" r="1"    g="0"    b="0.5" showDaughters="true" visible="true"/>
+        <vis name="HCalSensorRPCVis" alpha="1" r="1.0"  g="0.0"  b="0.2" showDaughters="true" visible="true"/>
+        <vis name="HCalSensorSciVis" alpha="1" r="0.0"  g="1.0"  b="0.0" showDaughters="true" visible="true"/>
+        <vis name="HCalAbsorberVis"  alpha="1" r="0.4"  g="0.4"  b="0.6" showDaughters="true" visible="true"/>
+        
+        <vis name="HCalEndcapVis"          alpha="1" r="1"    g="1"    b="0.1" showDaughters="false" visible="true"/>
+        <vis name="HCalEndcapLayerVis"     alpha="1" r="1"    g="0"    b="0.5" showDaughters="false" visible="true"/>
+    </display>
+    
+    <!--  Definition of the readout segmentation/definition  -->
+    <readouts>
+        <readout name="HCalBarrelCollection">
+          <segmentation   type="MultiSegmentation"  key="slice">
+            <segmentation name="RPCgrid" type="CartesianGridXY"    key_value="3"    grid_size_x="SDHCal_cell_size" grid_size_y="SDHCal_cell_size" />
+            <segmentation name="Scigrid" type="CartesianGridXY"    key_value="6"    grid_size_x="AHCal_cell_size" grid_size_y="AHCal_cell_size" />
+          </segmentation>
+          <hits_collections>
+            <hits_collection name="HCalBarrelRPCHits"  key="slice" key_value="3"/>
+            <hits_collection name="HCalBarrelSciHits"  key="slice" key_value="6"/>
+          </hits_collections>
+          <id>system:5,barrel:2,module:4,stave:6,layer:6,slice:4,x:32:-16,y:-16</id>
+       </readout>
+    </readouts>
+    
+    <detectors>
+	<detector id="DetID_HCAL_Barrel" name="HcalBarrel" type="DD4hep_PolyhedraBarrelCalorimeter2" readout="HCalBarrelCollection" vis="HCALVis" calorimeterType="HAD_BARREL" gap="0.*cm" material="Steel235">
+            
+            <comment>Hadron Calorimeter Barrel</comment>
+            
+            <type_flags type=" DetType_CALORIMETER + DetType_HADRONIC + DetType_BARREL"/>
+
+            <envelope vis="HCALVis">
+                <shape type="PolyhedraRegular" numsides="HCalBarrel_symmetry"  rmin="HCalBarrel_inner_radius-env_safety" rmax="HCalBarrel_outer_radius+env_safety" dz="HCalBarrel_half_length*2+2*env_safety" material = "Air"/>
+                <rotation x="0*deg" y="0*deg" z="90*deg-180*deg/HCalBarrel_symmetry"/>
+            </envelope>
+            
+            
+            <dimensions numsides="HCalBarrel_symmetry" rmin="HCalBarrel_inner_radius" z="HCalBarrel_half_length*2"/>
+            <staves vis="HCalStavesVis"/>
+            <layer repeat="(int) HCalBarrel_layers" vis="HCalLayerVis">
+                <slice material="Steel235" thickness="19*mm" vis="HCalAbsorberVis" radiator="yes"/>
+                <slice material="FloatGlass" thickness="0.7*mm" vis="InvisibleNoDaughters"/>
+                <slice material="RPCGAS2"    thickness="1.2*mm" sensitive="yes" limits="cal_limits" vis="HCalSensorRPCVis"/>
+                <slice material="FloatGlass" thickness="1.1*mm" vis="InvisibleNoDaughters"/>
+                <slice material="Steel235" thickness="0.5*mm" vis="HCalAbsorberVis" radiator="yes"/>
+                <slice material="G4_POLYSTYRENE" thickness="3*mm" sensitive="yes" limits="cal_limits" vis="HCalSensorSciVis"/>
+                <slice material="Copper"   thickness="0.1*mm" vis="HCalCopperVis"/>
+                <slice material="PCB"      thickness="0.4*mm" vis="HCalPCBVis"/>
+                <slice material="Steel235" thickness="0.5*mm" vis="HCalAbsorberVis" radiator="yes"/>
+            </layer>
+        </detector>
+        
+    </detectors>
+
+</lccdd>
+

--- a/ILD/compact/ILD_o4_v01/ILD_o4_v01.xml
+++ b/ILD/compact/ILD_o4_v01/ILD_o4_v01.xml
@@ -1,0 +1,109 @@
+<lccdd>
+    <info name="ILD_o4_v01"
+          title="ILD detector model option 4 version 01"
+          author="S.Lu DESY"
+          url="https://agenda.linearcollider.org/event/7512/contributions/38394/attachments/31207/46879/TC_report.pdf"
+          status="experimental"
+          version="experimental">
+        <comment>The compact format for the ILD Detector design</comment>
+    </info>
+
+    <includes>
+        <gdmlFile  ref="../ILD_common_v01/elements.xml"/>
+        <gdmlFile  ref="../ILD_common_v01/materials.xml"/>
+    </includes>
+
+    <define>
+        <constant name="world_side"             value="30000*mm"/>
+        <constant name="world_x"                value="world_side"/>
+        <constant name="world_y"                value="world_side"/>
+        <constant name="world_z"                value="world_side"/>
+
+
+        <constant name="CrossingAngle"          value="14*mrad"/>
+
+
+        <constant name="DetID_NOTUSED"          value="0"/>
+
+
+        <constant name="DetID_HCAL_Barrel"      value="10"/>
+
+
+
+        <!-- ################### ENVELOPE PARAMETERS ######################################################## -->
+
+        <comment> suggested naming convention:
+
+            main parameters:
+
+            DET_inner_radius    : inner radius of tube like envelope  ( inscribed cylinder )
+            DET_outer_radius    : outer radius of tube like envelope  ( circumscribed cylinder )
+            DET_half_length     : half length along z axis
+            DET_min_z           : smallest absolute value on z-axis
+            DET_max_z           : largest  absolute value on z-axis
+            DET_inner_symmetry  : number of sides on the inside  ( 0 for tube )
+            DET_outer_symmetry  : number of sides on the inside  ( 0 for tube )
+            DET_inner_phi0      : optional rotation of the inner polygon ( in r-phi plane )
+            DET_outer_phi0      : optional rotation of the outer polygon ( in r-phi plane )
+
+            additional parameters for cutting away volumes/shapes use one of the above with a number
+            appended and/or an extra specifiaction such as cone ( for a cut away cone )
+
+            DET_inner_radius_1
+            DET_outer_radius_2
+            DET_cone_min_z
+            DET_cone_max_z
+
+        </comment>
+
+        <constant name="env_safety"                 value="0.1*mm"/>
+
+
+        <constant name="HCalBarrel_inner_radius"    value="2058*mm"/>
+        <constant name="HCalBarrel_outer_radius"    value="3349*mm"/>
+        <constant name="HCalBarrel_half_length"     value="2350*mm"/>
+        <constant name="HCalBarrel_symmetry"        value="8"/>
+
+
+
+        <constant name="Coil_inner_radius"          value="3425*mm"/>
+        <constant name="Coil_half_length"           value="3872*mm"/>
+
+        <constant name="YokeBarrel_outer_radius"    value="7725*mm"/>
+
+    </define>
+
+    <limits>
+        <limitset name="cal_limits">
+            <limit name="step_length_max" particles="*" value="5.0" unit="mm" />
+        </limitset>
+    </limits>
+
+
+    <display>
+        <vis name="HCALVis"     alpha="1.0" r="0.078" g="0.01176" b="0.588" showDaughters="true"  visible="true"/>
+    </display>
+
+    <include ref="${DD4hepINSTALL}/DDDetectors/compact/detector_types.xml"/>
+
+    <include ref="HCalBarrel_o4_v01_01.xml"/>
+
+    <plugins>
+        <plugin name="DD4hepVolumeManager"/>
+        <plugin name="InstallSurfaceManager"/>
+    </plugins>
+
+
+    <fields>
+        <field name="GlobalSolenoid" type="solenoid"
+               inner_field="3.5*tesla"
+               outer_field="-1.5*tesla"
+               zmax="Coil_half_length"
+               inner_radius="Coil_inner_radius"
+               outer_radius="YokeBarrel_outer_radius">
+        </field>
+    </fields>
+
+
+</lccdd>
+


### PR DESCRIPTION
…Both RPC and Scintillator have 48 layers. MarlinProcessor may access RPC from slice:3 and access Scintillator from slice:6.



BEGINRELEASENOTES
- Initialise a module "ILD_o4_v01" for a combined RPC/Scintillator HcalBarrel simulation. 
   - Both RPC and Scintillator have 48 layers.
   - MarlinProcessor may access RPC from slice:3 and access Scintillator from slice:6
   - Assign different segmentations and output collections to the different sensitive type.

ENDRELEASENOTES