### PR TITLE
Fix overlaps

### DIFF
--- a/ILD/compact/ILD_common_v01/LHCal01.xml
+++ b/ILD/compact/ILD_common_v01/LHCal01.xml
@@ -13,9 +13,8 @@
 	<shape type="Box" dx="LHCal_outer_radius + env_safety" 
 	       dy="LHCal_outer_radius + env_safety" 
 	       dz="LHCal_max_z + env_safety"/>
-	<shape type="PolyhedraRegular" numsides="8"
-	       phi_start="22.5*deg" rmin="0.0" rmax="LHCal_inner_radius - env_safety" dz="LHCal_max_z + 2.0*env_safety"/>
-        <position x="20*mm" y="0" z="0" />
+	<shape type="Tube" rmin="0.0" rmax="LHCal_inner_radius - env_safety" dz="LHCal_max_z + 2.0*env_safety"/>
+        <position x="0.5*(LHCal_min_z + LHCal_max_z)*tan(ILC_Main_Crossing_Angle/2.0)" y="0" z="0" />
       </shape>
       <shape type="Box" dx="LHCal_outer_radius + 1.5*env_safety"
 	     dy="LHCal_outer_radius + 1.5*env_safety"

--- a/detector/fcal/LHCal_v01_geo.cpp
+++ b/detector/fcal/LHCal_v01_geo.cpp
@@ -148,7 +148,7 @@ static DD4hep::Geometry::Ref_t create_detector(DD4hep::Geometry::LCDD& lcdd,
 	DD4hep::Geometry::Box sliceBase(lhcalwidth*0.5, lhcalheight*0.5,sliceThickness*0.5);
 	DD4hep::Geometry::SubtractionSolid slice_subtracted;
 
-	slice_subtracted = DD4hep::Geometry::SubtractionSolid(sliceBase, innerBore );
+	slice_subtracted = DD4hep::Geometry::SubtractionSolid(sliceBase, innerBore, innerBorePosition );
 
 	DD4hep::Geometry::Volume slice_vol (sliceName,slice_subtracted,slice_mat);
 
@@ -225,8 +225,8 @@ static DD4hep::Geometry::Ref_t create_detector(DD4hep::Geometry::LCDD& lcdd,
 
   const DD4hep::Geometry::Position bcForwardPos ( 0.0, 0.0, lhcalCentreZ );
   const DD4hep::Geometry::Position bcBackwardPos( 0.0, 0.0,-lhcalCentreZ );
-  const DD4hep::Geometry::RotationY bcForwardRot ( mradFullCrossingAngle/2. );
-  const DD4hep::Geometry::RotationZYX bcBackwardRot( M_PI, M_PI - mradFullCrossingAngle/2., 0.0 );
+  const DD4hep::Geometry::RotationY bcForwardRot ( 0. );
+  const DD4hep::Geometry::RotationZYX bcBackwardRot( M_PI, M_PI, 0.0 );
 
   DD4hep::Geometry::PlacedVolume pv =
     envelope.placeVolume(envelopeVol, DD4hep::Geometry::Transform3D( bcForwardRot, bcForwardPos ) );

--- a/detector/fcal/LumiCal_o1_v03_geo.cpp
+++ b/detector/fcal/LumiCal_o1_v03_geo.cpp
@@ -118,8 +118,8 @@ static DD4hep::Geometry::Ref_t create_detector(DD4hep::Geometry::LCDD& lcdd,
     // build services space containing support and electronics
     // simplified NOT layered for compactness
     double bolt_radius = 0.6 *dd4hep::cm; 
-    double ear_hight = lcalExtraS - 0.1*dd4hep::cm;
-    double ear_dy    = lcalOuterR + ear_hight;
+    double ear_height = lcalExtraS - 0.1*dd4hep::cm;
+    double ear_dy    = lcalOuterR + ear_height;
    if( lcalExtraS > 0. ){
       DD4hep::Geometry::Tube envelopeExtras (lcalOuterR, lcalOuterR + lcalExtraS-0.1, lcalThickness*0.5 );
       DD4hep::Geometry::Volume     ServicesVol(detName+"_Services",envelopeExtras,air);
@@ -127,18 +127,18 @@ static DD4hep::Geometry::Ref_t create_detector(DD4hep::Geometry::LCDD& lcdd,
       // mounting ears
       DD4hep::Geometry::Material earMaterial = lcdd.material("TungstenDens24");
       int n_ears = 3;  // ears come in pairs
-      double earsAng0 = 0.*dd4hep::deg;
-      double ear_width = ear_hight;
-      double ear_dx    = ear_width*ear_dy/sqrt(ear_dy*ear_dy-lcalOuterR*lcalOuterR);
+      double ear_width = ear_height/2.;
+      double ear_dx    = ear_width/sqrt(1. - ( lcalOuterR*lcalOuterR - ear_width*ear_width)/(ear_dy*ear_dy) );
       double ear_hdz   = lcalThickness*0.5;
+      double earsDPhi = 180./double( n_ears ) * dd4hep::deg;
       // anonymous volumes - support
       DD4hep::Geometry::EllipticalTube EarEllipse( ear_dx, ear_dy, ear_hdz );
       DD4hep::Geometry::Tube earClip ( 0., lcalOuterR,  (ear_hdz + 0.1*dd4hep::cm), 0., 360.*dd4hep::deg );
       DD4hep::Geometry::Tube boltHole( 0., bolt_radius, (ear_hdz + 0.1*dd4hep::cm) );
       // mixed elcetronics
-      double phiSpanFE = lcalTileDphi - atan( ear_width/lcalOuterR); 
+      double phiSpanFE = earsDPhi - 2.* atan( ear_width/sqrt(lcalOuterR*lcalOuterR-ear_width*ear_width) ); 
       DD4hep::Geometry::Material mixFEmat = lcdd.material("siPCBMix");
-      DD4hep::Geometry::Tube mixFE( lcalOuterR, lcalOuterR+lcalExtraS-0.2*dd4hep::cm, 0.5*lcalThickness, -phiSpanFE, phiSpanFE);
+      DD4hep::Geometry::Tube mixFE( lcalOuterR, lcalOuterR+lcalExtraS-0.2*dd4hep::cm, 0.5*lcalThickness, -phiSpanFE/2., phiSpanFE/2.);
       DD4hep::Geometry::Volume mixFEvol(detName+"FEmix", mixFE, mixFEmat );
       // clipping
       // pair of ears
@@ -152,13 +152,12 @@ static DD4hep::Geometry::Ref_t create_detector(DD4hep::Geometry::LCDD& lcdd,
       DD4hep::Geometry::Volume EarsVolume(detName+"Ears", EarShape2, earMaterial);
       EarsVolume.setVisAttributes( lcdd,"GrayVis");
       // place mountings and electronics  in Services volume
-      double earsAng = earsAng0;
-      double earsDPhi = 180./double( n_ears ) * dd4hep::deg;
+      double earsAng = 0.;
       double feAng = 0.;
       for( int ie=0; ie<n_ears; ie++ ){
 	DD4hep::Geometry::RotationZ earsRotZ( earsAng );
 	DD4hep::Geometry::RotationZ feRotZ1( feAng );
-	DD4hep::Geometry::RotationZ feRotZ2( feAng + 180.*dd4hep::deg );
+	DD4hep::Geometry::RotationZ feRotZ2( feAng + M_PI );
 	DD4hep::Geometry::Position  earsPos( 0., 0., 0.);
 	ServicesVol.placeVolume( EarsVolume, DD4hep::Geometry::Transform3D( earsRotZ, earsPos ));
 	ServicesVol.placeVolume( mixFEvol, DD4hep::Geometry::Transform3D( feRotZ1, earsPos) );


### PR DESCRIPTION

BEGINRELEASENOTES
 - corrections for LHCal01.xml and LHCal_o1_v01_geo.cpp fixing overlaps.
 -  Inner cutout in LHCal envelope changed from octagon to tube, as for some reasons 
    PolyhedraRegular is not subtracted - causing lack of inner cutout in envelope and overlaps 
    with beam pipe.
-  Fix of bug in geo driver which caused  internal overlaps 
ENDRELEASENOTES