### PR TITLE
Add new model to account for material change in HCal

### DIFF
--- a/CLIC/compact/CLIC_o3_v09/BeamCal_o1_v01_01.xml
+++ b/CLIC/compact/CLIC_o3_v09/BeamCal_o1_v01_01.xml
@@ -1,0 +1,100 @@
+<lccdd>
+    
+    <define>
+        <constant name="BeamCal_cell_size" value="1*mm"/>
+        <constant name="BeamCal_spanning_angle" value="350*degree"/>
+    </define>
+    
+    <readouts>
+        <readout name="BeamCalCollection">
+	    <segmentation type="PolarGridRPhi2"
+			  grid_r_values="3.200*cm 3.9876*cm 4.7742*cm 5.5608*cm 6.3474*cm 7.134*cm 7.9206*cm 8.7072*cm 9.4938*cm 10.2804*cm 11.067*cm 11.8536*cm 12.6402*cm 13.4268*cm 14.2134*cm 15.0*cm"
+			  grid_phi_values="350/(4*8)*degree
+					   350/(5*8)*degree
+					   350/(6*8)*degree
+					   350/(6*8)*degree
+					   350/(7*8)*degree
+					   350/(8*8)*degree
+					   350/(9*8)*degree
+					   350/(9*8)*degree
+					   350/(10*8)*degree
+					   350/(11*8)*degree
+					   350/(12*8)*degree
+					   350/(12*8)*degree
+					   350/(13*8)*degree
+					   350/(14*8)*degree
+					   350/(15*8)*degree"
+			  offset_phi="-180*degree+(360*degree-BeamCal_spanning_angle)*0.5"
+			  />
+	    <id>system:8,barrel:3,layer:8,slice:5,r:32:16,phi:16</id>
+        </readout>
+    </readouts>
+    
+    <detectors>
+        <detector name="BeamCal" type="BeamCal_o1_v01" vis="SeeThrough" id="DetID_BeamCal" readout="BeamCalCollection" >
+            
+          <type_flags type=" DetType_CALORIMETER + DetType_ELECTROMAGNETIC + DetType_ENDCAP + DetType_FORWARD + DetType_AUXILIARY "/>
+
+            <envelope vis="BCALVis">
+                <shape type="BooleanShape" operation="Union"  material="Air">
+                    <shape type="BooleanShape" operation="Intersection">
+                        <shape type="Box"  dx="world_side" dy="world_side" dz="world_side"/>
+                        <shape type="BooleanShape" operation="Subtraction">
+                            <shape type="Tube"  rmin="BeamCal_inner_radius" rmax="BeamCal_outer_radius+env_safety" dz="BeamCal_dz+env_safety"/>
+                            <shape type="Tube"  rmin="0" rmax="3.5*mm" dz="BeamCal_dz+10*env_safety"/>
+                            <position x="tan(-CrossingAngle)*(BeamCal_min_z+BeamCal_dz)" y="0" z="0"/>
+                            <rotation x="0" y="-CrossingAngle" z="0"/>
+                        </shape>
+                        <position x="tan(0.5*CrossingAngle)*(BeamCal_min_z+BeamCal_dz)" y="0" z="(BeamCal_min_z+BeamCal_dz)"/>
+                        <rotation x="0" y="0.5*CrossingAngle" z="0"/>
+                    </shape>
+                    <shape type="BooleanShape" operation="Intersection">
+                        <shape type="Box"  dx="world_side" dy="world_side" dz="world_side"/>
+                        <shape type="BooleanShape" operation="Subtraction">
+                            <shape type="Tube"  rmin="BeamCal_inner_radius" rmax="BeamCal_outer_radius+env_safety" dz="BeamCal_dz+env_safety"/>
+                            <shape type="Tube"  rmin="0" rmax="3.5*mm" dz="BeamCal_dz+10*env_safety"/>
+                            <position x="tan(-CrossingAngle)*(BeamCal_min_z+BeamCal_dz)" y="0" z="0"/>
+                            <rotation x="0" y="-CrossingAngle" z="0"/>
+                        </shape>
+                        <position x="tan(0.5*CrossingAngle)*(BeamCal_min_z+BeamCal_dz)" y="0" z="-(BeamCal_min_z+BeamCal_dz)"/>
+                        <rotation x="0" y="180*deg-CrossingAngle*0.5" z="180*deg"/>
+                    </shape>
+                </shape>
+            </envelope>
+            
+            <parameter crossingangle="CrossingAngle"
+            cutoutspanningangle="360*degree-BeamCal_spanning_angle"
+            incomingbeampiperadius="3.5*mm"
+            />
+            
+            <dimensions inner_r = "BeamCal_inner_radius"
+            inner_z = "BeamCal_min_z"
+            outer_r = "BeamCal_outer_radius" />
+            
+            <!-- Avoid dummy layers without sensitive element which cannot be handled by  DDMarlinPandora -->
+            <!-- Instead, create another layer group with the extra absorber in the front -->
+            <layer repeat="1" vis="SeeThrough">
+                <slice material = "C" thickness = "100*mm" vis="LayerVis1"      layerType="holeForIncomingBeampipe"/>
+                <slice material = "TungstenDens24" thickness = "3.5*mm" vis="BCLayerVis1"  layerType="holeForIncomingBeampipe" />
+                <slice material = "Silicon"        thickness = "0.3004*mm"      vis="BCLayerVis2"  sensitive = "yes"  />
+                <slice material = "Copper"         thickness = "0.0004*mm"      vis="BCLayerVis3"                     />
+                <slice material = "Kapton"         thickness = "0.15*mm"        vis="BCLayerVis4"                     />
+                <slice material = "Air"            thickness = "0.05*mm" />
+            </layer>
+            
+            <layer repeat="39" vis="SeeThrough">
+                <slice material = "TungstenDens24" thickness = "3.5*mm" vis="BCLayerVis1"  layerType="holeForIncomingBeampipe" />
+                <slice material = "Silicon"        thickness = "0.3004*mm"      vis="BCLayerVis2"  sensitive = "yes"  />
+                <slice material = "Copper"         thickness = "0.0004*mm"      vis="BCLayerVis3"                     />
+                <slice material = "Kapton"         thickness = "0.15*mm"        vis="BCLayerVis4"                     />
+                <slice material = "Air"            thickness = "0.05*mm" />
+            </layer>
+            
+            
+            
+        </detector>
+    </detectors>
+    
+</lccdd>
+
+

--- a/CLIC/compact/CLIC_o3_v09/BeamInstrumentation_o1_v01_01.xml
+++ b/CLIC/compact/CLIC_o3_v09/BeamInstrumentation_o1_v01_01.xml
@@ -1,0 +1,27 @@
+<lccdd>    
+    
+    <detectors>
+        <comment>Beampipe Instrumentation</comment>
+        
+        <detector name="Kicker" type="DD4hep_Mask_o1_v01" vis="KICKVis">
+            <parameter crossingangle="CrossingAngle" />
+            <envelope vis="KICKVis">
+                <shape type="Assembly"/>
+            </envelope>
+            <!--             &A                                Z1                  Z2                    RIn1                       RIn2                             ROut1                        ROut2              Material -->
+            <section type="Upstream"               start="Kicker_min_z"    end="Kicker_max_z" rMin1="Kicker_inner_radius"  rMin2="Kicker_inner_radius"  rMax1="Kicker_outer_radius"  rMax2="Kicker_outer_radius"  material="Iron" name="Kicker"/>     
+        </detector>
+        
+        
+        <detector name="BPM" type="DD4hep_Mask_o1_v01" vis="BPMVis">
+            <parameter crossingangle="CrossingAngle" />
+            <envelope vis="BPMVis">
+                <shape type="Assembly"/>
+            </envelope>
+            <!--             &A                                Z1                  Z2                    RIn1                       RIn2                             ROut1                        ROut2              Material -->
+            <section type="Dnstream"               start="BPM_min_z"    end="BPM_max_z" rMin1="BPM_inner_radius"  rMin2="BPM_inner_radius"  rMax1="BPM_outer_radius"  rMax2="BPM_outer_radius"  material="Iron" name="BPM"/>     
+        </detector>
+        
+        
+    </detectors>
+</lccdd>

--- a/CLIC/compact/CLIC_o3_v09/Beampipe_o1_v01_02.xml
+++ b/CLIC/compact/CLIC_o3_v09/Beampipe_o1_v01_02.xml
@@ -1,0 +1,40 @@
+<lccdd>
+    <!--  Definition of global dictionary constants          -->
+    <define>
+    </define>
+    
+    <!--  Definition of the used visualization attributes    -->
+    <display>
+        <vis name="BeamPipeVis" alpha="0.0" r="0.0" g="1.0" b="0.0" showDaughters="true" visible="false"/>
+        <vis name="TubeVis"  alpha="1.0" r="1.0" g="0.7"  b="0.5"   showDaughters="true"  visible="true"/>
+        <vis name="VacVis"   alpha="1.0" r="1.0" g="1.0"  b="1.0"   showDaughters="true"  visible="false"/>
+    </display>
+    
+    
+    <detectors>
+        <comment>Beampipe</comment>
+        
+        <detector name="Beampipe" type="DD4hep_Beampipe_o1_v01" vis="BeamPipeVis" region="BeampipeRegion">
+            <parameter crossingangle="CrossingAngle" />
+            <envelope vis="BlueVis">
+                <shape type="Assembly"/>
+            </envelope>
+
+            <!--             &A                       Z1                  Z2                    RIn1                RIn2                                 ROut1                        ROut2                                              Material -->
+            <section type="Center"               start="0*mm"    end="CentralBeamPipe_zmax" rMin1="29.4*mm"  rMin2="29.4*mm"                             rMax1="CentralBeamPipe_rmax"  rMax2="CentralBeamPipe_rmax"                       material="Beryllium" name="VertexInner"/>
+            <section type="Center" start="CentralBeamPipe_zmax"  end="337*mm"               rMin1="29.4*mm"  rMin2="29.4*mm"                             rMax1="30.0*mm"               rMax2="33.4*mm"                                    material="Iron"      name="ConeConnector"/>
+            <section type="Center"               start="337*mm"  end="ConeBeamPipe_zmax"    rMin1="29.4*mm"  rMin2="235.2*mm"                            rMax1="33.4*mm"               rMax2="ConeBeamPipe_rmax"                          material="Iron"      name="BigCone"/>
+            <section type="Center"               start="2080*mm" end="BigBeamPipe_zmax"     rMin1="235.2*mm" rMin2="235.2*mm"                            rMax1="ConeBeamPipe_rmax"     rMax2="ConeBeamPipe_rmax"                          material="Iron"      name="LumiCalConnector"/>
+            <section type="PunchedCenter"        start="BigBeamPipe_zmax" end="BigBeamPipe_zmax+3*mm"              rMin1="0.0*mm"   rMin2="98.0*mm"                             rMax1="240.0*mm"              rMax2="240.0*mm"                                   material="Iron"      name="LumiCalFront"/>
+            <section type="DnstreamClippedFront" start="BigBeamPipe_zmax+3*mm" end="3170*mm"              rMin1="98.0*mm"  rMin2="98.0*mm"                             rMax1="99.0*mm"               rMax2="99.0*mm"                                    material="Iron"      name="BeamCalConnector"/>
+            <section type="PunchedDnstream"      start="3170*mm" end="3173*mm"              rMin1="2.7*mm"   rMin2="31.0*mm"                             rMax1="99.0*mm"               rMax2="99.0*mm"                                    material="Iron"      name="BeamCalFront"/>
+            <section type="Dnstream"             start="3173*mm" end="3500*mm"              rMin1="31.0*mm"  rMin2="31.0*mm"                             rMax1="32.0*mm"               rMax2="32.0*mm"                                    material="Iron"      name="BeamCalInnerDownstream"/>
+            <section type="UpstreamSlicedFront"  start="3173*mm" end="3281*mm"              rMin1="2.7*mm"   rMin2="2.7*mm"                              rMax1="3.7*mm"                rMax2="3.7*mm"                                     material="Iron"      name="BeamCalInnerUpstream"/>
+            <section type="Upstream"             start="3281*mm" end="3835*mm"      rMin1="2.7*mm"   rMin2="2.7*mm"                              rMax1="3.7*mm"                rMax2="3.7*mm"                                     material="Iron"      name="UpstreamSmall"/>
+            <section type="Upstream"             start="3835*mm" end="3835*mm+10*mm" rMin1="2.7*mm"   rMin2="12*mm"                               rMax1="3.7*mm"                rMax2="13.5*mm"                                    material="Iron"      name="UpstreamCone"/>
+            <section type="Upstream"             start="3835*mm+10*mm" end="BeamPipe_end"   rMin1="12*mm"    rMin2="12*mm"                               rMax1="13.5*mm"               rMax2="13.5*mm"                                    material="Iron"      name="UpstreamLarge"/>
+            <section type="Dnstream"             start="3500*mm" end="BeamPipe_end"         rMin1="31.0*mm"  rMin2="BeamPipe_end*tan(CrossingAngle*0.5)" rMax1="32.0*mm"               rMax2="BeamPipe_end*tan(CrossingAngle*0.5)+2.0*mm" material="Iron"      name="DownstreamCone"/>
+            
+        </detector>
+    </detectors>
+</lccdd>

--- a/CLIC/compact/CLIC_o3_v09/CLIC_o3_v08.xml
+++ b/CLIC/compact/CLIC_o3_v09/CLIC_o3_v08.xml
@@ -1,0 +1,259 @@
+<lccdd>
+    <info name="CLIC_o3_v08"
+          title="CLIC detector model option 3 version 08"
+          author="Marko Petric"
+          url="https://twiki.cern.ch/twiki/bin/view/CLIC/NewCLIC"
+          status="development"
+          version="$Id: 2016-12-05 marko.petric@cern.ch $">
+        <comment>The compact format for the CLIC Detector design</comment>
+    </info>
+
+    <includes>
+        <gdmlFile  ref="elements.xml"/>
+        <gdmlFile  ref="materials.xml"/>
+    </includes>
+
+    <define>
+        <constant name="world_side"             value="30000*mm"/>
+        <constant name="world_x"                value="world_side"/>
+        <constant name="world_y"                value="world_side"/>
+        <constant name="world_z"                value="world_side"/>
+
+        <constant name="CrossingAngle"          value="0.020*rad"/>
+
+
+        <constant name="DetID_NOTUSED"          value="0"/>
+
+        <constant name="DetID_VXD_Barrel"       value="1"/>
+        <constant name="DetID_VXD_Endcap"       value="2"/>
+
+        <constant name="DetID_IT_Barrel"        value="3"/>
+        <constant name="DetID_IT_Endcap"        value="4"/>
+
+        <constant name="DetID_OT_Barrel"        value="5"/>
+        <constant name="DetID_OT_Endcap"        value="6"/>
+
+        <constant name="DetID_ECal_Barrel"      value="20"/>
+        <constant name="DetID_ECal_Endcap"      value="29"/>
+        <constant name="DetID_ECal_Plug"        value="21"/>
+
+        <constant name="DetID_HCAL_Barrel"      value="10"/>
+        <constant name="DetID_HCAL_Endcap"      value="11"/>
+        <constant name="DetID_HCAL_Ring"        value="12"/>
+
+        <constant name="DetID_Yoke_Barrel"      value="13"/>
+        <constant name="DetID_Yoke_Endcap"      value="14"/>
+
+        <constant name="DetID_LumiCal"          value="15"/>
+        <constant name="DetID_BeamCal"          value="16"/>
+
+        <constant name="CentralBeamPipe_zmax"   value="308.*mm"/>
+        <constant name="CentralBeamPipe_rmax"   value="30.0*mm"/>
+        <constant name="ConeBeamPipe_zmax"      value="2080*mm"/>
+        <constant name="ConeBeamPipe_rmax"      value="240.0*mm"/>
+        <constant name="BigBeamPipe_zmax"       value="2528*mm"/>
+        <constant name="BeamPipe_end"           value="12500*mm"/>
+
+
+
+        <!-- ################### ENVELOPE PARAMETERS ######################################################## -->
+
+        <comment> suggested naming convention:
+
+            main parameters:
+
+            DET_inner_radius    : inner radius of tube like envelope  ( inscribed cylinder )
+            DET_outer_radius    : outer radius of tube like envelope  ( circumscribed cylinder )
+            DET_half_length     : half length along z axis
+            DET_min_z           : smallest absolute value on z-axis
+            DET_max_z           : largest  absolute value on z-axis
+            DET_inner_symmetry  : number of sides on the inside  ( 0 for tube )
+            DET_outer_symmetry  : number of sides on the inside  ( 0 for tube )
+            DET_inner_phi0      : optional rotation of the inner polygon ( in r-phi plane )
+            DET_outer_phi0      : optional rotation of the outer polygon ( in r-phi plane )
+
+            additional parameters for cutting away volumes/shapes use one of the above with a number
+            appended and/or an extra specifiaction such as cone ( for a cut away cone )
+
+            DET_inner_radius_1
+            DET_outer_radius_2
+            DET_cone_min_z
+            DET_cone_max_z
+
+        </comment>
+
+        <constant name="env_safety"                 value="0.1*mm"/>
+
+        <constant name="Vertex_inner_radius"        value="30*mm"/>
+        <constant name="Vertex_outer_radius"        value="116*mm"/>
+        <constant name="Vertex_half_length"         value="307*mm"/>
+
+        <constant name="InnerTracker_inner_radius"  value="61*mm"/>
+        <constant name="InnerTracker_outer_radius"  value="580*mm"/>
+        <constant name="InnerTracker_half_length"   value="2306*mm"/>
+
+        <constant name="OuterTracker_inner_radius"  value="580*mm"/>
+        <constant name="OuterTracker_outer_radius"  value="1500*mm - 0.1*mm"/>  <!-- to avoid overlap with CaloFace-->
+        <constant name="OuterTracker_half_length"   value="2306*mm"/>
+
+        <constant name="ECalBarrel_inner_radius"    value="1500*mm"/>
+        <constant name="ECalBarrel_outer_radius"    value="1702*mm"/>
+        <constant name="ECalBarrel_half_length"     value="2210*mm"/>
+        <constant name="ECalBarrel_symmetry"        value="12"/>
+
+        <constant name="ECalEndcap_inner_radius"    value="410*mm"/>
+        <constant name="ECalEndcap_outer_radius"    value="1700*mm"/>
+        <constant name="ECalEndcap_min_z"           value="2307*mm"/>
+        <constant name="ECalEndcap_max_z"           value="2509*mm"/>
+        <constant name="ECalEndcap_outer_symmetry"  value="12"/>
+        <constant name="ECalEndcap_inner_symmetry"  value="12"/>
+
+        <constant name="ECalPlug_inner_radius"      value="260*mm"/>
+        <constant name="ECalPlug_outer_radius"      value="380*mm"/>
+        <constant name="ECalPlug_min_z"             value="2307*mm"/>
+        <constant name="ECalPlug_max_z"             value="2509*mm"/>
+        <constant name="ECalPlug_outer_symmetry"    value="12"/>
+        <constant name="ECalPlug_inner_symmetry"    value="12"/>
+
+        <constant name="HCalBarrel_inner_radius"    value="1740*mm"/>
+        <constant name="HCalBarrel_outer_radius"    value="3330*mm"/>
+        <constant name="HCalBarrel_half_length"     value="2210*mm"/>
+        <constant name="HCalBarrel_symmetry"        value="12"/>
+
+        <constant name="HCalEndcap_inner_radius"    value="250*mm"/>
+        <constant name="HCalEndcap_outer_radius"    value="3246*mm"/>
+        <constant name="HCalEndcap_min_z"           value="2539*mm"/>
+        <constant name="HCalEndcap_max_z"           value="4129*mm"/>
+        <constant name="HCalEndcap_symmetry"        value="12"/>
+        <constant name="HCalEndcap_zcutout"         value="200*mm"/>
+        <constant name="HCalEndcap_rcutout"         value="128*mm"/>
+
+        <constant name="HCalRing_inner_radius"      value="1738*mm"/>
+        <constant name="HCalRing_outer_radius"      value="HCalEndcap_outer_radius"/>
+        <constant name="HCalRing_min_z"             value="2353.5*mm"/>
+        <constant name="HCalRing_max_z"             value="HCalEndcap_min_z"/>
+        <constant name="HCalRing_symmetry"          value="12"/>
+
+        <constant name="Solenoid_inner_radius"      value="3483*mm"/>
+        <constant name="Solenoid_outer_radius"      value="4290*mm"/>
+        <constant name="Solenoid_half_length"       value="4129*mm"/>
+        <constant name="Solenoid_Coil_half_length"  value="3900*mm"/>
+        <constant name="Solenoid_Coil_radius"       value="3821*mm"/>
+
+        <constant name="YokeBarrel_inner_radius"    value="4461*mm"/>
+        <constant name="YokeBarrel_outer_radius"    value="6450*mm"/>
+        <constant name="YokeBarrel_half_length"     value="4179*mm"/>
+        <constant name="YokeBarrel_symmetry"        value="12"/>
+
+        <constant name="YokeEndcap_inner_radius"    value="490*mm"/>
+        <constant name="YokeEndcap_outer_radius"    value="6450*mm"/>
+        <constant name="YokeEndcap_min_z"           value="4179*mm"/>
+        <constant name="YokeEndcap_max_z"           value="5700*mm"/>
+        <constant name="YokeEndcap_outer_symmetry"  value="12"/>
+        <constant name="YokeEndcap_inner_symmetry"  value="0"/>
+
+        <constant name="LumiCal_inner_radius"       value="100*mm"/>
+        <constant name="LumiCal_outer_radius"       value="340*mm"/>
+        <constant name="LumiCal_min_z"              value="2539*mm"/>
+        <constant name="LumiCal_max_z"              value="2712*mm"/>
+        <constant name="LumiCal_dz"                 value="(LumiCal_max_z-LumiCal_min_z)/2.0"/>
+
+        <constant name="BeamCal_inner_radius"       value="32*mm"/>
+        <constant name="BeamCal_outer_radius"       value="150*mm"/>
+        <constant name="BeamCal_min_z"              value="3181*mm"/>
+        <constant name="BeamCal_max_z"              value="3441*mm"/>
+        <constant name="BeamCal_dz"                 value="(BeamCal_max_z-BeamCal_min_z)/2.0"/>
+
+        <constant name="Kicker_inner_radius"        value="4*mm"/>
+        <constant name="Kicker_outer_radius"        value="25*mm"/>
+        <constant name="Kicker_min_z"               value="3455*mm"/>
+        <constant name="Kicker_max_z"               value="3715*mm"/>
+
+        <constant name="BPM_inner_radius"           value="36*mm"/>
+        <constant name="BPM_outer_radius"           value="55*mm"/>
+        <constant name="BPM_min_z"                  value="3730*mm"/>
+        <constant name="BPM_max_z"                  value="3820*mm"/>
+
+
+        <constant name="tracker_region_zmax"        value="OuterTracker_half_length"/>
+        <constant name="tracker_region_rmax"        value="OuterTracker_outer_radius"/>
+
+        <constant name="GlobalTrackerReadoutID" type="string" value="system:5,side:-2,layer:6,module:11,sensor:8"/>
+    </define>
+
+    <limits>
+        <limitset name="cal_limits">
+            <limit name="step_length_max" particles="*" value="5.0" unit="mm" />
+        </limitset>
+    </limits>
+    <regions>
+        <region name="BeampipeRegion"            />
+        <region name="VertexBarrelRegion"        />
+        <region name="VertexEndcapRegion"        />
+        <region name="InnerTrackerBarrelRegion"  />
+        <region name="OuterTrackerBarrelRegion"  />
+        <region name="InnerTrackerEndcapRegion"  />
+        <region name="OuterTrackerEndcapRegion"  />
+    </regions>
+
+
+    <display>
+        <vis name="VXDVis"      alpha="1.0" r="0.2"   g="0.2"     b="0.2"   showDaughters="true"  visible="false"/>
+        <vis name="ITVis"       alpha="1.0" r="0.54"  g="0.43"    b="0.04"  showDaughters="true"  visible="false"/>
+        <vis name="OTVis"       alpha="1.0" r="0.8"   g="0.8"     b="0.4"   showDaughters="true"  visible="false"/>
+        <vis name="ECALVis"     alpha="1.0" r="0.2"   g="0.6"     b="0"     showDaughters="true"  visible="true"/>
+        <vis name="HCALVis"     alpha="1.0" r="0.078" g="0.01176" b="0.588" showDaughters="true"  visible="true"/>
+        <vis name="SOLVis"      alpha="1.0" r="0.4"   g="0.4"     b="0.4"   showDaughters="true"  visible="true"/>
+        <vis name="YOKEVis"     alpha="1.0" r="0.6"   g="0.0"     b="0.0"   showDaughters="true"  visible="true"/>
+        <vis name="LCALVis"     alpha="1.0" r="0.35"  g="0.0"     b="0.47"  showDaughters="true"  visible="true"/>
+        <vis name="BCALVis"     alpha="1.0" r="0.0"   g="0.4"     b="0.4"   showDaughters="true"  visible="true"/>
+        <vis name="KICKVis"     alpha="1.0" r="1.0"   g="0.498"   b="0.0"   showDaughters="true"  visible="true"/>
+        <vis name="BPMVis"      alpha="1.0" r="0.25"  g="0.88"    b="0.81"  showDaughters="true"  visible="true"/>
+        <vis name="SupportVis"  alpha="1"   r="0.2"   g="0.2"     b="0.2"   showDaughters="false" visible="true"/>
+    </display>
+
+    <include ref="${DD4hepINSTALL}/DDDetectors/compact/detector_types.xml"/>
+
+    <include ref="Beampipe_o1_v01_02.xml"/>
+    <include ref="BeamInstrumentation_o1_v01_01.xml"/>
+
+    <include ref="Vertex_o2_v06_01.xml"/>
+
+    <include ref="InnerTracker_o2_v06_01.xml"/>
+    <include ref="OuterTracker_o2_v06_01.xml"/>
+
+    <include ref="ECalBarrel_o2_v01_02.xml"/>
+    <include ref="ECalEndcap_o2_v01_02.xml"/>
+    <include ref="ECalPlug_o1_v01_02.xml"/>
+
+    <include ref="HCalBarrel_o1_v01_01.xml"/>
+    <include ref="HCalEndcap_o1_v01_01.xml"/>
+
+    <include ref="Solenoid_o1_v01_01.xml"/>
+
+    <include ref="YokeBarrel_o1_v01_01.xml"/>
+    <include ref="YokeEndcap_o1_v01_01.xml"/>
+
+    <include ref="LumiCal_o1_v01_01.xml"/>
+
+    <include ref="BeamCal_o1_v01_01.xml"/>
+
+    <plugins>
+        <plugin name="DD4hepVolumeManager"/>
+        <plugin name="InstallSurfaceManager"/>
+    </plugins>
+
+
+    <fields>
+        <field name="GlobalSolenoid" type="solenoid"
+               inner_field="4.0*tesla"
+               outer_field="-1.5*tesla"
+               zmax="Solenoid_Coil_half_length"
+               inner_radius="Solenoid_Coil_radius"
+               outer_radius="YokeBarrel_outer_radius">
+        </field>
+    </fields>
+
+
+</lccdd>
+

--- a/CLIC/compact/CLIC_o3_v09/CLIC_o3_v09.xml
+++ b/CLIC/compact/CLIC_o3_v09/CLIC_o3_v09.xml
@@ -1,10 +1,10 @@
 <lccdd>
-    <info name="CLIC_o3_v08"
-          title="CLIC detector model option 3 version 08"
+    <info name="CLIC_o3_v09"
+          title="CLIC detector model option 3 version 09"
           author="Marko Petric"
           url="https://twiki.cern.ch/twiki/bin/view/CLIC/NewCLIC"
           status="development"
-          version="$Id: 2016-12-05 marko.petric@cern.ch $">
+          version="$Id: 2017-03-31 marko.petric@cern.ch $">
         <comment>The compact format for the CLIC Detector design</comment>
     </info>
 

--- a/CLIC/compact/CLIC_o3_v09/ECalBarrel_o2_v01_02.xml
+++ b/CLIC/compact/CLIC_o3_v09/ECalBarrel_o2_v01_02.xml
@@ -1,0 +1,71 @@
+<lccdd>
+
+    <!--  Definition of the readout segmentation  -->
+    <define>
+        <constant name="ECal_cell_size" value="5.1*mm"/>
+    </define>
+ 
+    <readouts>
+        <readout name="ECalBarrelCollection">
+            <segmentation type="CartesianGridXY" grid_size_x="ECal_cell_size" grid_size_y="ECal_cell_size" />
+            <id>system:5,side:2,module:8,stave:4,layer:9,submodule:4,x:32:-16,y:-16</id>
+        </readout>
+    </readouts>
+    
+    <!--  Definitions of visualization attributes  -->
+    <display>
+        <vis name="ECalStaveVis"      alpha="1.0" r="0.0"  g="0.8"  b="1.0"  showDaughters="true"  visible="true"/>
+        <vis name="ECalLayerVis"      alpha="1.0" r="0.8"  g="0.8"  b="0.0"  showDaughters="true"  visible="true"/>
+        <vis name="ECalSensitiveVis"  alpha="1.0" r="0.7"  g="0.3"  b="0.0"  showDaughters="false" visible="true"/>
+        <vis name="ECalAbsorberVis"   alpha="1.0" r="0.4"  g="0.4"  b="0.0"  showDaughters="false" visible="true"/>
+        <vis name="ECalEndcapVis"     alpha="1.0" r="0.77" g="0.74" b="0.86" showDaughters="true"  visible="true"/>
+	<vis name="HiddenEnvelope"    alpha="0.0" r="1.0"  g="1.0"  b="1.0"  showDaughters="true"  visible="false"/>
+	<vis name="CompositeVis"      alpha="1.0" r="1.0"  g="0.0"  b="0.0"  showDaughters="true"  visible="true"/>
+    </display>
+
+    <detectors>        
+        <detector name="ECalBarrel" type="GenericCalBarrel_o1_v01" id="DetID_ECal_Barrel" readout="ECalBarrelCollection" vis="BlueVis" gap="0.*cm">
+
+            <comment>EM Calorimeter Barrel</comment>
+            
+            <type_flags type=" DetType_CALORIMETER + DetType_ELECTROMAGNETIC + DetType_BARREL"/>
+
+            <envelope vis="ECALVis">
+                <shape type="PolyhedraRegular" numsides="ECalBarrel_symmetry"  rmin="ECalBarrel_inner_radius" rmax="ECalBarrel_outer_radius" dz="2.*ECalBarrel_half_length"  material="Air"/>
+		<!-- Radii definitions as in http://cern.ch/go/r9mZ -->
+                <rotation x="0*deg" y="0*deg" z="90*deg-180*deg/ECalBarrel_symmetry"/>
+            </envelope>
+            
+            <dimensions numsides="ECalBarrel_symmetry" rmin="ECalBarrel_inner_radius" z="ECalBarrel_half_length*2" />
+            <staves vis="ECalStaveVis" />
+            <layer repeat="40" vis="ECalLayerVis">
+                <slice material = "TungstenDens24" thickness = "1.90*mm" vis="ECalAbsorberVis" radiator="yes"/>
+                <slice material = "G10"            thickness = "0.15*mm" vis="InvisibleNoDaughters"/>
+                <slice material = "GroundOrHVMix"  thickness = "0.10*mm" vis="ECalAbsorberVis"/>
+                <slice material = "Silicon"        thickness = "0.50*mm" sensitive="yes" limits="cal_limits" vis="ECalSensitiveVis"/>
+                <slice material = "Air"            thickness = "0.10*mm" vis="InvisibleNoDaughters"/>
+                <slice material = "siPCBMix"       thickness = "1.30*mm" vis="ECalAbsorberVis"/>
+                <slice material = "Air"            thickness = "0.25*mm" vis="InvisibleNoDaughters"/>
+                <slice material = "G10"            thickness = "0.75*mm" vis="InvisibleNoDaughters"/>
+            </layer>
+        </detector>
+    </detectors>
+    
+    <plugins>
+        <plugin name="DD4hep_CaloFaceBarrelSurfacePlugin">
+            <argument value="ECalBarrel"/>
+            <argument value="length=2.*ECalBarrel_half_length"    /> 
+            <argument value="radius=ECalBarrel_inner_radius"  /> 
+            <argument value="phi0=0"    /> 
+            <argument value="symmetry=ECalBarrel_symmetry"/>
+            <argument value="systemID=DetID_ECal_Barrel"/>
+        </plugin>
+    </plugins>
+    
+    
+</lccdd>
+
+
+
+
+

--- a/CLIC/compact/CLIC_o3_v09/ECalEndcap_o2_v01_02.xml
+++ b/CLIC/compact/CLIC_o3_v09/ECalEndcap_o2_v01_02.xml
@@ -1,0 +1,59 @@
+<lccdd>
+    
+       
+    
+    <!--  Definition of the readout segmentation/definition  -->
+    <readouts>
+        <readout name="ECalEndcapCollection">
+            <segmentation type="CartesianGridXY" grid_size_x="ECal_cell_size" grid_size_y="ECal_cell_size" />
+            <id>system:5,side:2,module:8,stave:4,layer:9,submodule:4,x:32:-16,y:-16</id>
+        </readout>
+    </readouts>
+    
+    <!--  Includes for sensitives and support                -->
+    <detectors>
+        
+        <detector name="ECalEndcap" type="GenericCalEndcap_o1_v01" id="DetID_ECal_Endcap" readout="ECalEndcapCollection" vis="ECALVis" >
+            
+            <comment>Electromagnetic Calorimeter Endcap</comment>
+            
+            <type_flags type=" DetType_CALORIMETER + DetType_ELECTROMAGNETIC + DetType_ENDCAP"/>
+
+            <envelope vis="ECALVis">
+                <shape type="BooleanShape" operation="Subtraction" material="Air">
+                        <shape type="PolyhedraRegular"  numsides="ECalEndcap_outer_symmetry" rmin="ECalEndcap_inner_radius-env_safety" rmax="ECalEndcap_outer_radius+ 10.0*env_safety" dz="2.0*ECalEndcap_max_z+2*env_safety"/>
+                        <shape type="PolyhedraRegular"  numsides="ECalEndcap_outer_symmetry" rmin="0" rmax="ECalEndcap_outer_radius+ 100.0*env_safety" dz="2.0*ECalEndcap_min_z-2*env_safety"/>
+                    </shape>
+                <rotation x="0*deg" y="0*deg" z="90*deg-180*deg/ECalEndcap_outer_symmetry"/>
+            </envelope>
+            
+            
+            <dimensions nsides_inner="ECalEndcap_inner_symmetry" nsides_outer="(int) ECalEndcap_outer_symmetry" zmin="ECalEndcap_min_z" rmin="ECalEndcap_inner_radius" rmax="ECalEndcap_outer_radius"/>
+            
+            <layer repeat="40" vis="ECalLayerVis">
+                <slice material = "TungstenDens24" thickness = "1.90*mm" vis="ECalAbsorberVis" radiator="yes"/>
+                <slice material = "G10"            thickness = "0.15*mm" vis="InvisibleNoDaughters"/>
+                <slice material = "GroundOrHVMix"  thickness = "0.10*mm" vis="ECalAbsorberVis"/>
+                <slice material = "Silicon"        thickness = "0.50*mm" sensitive="yes" limits="cal_limits" vis="ECalSensitiveVis"/>
+                <slice material = "Air"            thickness = "0.10*mm" vis="InvisibleNoDaughters"/>
+                <slice material = "siPCBMix"       thickness = "1.30*mm" vis="ECalAbsorberVis"/>
+                <slice material = "Air"            thickness = "0.25*mm" vis="InvisibleNoDaughters"/>
+                <slice material = "G10"            thickness = "0.75*mm" vis="InvisibleNoDaughters"/>
+            </layer>
+            
+        </detector>
+    </detectors>
+    
+    <plugins>
+        <plugin name="DD4hep_CaloFaceEndcapSurfacePlugin">
+            <argument value="ECalEndcap"/>
+	        <argument value="zpos=ECalEndcap_min_z"    />
+	        <argument value="radius=ECalEndcap_outer_radius"  />
+	        <argument value="phi0=0"    />
+	        <argument value="symmetry=ECalEndcap_outer_symmetry"/>
+	        <argument value="systemID=DetID_ECal_Endcap"/>
+	  </plugin>
+    </plugins>
+</lccdd>
+
+

--- a/CLIC/compact/CLIC_o3_v09/ECalPlug_o1_v01_02.xml
+++ b/CLIC/compact/CLIC_o3_v09/ECalPlug_o1_v01_02.xml
@@ -1,0 +1,48 @@
+<lccdd>
+    
+       
+    
+    <!--  Definition of the readout segmentation/definition  -->
+    <readouts>
+        <readout name="ECalPlugCollection">
+            <segmentation type="CartesianGridXY" grid_size_x="ECal_cell_size" grid_size_y="ECal_cell_size" />
+            <id>system:5,side:2,module:8,stave:4,layer:9,submodule:4,x:32:-16,y:-16</id>
+        </readout>
+    </readouts>
+    
+    <!--  Includes for sensitives and support                -->
+    <detectors>
+        
+        <detector name="ECalPlug" type="GenericCalEndcap_o1_v01" id="DetID_ECal_Plug" readout="ECalPlugCollection" vis="ECALVis" >
+            
+            <comment>Hadronic Calorimeter Endcap</comment>
+            
+            <type_flags type=" DetType_CALORIMETER + DetType_ELECTROMAGNETIC + DetType_ENDCAP + DetType_AUXILIARY"/>
+
+            <envelope vis="ECALVis">
+                <shape type="BooleanShape" operation="Subtraction" material="Air">
+                        <shape type="PolyhedraRegular"  numsides="ECalPlug_outer_symmetry" rmin="ECalPlug_inner_radius-env_safety" rmax="ECalPlug_outer_radius+ 10.0*env_safety" dz="2.0*ECalPlug_max_z+2*env_safety"/>
+                        <shape type="PolyhedraRegular"  numsides="ECalPlug_outer_symmetry" rmin="0" rmax="ECalPlug_outer_radius+ 100.0*env_safety" dz="2.0*ECalPlug_min_z-2*env_safety"/>
+                    </shape>
+                <rotation x="0*deg" y="0*deg" z="90*deg-180*deg/ECalPlug_outer_symmetry"/>
+            </envelope>
+            
+            
+            <dimensions nsides_inner="ECalPlug_inner_symmetry" nsides_outer="(int) ECalPlug_outer_symmetry" zmin="ECalPlug_min_z" rmin="ECalPlug_inner_radius" rmax="ECalPlug_outer_radius" phi0="0"/>
+            
+            <layer repeat="40" vis="ECalLayerVis">
+                <slice material = "TungstenDens24" thickness = "1.90*mm" vis="ECalAbsorberVis" radiator="yes"/>
+                <slice material = "G10"            thickness = "0.15*mm" vis="InvisibleNoDaughters"/>
+                <slice material = "GroundOrHVMix"  thickness = "0.10*mm" vis="ECalAbsorberVis"/>
+                <slice material = "Silicon"        thickness = "0.50*mm" sensitive="yes" limits="cal_limits" vis="ECalSensitiveVis"/>
+                <slice material = "Air"            thickness = "0.10*mm" vis="InvisibleNoDaughters"/>
+                <slice material = "siPCBMix"       thickness = "1.30*mm" vis="ECalAbsorberVis"/>
+                <slice material = "Air"            thickness = "0.25*mm" vis="InvisibleNoDaughters"/>
+                <slice material = "G10"            thickness = "0.75*mm" vis="InvisibleNoDaughters"/>
+            </layer>
+            
+        </detector>
+    </detectors>
+</lccdd>
+
+

--- a/CLIC/compact/CLIC_o3_v09/FalsePositiveOverlaps.txt
+++ b/CLIC/compact/CLIC_o3_v09/FalsePositiveOverlaps.txt
@@ -1,0 +1,38 @@
+#########################################################################################################
+#########################################################################################################
+#########################################################################################################
+
+
+Checking overlaps for volume av_4_impr_2_OuterTrackerBarrelModule_In_pv_0 ...
+-------- WWWW ------- G4Exception-START -------- WWWW -------
+*** G4Exception : GeomVol1002
+      issued by : G4PVPlacement::CheckOverlaps()
+Overlap with volume already placed !
+          Overlap is detected for volume av_4_impr_2_OuterTrackerBarrelModule_In_pv_0
+          with av_4_impr_2_OuterTrackerBarrelModule_In_pv_1 volume's
+          local point (-0.019326,15.0452,-0.922273), overlapping by at least: 4.81928 um
+NOTE: Reached maximum fixed number -1- of overlaps reports for this volume !
+*** This is just a warning message. ***
+-------- WWWW -------- G4Exception-END --------- WWWW -------
+
+Checking overlaps for volume av_4_impr_4_OuterTrackerBarrelModule_Out_pv_0 ...
+-------- WWWW ------- G4Exception-START -------- WWWW -------
+*** G4Exception : GeomVol1002
+      issued by : G4PVPlacement::CheckOverlaps()
+Overlap with volume already placed !
+          Overlap is detected for volume av_4_impr_4_OuterTrackerBarrelModule_Out_pv_0
+          with av_4_impr_4_OuterTrackerBarrelModule_Out_pv_1 volume's
+          local point (9.32806,15.0452,-0.0394282), overlapping by at least: 4.81928 um
+NOTE: Reached maximum fixed number -1- of overlaps reports for this volume !
+*** This is just a warning message. ***
+-------- WWWW -------- G4Exception-END --------- WWWW -------
+
+
+This two over due to tight placement of modules in Outer tracker barrel.
+If you place a large number of along z (e.g. 84) you get this.
+If you reduce the number along z this disappears
+
+
+#########################################################################################################
+#########################################################################################################
+#########################################################################################################

--- a/CLIC/compact/CLIC_o3_v09/HCalBarrel_o1_v01_01.xml
+++ b/CLIC/compact/CLIC_o3_v09/HCalBarrel_o1_v01_01.xml
@@ -1,0 +1,59 @@
+<lccdd>
+    <!--  Definition of global dictionary constants          -->
+    <define>
+        <constant name="HCalBarrel_layers" value="(int) 60"/>
+        <constant name="HCalBarrel_layer_thickness" value="2.0*cm + 0.65*cm"/>
+        <constant name="HCal_cell_size" value="3.0*cm"/>
+        
+    </define>
+    
+    <!--  Definition of the used visualization attributes    -->
+    <display>
+        <vis name="HCalBarrelVis"    alpha="1" r="0.0"  g="0.3"  b="0.8" showDaughters="true" visible="true"/>
+        <vis name="HCalStavesVis"    alpha="1" r="0.0"  g="0.0"  b="0.1" showDaughters="true" visible="false"/>
+        <vis name="HCalLayerVis"     alpha="1" r="1"    g="0"    b="0.5" showDaughters="false" visible="true"/>
+        <vis name="HCalSensorVis"    alpha="1" r="1.0"  g="0.0"  b="0.2" showDaughters="true" visible="true"/>
+        <vis name="HCalAbsorberVis"  alpha="1" r="0.4"  g="0.4"  b="0.6" showDaughters="true" visible="true"/>
+        
+        <vis name="HCalEndcapVis"          alpha="1" r="1"    g="1"    b="0.1" showDaughters="false" visible="true"/>
+        <vis name="HCalEndcapLayerVis"     alpha="1" r="1"    g="0"    b="0.5" showDaughters="false" visible="true"/>
+    </display>
+    
+    <!--  Definition of the readout segmentation/definition  -->
+    <readouts>
+        <readout name="HCalBarrelCollection">
+          <segmentation type="CartesianGridXY" grid_size_x="HCal_cell_size" grid_size_y="HCal_cell_size" />
+          <id>system:5,side:2,module:8,stave:4,layer:9,submodule:4,x:32:-16,y:-16</id>
+        </readout>
+    </readouts>
+    
+    <detectors>
+        <detector id="DetID_HCAL_Barrel" name="HCalBarrel" type="GenericCalBarrel_o1_v01" readout="HCalBarrelCollection" vis="HCALVis" calorimeterType="HAD_BARREL" gap="0.*cm" material="Steel235">
+            
+            <comment>Hadron Calorimeter Barrel</comment>
+            
+            <type_flags type=" DetType_CALORIMETER + DetType_HADRONIC + DetType_BARREL"/>
+
+            <envelope vis="HCALVis">
+                <shape type="PolyhedraRegular" numsides="HCalBarrel_symmetry"  rmin="HCalBarrel_inner_radius-10*env_safety" rmax="HCalBarrel_outer_radius+10*env_safety" dz="HCalBarrel_half_length*2+10*env_safety" material = "Air"/>
+                <rotation x="0*deg" y="0*deg" z="90*deg-180*deg/HCalBarrel_symmetry"/>
+            </envelope>
+            
+            
+            <dimensions numsides="HCalBarrel_symmetry" rmin="HCalBarrel_inner_radius" z="HCalBarrel_half_length*2"/>
+            <staves vis="HCalStavesVis"/>
+            <layer repeat="(int) HCalBarrel_layers" vis="HCalLayerVis">
+                <slice material="Steel235" thickness="0.5*mm" vis="HCalAbsorberVis" radiator="yes"/>
+                <slice material="Steel235" thickness="19*mm" vis="HCalAbsorberVis" radiator="yes"/>
+                <slice material="Polystyrene" thickness="3*mm" sensitive="yes" limits="cal_limits" vis="HCalSensorVis"/>
+                <slice material="Copper" thickness="0.1*mm" vis="HCalCopperVis"/>
+                <slice material="PCB" thickness="0.7*mm" vis="HCalPCBVis"/>
+                <slice material="Steel235" thickness="0.5*mm" vis="HCalAbsorberVis" radiator="yes"/>
+                <slice material="Air" thickness="2.7*mm" vis="InvisibleNoDaughters"/>
+            </layer>
+        </detector>
+        
+    </detectors>
+
+</lccdd>
+

--- a/CLIC/compact/CLIC_o3_v09/HCalBarrel_o1_v01_01.xml
+++ b/CLIC/compact/CLIC_o3_v09/HCalBarrel_o1_v01_01.xml
@@ -45,7 +45,7 @@
             <layer repeat="(int) HCalBarrel_layers" vis="HCalLayerVis">
                 <slice material="Steel235" thickness="0.5*mm" vis="HCalAbsorberVis" radiator="yes"/>
                 <slice material="Steel235" thickness="19*mm" vis="HCalAbsorberVis" radiator="yes"/>
-                <slice material="Polystyrene" thickness="3*mm" sensitive="yes" limits="cal_limits" vis="HCalSensorVis"/>
+                <slice material="G4_POLYSTYRENE" thickness="3*mm" sensitive="yes" limits="cal_limits" vis="HCalSensorVis"/>
                 <slice material="Copper" thickness="0.1*mm" vis="HCalCopperVis"/>
                 <slice material="PCB" thickness="0.7*mm" vis="HCalPCBVis"/>
                 <slice material="Steel235" thickness="0.5*mm" vis="HCalAbsorberVis" radiator="yes"/>

--- a/CLIC/compact/CLIC_o3_v09/HCalEndcap_o1_v01_01.xml
+++ b/CLIC/compact/CLIC_o3_v09/HCalEndcap_o1_v01_01.xml
@@ -1,0 +1,133 @@
+<lccdd>
+    <define>
+        <constant name="HCalEndcap_layers" value="60"/>
+        <constant name="HCalEndcap_layer_thickness" value="2.0*cm + 0.65*cm"/>
+        <constant name="HCal_cell_size" value="3.0*cm"/>
+        <constant name="HCalEndcap_cutout_layers" value="- floor( -HCalEndcap_zcutout / HCalEndcap_layer_thickness)"/>
+        <constant name="HCalRing_layers" value=" floor( (HCalEndcap_min_z - HCalRing_min_z) / HCalEndcap_layer_thickness + 0.5)"/>
+    </define>
+    
+    
+    <detectors>
+        <detector name="HCalEndcaps" type="DD4hep_SubdetectorAssembly" vis="HCALVis">
+            
+                <shape type="BooleanShape" operation="Subtraction" material="Air">
+                    <shape type="BooleanShape" operation="Subtraction">
+                        <shape type="BooleanShape" operation="Subtraction">
+                            <shape type="BooleanShape" operation="Subtraction">
+                                <shape type="PolyhedraRegular"  numsides="HCalEndcap_symmetry" rmin="0" rmax="HCalEndcap_outer_radius+5*env_safety" dz="2.0*HCalEndcap_max_z+10*env_safety"/>
+                                <shape type="PolyhedraRegular"  numsides="HCalEndcap_symmetry" rmin="0" rmax="HCalEndcap_outer_radius+10*env_safety" dz="2.0*HCalRing_min_z-5*env_safety"/>
+                            </shape>
+                            <shape type="PolyhedraRegular"  numsides="HCalEndcap_symmetry" rmin="0" rmax="HCalRing_inner_radius-5*env_safety" dz="2.0*HCalEndcap_min_z-10*env_safety"/>
+                        </shape>
+                        <shape type="PolyhedraRegular"  numsides="HCalEndcap_symmetry" rmin="0" rmax="HCalEndcap_inner_radius + HCalEndcap_rcutout" dz="2.0*HCalEndcap_min_z + 2*HCalEndcap_zcutout"/>
+                    </shape>
+                    <shape type="Tube" rmin="0" rmax="HCalEndcap_inner_radius-env_safety" dz="2.0*HCalEndcap_max_z + 2*HCalEndcap_zcutout"/>
+                </shape>
+                <rotation x="0*deg" y="0*deg" z="90*deg-180*deg/HCalEndcap_symmetry"/>
+            
+            
+            <comment>HCalEndcap Assembly</comment>
+            <composite name="HCalEndcap"/>
+            <composite name="HCalRing"/>
+        </detector>
+    </detectors>
+    
+    
+    
+    
+    <!--  Definition of the readout segmentation/definition  -->
+    <readouts>
+        <readout name="HCalEndcapCollection">
+            <segmentation type="CartesianGridXY" grid_size_x="3.5" grid_size_y="3.5" />
+            <id>system:5,side:2,module:8,stave:4,layer:9,submodule:4,x:32:-16,y:-16</id>
+        </readout>
+        <readout name="HCalRingCollection">
+            <segmentation type="CartesianGridXY" grid_size_x="3.5" grid_size_y="3.5" />
+            <id>system:5,side:2,module:8,stave:4,layer:9,submodule:4,x:32:-16,y:-16</id>
+        </readout>
+    </readouts>
+    
+
+    <detectors>
+        
+        <detector name="HCalEndcap" type="GenericCalEndcap_o1_v01" id="DetID_HCAL_Endcap" readout="HCalEndcapCollection" vis="HCALVis" >
+            
+            <comment>Hadronic Calorimeter Endcap</comment>
+            
+            <type_flags type=" DetType_CALORIMETER + DetType_HADRONIC + DetType_ENDCAP"/>
+
+            <envelope vis="HCALVis">
+                <shape type="Assembly"/>
+            </envelope>
+            
+            
+            <dimensions nsides_inner="HCalEndcap_symmetry" nsides_outer="(int) HCalEndcap_symmetry" zmin="HCalEndcap_min_z" rmin="HCalEndcap_inner_radius" rmax="HCalEndcap_outer_radius" phi0="0" rmin2="HCalEndcap_rcutout" z2="HCalEndcap_cutout_layers * HCalEndcap_layer_thickness"/>
+            
+            <layer repeat="HCalEndcap_cutout_layers" gap="HCalEndcap_rcutout" vis="HCalEndcapLayerVis">
+                <slice material="Steel235" thickness="0.5*mm" vis="HCalAbsorberVis" radiator="yes"/>
+                <slice material="Steel235" thickness="19*mm" vis="HCalAbsorberVis" radiator="yes"/>
+                <slice material="Polystyrene" thickness="3*mm" sensitive="yes" limits="cal_limits" vis="HCalSensorVis"/>
+                <slice material="Copper" thickness="0.1*mm" vis="HCalCopperVis"/>
+                <slice material="PCB" thickness="0.7*mm" vis="HCalPCBVis"/>
+                <slice material="Steel235" thickness="0.5*mm" vis="HCalAbsorberVis" radiator="yes"/>
+                <slice material="Air" thickness="2.7*mm" vis="InvisibleNoDaughters"/>
+            </layer>
+            
+            <layer repeat="HCalEndcap_layers - HCalEndcap_cutout_layers" vis="HCalEndcapLayerVis">
+                <slice material="Steel235" thickness="0.5*mm" vis="HCalAbsorberVis" radiator="yes"/>
+                <slice material="Steel235" thickness="19*mm" vis="HCalAbsorberVis" radiator="yes"/>
+                <slice material="Polystyrene" thickness="3*mm" sensitive="yes" limits="cal_limits" vis="HCalSensorVis"/>
+                <slice material="Copper" thickness="0.1*mm" vis="HCalCopperVis"/>
+                <slice material="PCB" thickness="0.7*mm" vis="HCalPCBVis"/>
+                <slice material="Steel235" thickness="0.5*mm" vis="HCalAbsorberVis" radiator="yes"/>
+                <slice material="Air" thickness="2.7*mm" vis="InvisibleNoDaughters"/>
+            </layer>
+            
+            
+        </detector>
+        
+    </detectors>
+    
+    
+    
+    <detectors>
+        
+        <detector name="HCalRing" type="GenericCalEndcap_o1_v01" id="DetID_HCAL_Ring" readout="HCalRingCollection" vis="HCALVis" >
+            
+            <comment>Hadronic Calorimeter Endcap</comment>
+            
+            <type_flags type=" DetType_CALORIMETER + DetType_HADRONIC + DetType_ENDCAP + DetType_AUXILIARY"/>
+
+            <envelope vis="HCALVis">
+                <shape type="Assembly"/>
+            </envelope>
+            
+            
+            <dimensions nsides_inner="HCalEndcap_symmetry" nsides_outer="(int) HCalEndcap_symmetry" zmin="HCalRing_min_z" rmin="HCalRing_inner_radius" rmax="HCalRing_outer_radius" phi0="0" rmin2="0" z2="HCalRing_layers * HCalEndcap_layer_thickness"/>
+            
+            
+            <layer repeat="HCalRing_layers" vis="HCalEndcapLayerVis">
+                <slice material="Steel235" thickness="0.5*mm" vis="HCalAbsorberVis" radiator="yes"/>
+                <slice material="Steel235" thickness="19*mm" vis="HCalAbsorberVis" radiator="yes"/>
+                <slice material="Polystyrene" thickness="3*mm" sensitive="yes" limits="cal_limits" vis="HCalSensorVis"/>
+                <slice material="Copper" thickness="0.1*mm" vis="HCalCopperVis"/>
+                <slice material="PCB" thickness="0.7*mm" vis="HCalPCBVis"/>
+                <slice material="Steel235" thickness="0.5*mm" vis="HCalAbsorberVis" radiator="yes"/>
+                <slice material="Air" thickness="2.7*mm" vis="InvisibleNoDaughters"/>
+            </layer>
+            
+            
+        </detector>
+        
+    </detectors>
+    
+    
+    
+    
+    
+    
+    
+</lccdd>
+
+

--- a/CLIC/compact/CLIC_o3_v09/HCalEndcap_o1_v01_01.xml
+++ b/CLIC/compact/CLIC_o3_v09/HCalEndcap_o1_v01_01.xml
@@ -67,7 +67,7 @@
             <layer repeat="HCalEndcap_cutout_layers" gap="HCalEndcap_rcutout" vis="HCalEndcapLayerVis">
                 <slice material="Steel235" thickness="0.5*mm" vis="HCalAbsorberVis" radiator="yes"/>
                 <slice material="Steel235" thickness="19*mm" vis="HCalAbsorberVis" radiator="yes"/>
-                <slice material="Polystyrene" thickness="3*mm" sensitive="yes" limits="cal_limits" vis="HCalSensorVis"/>
+                <slice material="G4_POLYSTYRENE" thickness="3*mm" sensitive="yes" limits="cal_limits" vis="HCalSensorVis"/>
                 <slice material="Copper" thickness="0.1*mm" vis="HCalCopperVis"/>
                 <slice material="PCB" thickness="0.7*mm" vis="HCalPCBVis"/>
                 <slice material="Steel235" thickness="0.5*mm" vis="HCalAbsorberVis" radiator="yes"/>
@@ -77,7 +77,7 @@
             <layer repeat="HCalEndcap_layers - HCalEndcap_cutout_layers" vis="HCalEndcapLayerVis">
                 <slice material="Steel235" thickness="0.5*mm" vis="HCalAbsorberVis" radiator="yes"/>
                 <slice material="Steel235" thickness="19*mm" vis="HCalAbsorberVis" radiator="yes"/>
-                <slice material="Polystyrene" thickness="3*mm" sensitive="yes" limits="cal_limits" vis="HCalSensorVis"/>
+                <slice material="G4_POLYSTYRENE" thickness="3*mm" sensitive="yes" limits="cal_limits" vis="HCalSensorVis"/>
                 <slice material="Copper" thickness="0.1*mm" vis="HCalCopperVis"/>
                 <slice material="PCB" thickness="0.7*mm" vis="HCalPCBVis"/>
                 <slice material="Steel235" thickness="0.5*mm" vis="HCalAbsorberVis" radiator="yes"/>
@@ -110,7 +110,7 @@
             <layer repeat="HCalRing_layers" vis="HCalEndcapLayerVis">
                 <slice material="Steel235" thickness="0.5*mm" vis="HCalAbsorberVis" radiator="yes"/>
                 <slice material="Steel235" thickness="19*mm" vis="HCalAbsorberVis" radiator="yes"/>
-                <slice material="Polystyrene" thickness="3*mm" sensitive="yes" limits="cal_limits" vis="HCalSensorVis"/>
+                <slice material="G4_POLYSTYRENE" thickness="3*mm" sensitive="yes" limits="cal_limits" vis="HCalSensorVis"/>
                 <slice material="Copper" thickness="0.1*mm" vis="HCalCopperVis"/>
                 <slice material="PCB" thickness="0.7*mm" vis="HCalPCBVis"/>
                 <slice material="Steel235" thickness="0.5*mm" vis="HCalAbsorberVis" radiator="yes"/>

--- a/CLIC/compact/CLIC_o3_v09/InnerTrackerBarrelModuleDown.xml
+++ b/CLIC/compact/CLIC_o3_v09/InnerTrackerBarrelModuleDown.xml
@@ -1,0 +1,25 @@
+<lccdd>
+    <!-- Build slices top-down from innermost slice (closest to IP) to outer-most (away from IP)-->
+    <module_component thickness="0.100*mm"  material="Kapton"           info="Power bus: Insulating layer"  sensitive="false"/>
+    <module_component thickness="0.200*mm"  material="Aluminium"        info="Power bus: Conductor"         sensitive="false"/>
+    <module_component thickness="0.100*mm"  material="Kapton"           info="Power bus: Insulating layer"  sensitive="false"/>
+
+    <module_component thickness="0.100*mm"  material="Epoxy"            info="Glue: Eccobond"               sensitive="false"/>
+
+    <module_component thickness="0.050*mm"  material="Kapton"           info="Module: FPC insulating layer" sensitive="false"/>
+    <module_component thickness="0.050*mm"  material="Aluminium"        info="Module: FPC metal layer"      sensitive="false"/>
+    <module_component thickness="0.050*mm"  material="Kapton"           info="Module: FPC insulating layer" sensitive="false"/>
+    <module_component thickness="0.100*mm"  material="Silicon"          info="Module: r/o ASIC"             sensitive="false"/>
+    <module_component thickness="0.100*mm"  material="Silicon"          info="Module: Sensor"               sensitive="true" />
+    <module_component thickness="0.100*mm"  material="Epoxy"            info="Module: Glue"                 sensitive="false"/>
+    <module_component thickness="0.120*mm"  material="CarbonFiber"      info="Module: Plate"                sensitive="false"/>
+
+    <module_component thickness="0.100*mm"  material="Epoxy"            info="Glue: Eccobond"               sensitive="false"/>
+
+    <module_component thickness="0.020*mm"  material="CarbonFiber_25D"  info="Cold Plate: Carbon fleece"    sensitive="false"/>
+    <module_component thickness="0.120*mm"  material="CarbonFiber"      info="Cold Plate: Carbon plate"     sensitive="false"/>
+    <module_component thickness="0.235*mm"  material="Water"            info="Cold Plate: Cooling fluid"    sensitive="false"/>
+    <module_component thickness="0.068*mm"  material="Kapton"           info="Cold Plate: Cooling pipe"     sensitive="false"/>
+    <module_component thickness="0.030*mm"  material="CarbonFiber"      info="Cold Plate: Graphite foil"    sensitive="false"/>
+    <module_component thickness="0.020*mm"  material="CarbonFiber_25D"  info="Cold Plate: Carbon fleece"    sensitive="false"/>
+</lccdd>

--- a/CLIC/compact/CLIC_o3_v09/InnerTrackerBarrelModuleUp.xml
+++ b/CLIC/compact/CLIC_o3_v09/InnerTrackerBarrelModuleUp.xml
@@ -1,0 +1,25 @@
+<lccdd>
+    <!-- Build slices top-down from innermost slice (closest to IP) to outer-most (away from IP)-->
+    <module_component thickness="0.020*mm"  material="CarbonFiber_25D"  info="Cold Plate: Carbon fleece"    sensitive="false"/>
+    <module_component thickness="0.030*mm"  material="CarbonFiber"      info="Cold Plate: Graphite foil"    sensitive="false"/>
+    <module_component thickness="0.068*mm"  material="Kapton"           info="Cold Plate: Cooling pipe"     sensitive="false"/>
+    <module_component thickness="0.235*mm"  material="Water"            info="Cold Plate: Cooling fluid"    sensitive="false"/>
+    <module_component thickness="0.120*mm"  material="CarbonFiber"      info="Cold Plate: Carbon plate"     sensitive="false"/>
+    <module_component thickness="0.020*mm"  material="CarbonFiber_25D"  info="Cold Plate: Carbon fleece"    sensitive="false"/>
+
+    <module_component thickness="0.100*mm"  material="Epoxy"            info="Glue: Eccobond"               sensitive="false"/>
+
+    <module_component thickness="0.120*mm"  material="CarbonFiber"      info="Module: Plate"                sensitive="false"/>
+    <module_component thickness="0.100*mm"  material="Epoxy"            info="Module: Glue"                 sensitive="false"/>
+    <module_component thickness="0.100*mm"  material="Silicon"          info="Module: Sensor"               sensitive="true" />
+    <module_component thickness="0.100*mm"  material="Silicon"          info="Module: r/o ASIC"             sensitive="false"/>
+    <module_component thickness="0.050*mm"  material="Kapton"           info="Module: FPC insulating layer" sensitive="false"/>
+    <module_component thickness="0.050*mm"  material="Aluminium"        info="Module: FPC metal layer"      sensitive="false"/>
+    <module_component thickness="0.050*mm"  material="Kapton"           info="Module: FPC insulating layer" sensitive="false"/>
+
+    <module_component thickness="0.100*mm"  material="Epoxy"            info="Glue: Eccobond"               sensitive="false"/>
+
+    <module_component thickness="0.100*mm"  material="Kapton"           info="Power bus: Insulating layer"  sensitive="false"/>
+    <module_component thickness="0.200*mm"  material="Aluminium"        info="Power bus: Conductor"         sensitive="false"/>
+    <module_component thickness="0.100*mm"  material="Kapton"           info="Power bus: Insulating layer"  sensitive="false"/>
+</lccdd>

--- a/CLIC/compact/CLIC_o3_v09/InnerTracker_o2_v06_01.xml
+++ b/CLIC/compact/CLIC_o3_v09/InnerTracker_o2_v06_01.xml
@@ -1,0 +1,428 @@
+<lccdd>
+    <define>
+
+        <constant name="InnerTracker_Barrel_radius_0" value="127*mm"/>
+        <constant name="InnerTracker_Barrel_radius_1" value="340*mm"/>
+        <constant name="InnerTracker_Barrel_radius_2" value="554*mm"/>
+
+        <constant name="InnerTracker_Barrel_half_length_0" value="482*mm"/>
+        <constant name="InnerTracker_Barrel_half_length_1" value="482*mm"/>
+        <constant name="InnerTracker_Barrel_half_length_2" value="692*mm"/>
+
+        <constant name="InnerTracker_Endcap_z_0" value="524*mm"/>
+        <constant name="InnerTracker_Endcap_z_1" value="808*mm"/>
+        <constant name="InnerTracker_Endcap_z_2" value="1093*mm"/>
+        <constant name="InnerTracker_Endcap_z_3" value="1377*mm"/>
+        <constant name="InnerTracker_Endcap_z_4" value="1661*mm"/>
+        <constant name="InnerTracker_Endcap_z_5" value="1946*mm"/>
+        <constant name="InnerTracker_Endcap_z_6" value="2190*mm"/>
+
+
+        <constant name="InnerTracker_Endcap_radius_0" value="72*mm"/>
+        <constant name="InnerTracker_Endcap_radius_1" value="99*mm"/>
+        <constant name="InnerTracker_Endcap_radius_2" value="132*mm"/>
+        <constant name="InnerTracker_Endcap_radius_3" value="164*mm"/>
+        <constant name="InnerTracker_Endcap_radius_4" value="197*mm"/>
+        <constant name="InnerTracker_Endcap_radius_5" value="231*mm"/>
+        <constant name="InnerTracker_Endcap_radius_6" value="250*mm"/>
+
+
+        <constant name="VertexCoolingGap"            value="5*mm"/>
+        <constant name="VertexCoolingShellThickness" value="1*mm"/>
+
+        <constant name="ITM" value="15.1*mm"/>
+
+    </define>
+
+
+    <comment>Tracking detectors</comment>
+    <detectors>
+        <detector name="InnerTrackers" type="DD4hep_SubdetectorAssembly" vis="ITVis">
+            <shape type="BooleanShape" operation="Subtraction" material="Air">
+                <shape type="BooleanShape" operation="Subtraction">
+                    <shape type="BooleanShape" operation="Subtraction">
+                        <shape type="BooleanShape" operation="Subtraction">
+                            <shape type="BooleanShape" operation="Subtraction"  >
+                                <shape type="Tube" rmin="CentralBeamPipe_rmax" rmax="InnerTracker_outer_radius" dz="InnerTracker_half_length+env_safety"/>
+                                <shape type="Cone" rmin1="0" rmax1="CentralBeamPipe_rmax" rmin2="0" rmax2="ConeBeamPipe_rmax" z="(ConeBeamPipe_zmax-CentralBeamPipe_zmax)/2.0"/>
+                                <position x="0" y="0" z="(ConeBeamPipe_zmax-CentralBeamPipe_zmax)/2.0 + CentralBeamPipe_zmax" />
+                            </shape>
+                            <shape type="Cone" rmin2="0" rmax2="CentralBeamPipe_rmax" rmin1="0" rmax1="ConeBeamPipe_rmax" z="(ConeBeamPipe_zmax-CentralBeamPipe_zmax)/2.0"/>
+                            <position x="0" y="0" z="-(ConeBeamPipe_zmax-CentralBeamPipe_zmax)/2.0 - CentralBeamPipe_zmax" />
+                        </shape>
+                        <shape type="Tube" rmin="0" rmax="ConeBeamPipe_rmax" dz="(InnerTracker_half_length-ConeBeamPipe_zmax)/2.0+10*env_safety"/>
+                        <position x="0" y="0" z="(InnerTracker_half_length-ConeBeamPipe_zmax)/2.0+ConeBeamPipe_zmax+10*env_safety" />
+                    </shape>
+                    <shape type="Tube" rmin="0" rmax="ConeBeamPipe_rmax" dz="(InnerTracker_half_length-ConeBeamPipe_zmax)/2.0+10*env_safety"/>
+                    <position x="0" y="0" z="-(InnerTracker_half_length-ConeBeamPipe_zmax)/2.0-ConeBeamPipe_zmax-10*env_safety" />
+                </shape>
+                <shape type="Tube" rmin="0" rmax="Vertex_outer_radius" dz="Vertex_half_length"/>
+            </shape>
+
+
+            <comment>Inner Tracker Assembly</comment>
+            <composite name="InnerTrackerBarrel"/>
+            <composite name="InnerTrackerEndcap"/>
+            <composite name="InnerTrackerBarrelSupport"/>
+            <composite name="InnerTrackerEndcapSupport"/>
+            <composite name="InnerTrackerInterlink"/>
+            <composite name="InnerTrackerVertexCable"/>
+            <composite name="BeampipeShell"/>
+            <composite name="BeampipeShell2"/>
+            <composite name="BeampipeShell3"/>
+        </detector>
+    </detectors>
+
+
+    <display>
+        <vis name="InnerTrackerModuleVis"  alpha="0.5" r="0.0" g="1.0" b="0.6" showDaughters="false" visible="true"/>
+        <vis name="InnerTrackerForwardVis" alpha="1.0" r="0.8" g="0.1" b="0.1" showDaughters="false" visible="true"/>
+        <vis name="RedVis" alpha="1.0" r="1" g="0" b="0" showDaughters="true" visible="true"/>
+        <vis name="BlueVis" alpha="1.0" r="0" g="0" b="1" showDaughters="true" visible="true"/>
+        <vis name="InterlinkVis" alpha="1.0" r="0.078" g="0.12" b="0.59" showDaughters="true" visible="true"/>
+    </display>
+
+    <!--  Definition of the readout segmentation/definition  -->
+    <readouts>
+        <readout name="InnerTrackerBarrelCollection">
+            <id>${GlobalTrackerReadoutID}</id>
+        </readout>
+        <readout name="InnerTrackerEndcapCollection">
+            <id>${GlobalTrackerReadoutID}</id>
+        </readout>
+    </readouts>
+
+    <detectors>
+
+        <detector id="DetID_IT_Barrel" name="InnerTrackerBarrel" type="TrackerBarrel_o1_v05" readout="InnerTrackerBarrelCollection" region="InnerTrackerBarrelRegion">
+            <envelope vis="ITVis">
+                <shape type="Assembly"/>
+            </envelope>
+            <comment>Silicon Inner Tracker Barrel</comment>
+
+            <type_flags type=" DetType_TRACKER + DetType_BARREL"/>
+
+            <module name="InnerTrackerBarrelModule_01" vis="InnerTrackerModuleVis">
+                <module_envelope width="30.1*mm" length="30.1*mm"/>
+                <include ref="InnerTrackerBarrelModuleDown.xml"/>
+            </module>
+
+            <layer module="InnerTrackerBarrelModule_01" id="0" type="1" >
+                <rphi_layout phi_tilt="0*deg" nphi="14*2" phi0="0" rc="InnerTracker_Barrel_radius_0" dr="2.5*mm"/>
+                <z_layout dr="0" z0="InnerTracker_Barrel_half_length_0-15.05*mm" nz="32"/>
+            </layer>
+            <layer module="InnerTrackerBarrelModule_01" id="1" >
+                <rphi_layout phi_tilt="0*deg" nphi="38*2" phi0="0" rc="InnerTracker_Barrel_radius_1" dr="2.5*mm"/>
+                <z_layout dr="0" z0="InnerTracker_Barrel_half_length_1-15.05*mm" nz="32"/>
+            </layer>
+            <layer module="InnerTrackerBarrelModule_01" id="2" >
+                <rphi_layout phi_tilt="0*deg" nphi="62*2" phi0="0" rc="InnerTracker_Barrel_radius_2" dr="2.5*mm"/>
+                <z_layout dr="0" z0="InnerTracker_Barrel_half_length_2-15.05*mm" nz="46"/>
+            </layer>
+        </detector>
+
+
+        <detector id="DetID_IT_Endcap" name="InnerTrackerEndcap" type="TrackerEndcap_o2_v06" readout="InnerTrackerEndcapCollection" reflect="true" region="InnerTrackerEndcapRegion">
+            <envelope vis="ITVis">
+                <shape type="Assembly"/>
+            </envelope>
+            <comment>Silicon Inner Tracker Endcaps</comment>
+
+            <type_flags type=" DetType_TRACKER + DetType_ENDCAP"/>
+
+            <module name="InnerTrackerEndcapModule_2x2_Out" vis="InnerTrackerModuleVis">
+                <trd x="30.2*mm" y="30.2*mm"/>
+                <include ref="TrackerDiskModuleOut.xml"/>
+            </module>
+            <module name="InnerTrackerEndcapModule_3x2_Out" vis="InnerTrackerModuleVis">
+                <trd x="45.3*mm" y="30.2*mm"/>
+                <include ref="TrackerDiskModuleOut.xml"/>
+            </module>
+            <module name="InnerTrackerEndcapModule_3x4_Out" vis="InnerTrackerModuleVis">
+                <trd x="45.3*mm" y="60.4*mm"/>
+                <include ref="TrackerDiskModuleOut.xml"/>
+            </module>
+            <module name="InnerTrackerEndcapModule_5x2_Out" vis="InnerTrackerModuleVis">
+                <trd x="75.5*mm" y="30.2*mm"/>
+                <include ref="TrackerDiskModuleOut.xml"/>
+            </module>
+            <module name="InnerTrackerEndcapModule_5x4_Out" vis="InnerTrackerModuleVis">
+                <trd x="75.5*mm" y="60.4*mm"/>
+                <include ref="TrackerDiskModuleOut.xml"/>
+            </module>
+            <module name="InnerTrackerEndcapModule_5x6_Out" vis="InnerTrackerModuleVis">
+                <trd x="75.5*mm" y="90.6*mm"/>
+                <include ref="TrackerDiskModuleOut.xml"/>
+            </module>
+            <module name="InnerTrackerEndcapModule_5x7_Out" vis="InnerTrackerModuleVis">
+                <trd x="75.5*mm" y="105.7*mm"/>
+                <include ref="TrackerDiskModuleOut.xml"/>
+            </module>
+            <module name="InnerTrackerEndcapModule_5x8_Out" vis="InnerTrackerModuleVis">
+                <trd x="75.5*mm" y="120.8*mm"/>
+                <include ref="TrackerDiskModuleOut.xml"/>
+            </module>
+            <module name="InnerTrackerEndcapModule_7x8_Out" vis="InnerTrackerModuleVis">
+                <trd x="105.7*mm" y="120.8*mm"/>
+                <include ref="TrackerDiskModuleOut.xml"/>
+            </module>
+            <module name="InnerTrackerEndcapModule_8x5_Out" vis="InnerTrackerModuleVis">
+                <trd x="120.8*mm" y="75.5*mm"/>
+                <include ref="TrackerDiskModuleOut.xml"/>
+            </module>
+            <module name="InnerTrackerEndcapModule_8x7_Out" vis="InnerTrackerModuleVis">
+                <trd x="120.8*mm" y="105.7*mm"/>
+                <include ref="TrackerDiskModuleOut.xml"/>
+            </module>
+            <module name="InnerTrackerEndcapModule_9x8_Out" vis="InnerTrackerModuleVis">
+                <trd x="135.9*mm" y="120.8*mm"/>
+                <include ref="TrackerDiskModuleOut.xml"/>
+            </module>
+            <module name="InnerTrackerEndcapModule_9x9_Out" vis="InnerTrackerModuleVis">
+                <trd x="135.9*mm" y="135.9*mm"/>
+                <include ref="TrackerDiskModuleOut.xml"/>
+            </module>
+            <module name="InnerTrackerEndcapModule_11x2_Out" vis="InnerTrackerModuleVis">
+                <trd x="166.1*mm" y="30.2*mm"/>
+                <include ref="TrackerDiskModuleOut.xml"/>
+            </module>
+            <module name="InnerTrackerEndcapModule_11x3_Out" vis="InnerTrackerModuleVis">
+                <trd x="166.1*mm" y="45.3*mm"/>
+                <include ref="TrackerDiskModuleOut.xml"/>
+            </module>
+
+
+            <module name="InnerTrackerEndcapModule_2x2_In" vis="InnerTrackerModuleVis">
+                <trd x="30.2*mm" y="30.2*mm"/>
+                <include ref="TrackerDiskModuleIn.xml"/>
+            </module>
+            <module name="InnerTrackerEndcapModule_3x2_In" vis="InnerTrackerModuleVis">
+                <trd x="45.3*mm" y="30.2*mm"/>
+                <include ref="TrackerDiskModuleIn.xml"/>
+            </module>
+            <module name="InnerTrackerEndcapModule_3x4_In" vis="InnerTrackerModuleVis">
+                <trd x="45.3*mm" y="60.4*mm"/>
+                <include ref="TrackerDiskModuleIn.xml"/>
+            </module>
+            <module name="InnerTrackerEndcapModule_5x2_In" vis="InnerTrackerModuleVis">
+                <trd x="75.5*mm" y="30.2*mm"/>
+                <include ref="TrackerDiskModuleIn.xml"/>
+            </module>
+            <module name="InnerTrackerEndcapModule_5x4_In" vis="InnerTrackerModuleVis">
+                <trd x="75.5*mm" y="60.4*mm"/>
+                <include ref="TrackerDiskModuleIn.xml"/>
+            </module>
+            <module name="InnerTrackerEndcapModule_5x6_In" vis="InnerTrackerModuleVis">
+                <trd x="75.5*mm" y="90.6*mm"/>
+                <include ref="TrackerDiskModuleIn.xml"/>
+            </module>
+            <module name="InnerTrackerEndcapModule_5x7_In" vis="InnerTrackerModuleVis">
+                <trd x="75.5*mm" y="105.7*mm"/>
+                <include ref="TrackerDiskModuleIn.xml"/>
+            </module>
+            <module name="InnerTrackerEndcapModule_5x8_In" vis="InnerTrackerModuleVis">
+                <trd x="75.5*mm" y="120.8*mm"/>
+                <include ref="TrackerDiskModuleIn.xml"/>
+            </module>
+            <module name="InnerTrackerEndcapModule_7x8_In" vis="InnerTrackerModuleVis">
+                <trd x="105.7*mm" y="120.8*mm"/>
+                <include ref="TrackerDiskModuleIn.xml"/>
+            </module>
+            <module name="InnerTrackerEndcapModule_8x5_In" vis="InnerTrackerModuleVis">
+                <trd x="120.8*mm" y="75.5*mm"/>
+                <include ref="TrackerDiskModuleIn.xml"/>
+            </module>
+            <module name="InnerTrackerEndcapModule_8x7_In" vis="InnerTrackerModuleVis">
+                <trd x="120.8*mm" y="105.7*mm"/>
+                <include ref="TrackerDiskModuleIn.xml"/>
+            </module>
+            <module name="InnerTrackerEndcapModule_9x8_In" vis="InnerTrackerModuleVis">
+                <trd x="135.9*mm" y="120.8*mm"/>
+                <include ref="TrackerDiskModuleIn.xml"/>
+            </module>
+            <module name="InnerTrackerEndcapModule_9x9_In" vis="InnerTrackerModuleVis">
+                <trd x="135.9*mm" y="135.9*mm"/>
+                <include ref="TrackerDiskModuleIn.xml"/>
+            </module>
+            <module name="InnerTrackerEndcapModule_11x2_In" vis="InnerTrackerModuleVis">
+                <trd x="166.1*mm" y="30.2*mm"/>
+                <include ref="TrackerDiskModuleIn.xml"/>
+            </module>
+            <module name="InnerTrackerEndcapModule_11x3_In" vis="InnerTrackerModuleVis">
+                <trd x="166.1*mm" y="45.3*mm"/>
+                <include ref="TrackerDiskModuleIn.xml"/>
+            </module>
+
+
+            <layer id="0">
+                <ring r="InnerTracker_Endcap_radius_0"        zstart="InnerTracker_Endcap_z_0" nmodules="24" dz="3*mm" module="InnerTrackerEndcapModule_2x2_Out" phi0="0"/>
+                <ring r="InnerTracker_Endcap_radius_0+2*ITM"  zstart="InnerTracker_Endcap_z_0" nmodules="24" dz="3*mm" module="InnerTrackerEndcapModule_3x4_Out" phi0="0"/>
+                <ring r="InnerTracker_Endcap_radius_0+6*ITM"  zstart="InnerTracker_Endcap_z_0" nmodules="24" dz="3*mm" module="InnerTrackerEndcapModule_5x8_Out" phi0="0"/>
+                <ring r="InnerTracker_Endcap_radius_0+14*ITM" zstart="InnerTracker_Endcap_z_0" nmodules="24" dz="3*mm" module="InnerTrackerEndcapModule_7x8_Out" phi0="0"/>
+            </layer>
+            <layer id="1">
+                <ring r="InnerTracker_Endcap_radius_1"        zstart="InnerTracker_Endcap_z_1" nmodules="24" dz="3*mm" module="InnerTrackerEndcapModule_3x4_In"  phi0="0"/>
+                <ring r="InnerTracker_Endcap_radius_1+4*ITM"  zstart="InnerTracker_Endcap_z_1" nmodules="24" dz="3*mm" module="InnerTrackerEndcapModule_5x7_In"  phi0="0"/>
+                <ring r="InnerTracker_Endcap_radius_1+11*ITM" zstart="InnerTracker_Endcap_z_1" nmodules="24" dz="3*mm" module="InnerTrackerEndcapModule_7x8_In"  phi0="0"/>
+                <ring r="InnerTracker_Endcap_radius_1+19*ITM" zstart="InnerTracker_Endcap_z_1" nmodules="24" dz="3*mm" module="InnerTrackerEndcapModule_9x8_In"  phi0="0"/>
+                <ring r="InnerTracker_Endcap_radius_1+27*ITM" zstart="InnerTracker_Endcap_z_1" nmodules="24" dz="3*mm" module="InnerTrackerEndcapModule_11x3_In" phi0="0"/>
+            </layer>
+
+            <layer id="2">
+                <ring r="InnerTracker_Endcap_radius_2"        zstart="InnerTracker_Endcap_z_2" nmodules="24" dz="3*mm" module="InnerTrackerEndcapModule_3x2_Out"  phi0="0"/>
+                <ring r="InnerTracker_Endcap_radius_2+2*ITM"  zstart="InnerTracker_Endcap_z_2" nmodules="24" dz="3*mm" module="InnerTrackerEndcapModule_5x7_Out"  phi0="0"/>
+                <ring r="InnerTracker_Endcap_radius_2+9*ITM"  zstart="InnerTracker_Endcap_z_2" nmodules="24" dz="3*mm" module="InnerTrackerEndcapModule_7x8_Out"  phi0="0"/>
+                <ring r="InnerTracker_Endcap_radius_2+17*ITM" zstart="InnerTracker_Endcap_z_2" nmodules="24" dz="3*mm" module="InnerTrackerEndcapModule_9x8_Out"  phi0="0"/>
+                <ring r="InnerTracker_Endcap_radius_2+25*ITM" zstart="InnerTracker_Endcap_z_2" nmodules="24" dz="3*mm" module="InnerTrackerEndcapModule_11x3_Out" phi0="0"/>
+            </layer>
+
+            <layer id="3">
+                <ring r="InnerTracker_Endcap_radius_3"        zstart="InnerTracker_Endcap_z_3" nmodules="24" dz="3*mm" module="InnerTrackerEndcapModule_5x6_In"  phi0="0"/>
+                <ring r="InnerTracker_Endcap_radius_3+6*ITM"  zstart="InnerTracker_Endcap_z_3" nmodules="24" dz="3*mm" module="InnerTrackerEndcapModule_7x8_In"  phi0="0"/>
+                <ring r="InnerTracker_Endcap_radius_3+14*ITM" zstart="InnerTracker_Endcap_z_3" nmodules="24" dz="3*mm" module="InnerTrackerEndcapModule_9x9_In"  phi0="0"/>
+                <ring r="InnerTracker_Endcap_radius_3+23*ITM" zstart="InnerTracker_Endcap_z_3" nmodules="24" dz="3*mm" module="InnerTrackerEndcapModule_11x2_In" phi0="0"/>
+            </layer>
+
+            <layer id="4">
+                <ring r="InnerTracker_Endcap_radius_4"        zstart="InnerTracker_Endcap_z_4" nmodules="24" dz="3*mm" module="InnerTrackerEndcapModule_5x4_Out"  phi0="0"/>
+                <ring r="InnerTracker_Endcap_radius_4+4*ITM"  zstart="InnerTracker_Endcap_z_4" nmodules="24" dz="3*mm" module="InnerTrackerEndcapModule_7x8_Out"  phi0="0"/>
+                <ring r="InnerTracker_Endcap_radius_4+12*ITM" zstart="InnerTracker_Endcap_z_4" nmodules="24" dz="3*mm" module="InnerTrackerEndcapModule_9x9_Out"  phi0="0"/>
+                <ring r="InnerTracker_Endcap_radius_4+21*ITM" zstart="InnerTracker_Endcap_z_4" nmodules="24" dz="3*mm" module="InnerTrackerEndcapModule_11x2_Out" phi0="0"/>
+            </layer>
+
+            <layer id="5">
+                <ring r="InnerTracker_Endcap_radius_5"        zstart="InnerTracker_Endcap_z_5" nmodules="24" dz="3*mm" module="InnerTrackerEndcapModule_5x2_In"  phi0="0"/>
+                <ring r="InnerTracker_Endcap_radius_5+2*ITM"  zstart="InnerTracker_Endcap_z_5" nmodules="24" dz="3*mm" module="InnerTrackerEndcapModule_7x8_In"  phi0="0"/>
+                <ring r="InnerTracker_Endcap_radius_5+10*ITM" zstart="InnerTracker_Endcap_z_5" nmodules="24" dz="3*mm" module="InnerTrackerEndcapModule_9x9_In"  phi0="0"/>
+                <ring r="InnerTracker_Endcap_radius_5+19*ITM" zstart="InnerTracker_Endcap_z_5" nmodules="24" dz="3*mm" module="InnerTrackerEndcapModule_11x2_In" phi0="0"/>
+            </layer>
+
+            <layer id="6">
+                <ring r="InnerTracker_Endcap_radius_6"        zstart="InnerTracker_Endcap_z_6" nmodules="24" dz="3*mm" module="InnerTrackerEndcapModule_7x8_Out"  phi0="0"/>
+                <ring r="InnerTracker_Endcap_radius_6+8*ITM"  zstart="InnerTracker_Endcap_z_6" nmodules="24" dz="3*mm" module="InnerTrackerEndcapModule_9x9_Out"  phi0="0"/>
+                <ring r="InnerTracker_Endcap_radius_6+17*ITM" zstart="InnerTracker_Endcap_z_6" nmodules="24" dz="3*mm" module="InnerTrackerEndcapModule_11x2_Out" phi0="0"/>
+            </layer>
+        </detector>
+
+
+        <detector name="InnerTrackerBarrelSupport" type="TrackerBarrelSupport_o1_v01" id="0"  reflect="true" region="InnerTrackerBarrelRegion">
+            <envelope>
+                <shape type="Assembly"/>
+            </envelope>
+            <layer id="1" inner_r="InnerTracker_Barrel_radius_0+0.5*cm" outer_z="InnerTracker_Barrel_half_length_0" vis="SupportVis">
+                <slice material="CarbonFiber" thickness="0.17/3.5959*cm" />
+            </layer>
+            <layer id="2" inner_r="InnerTracker_Barrel_radius_1+0.5*cm" outer_z="InnerTracker_Barrel_half_length_1" vis="SupportVis">
+                <slice material="CarbonFiber" thickness="0.17/3.5959*cm" />
+            </layer>
+            <layer id="3" inner_r="InnerTracker_Barrel_radius_2+0.5*cm" outer_z="InnerTracker_Barrel_half_length_2" vis="SupportVis">
+                <slice material="CarbonFiber" thickness="0.17/3.5959*cm" />
+            </layer>
+            <layer id="4" inner_r="InnerTracker_outer_radius-1*cm" outer_z="InnerTracker_half_length" vis="SupportVis">
+                <slice material="CarbonFiber" thickness="1.25/3.5959*cm" />
+            </layer>
+            <comment>3.5959*cm = X0 for Carbon fibre</comment>
+        </detector>
+
+
+        <detector name="InnerTrackerEndcapSupport" type="TrackerEndcapSupport_o1_v01" reflect="true" region="InnerTrackerEndcapRegion">
+            <envelope>
+                <shape type="Assembly"/>
+            </envelope>
+            <layer id="0" inner_r="InnerTracker_Endcap_radius_0" inner_z="InnerTracker_Endcap_z_0-1*cm" outer_r="405*mm" vis="SupportVis">
+                <slice material="CarbonFiber" thickness="0.330/3.5959*cm" />
+            </layer>
+            <layer id="1" inner_r="InnerTracker_Endcap_radius_1" inner_z="InnerTracker_Endcap_z_1+1*cm" outer_r="555*mm" vis="SupportVis">
+                <slice material="CarbonFiber" thickness="0.308/3.5959*cm" />
+            </layer>
+            <layer id="2" inner_r="InnerTracker_Endcap_radius_2" inner_z="InnerTracker_Endcap_z_2-1*cm" outer_r="555*mm" vis="SupportVis">
+                <slice material="CarbonFiber" thickness="0.308/3.5959*cm" />
+            </layer>
+            <layer id="3" inner_r="InnerTracker_Endcap_radius_3+10*env_safety" inner_z="InnerTracker_Endcap_z_3+1*cm" outer_r="555*mm" vis="SupportVis">
+                <slice material="CarbonFiber" thickness="0.343/3.5959*cm" />
+            </layer>
+            <layer id="4" inner_r="InnerTracker_Endcap_radius_4" inner_z="InnerTracker_Endcap_z_4-1*cm" outer_r="555*mm" vis="SupportVis">
+                <slice material="CarbonFiber" thickness="0.343/3.5959*cm" />
+            </layer>
+            <layer id="5" inner_r="InnerTracker_Endcap_radius_5+10*env_safety" inner_z="InnerTracker_Endcap_z_5+1*cm" outer_r="555*mm" vis="SupportVis">
+                <slice material="CarbonFiber" thickness="0.369/3.5959*cm" />
+            </layer>
+            <layer id="6" inner_r="InnerTracker_Endcap_radius_6" inner_z="InnerTracker_Endcap_z_6-1*cm" outer_r="555*mm" vis="SupportVis">
+                <slice material="CarbonFiber" thickness="0.369/3.5959*cm" />
+            </layer>
+            <layer id="7" inner_r="InnerTracker_Barrel_radius_0" inner_z="InnerTracker_Barrel_half_length_1+2*cm" outer_r="InnerTracker_Barrel_radius_2-2*cm" vis="InterlinkVis">
+                <slice material="CarbonFiber" thickness="0.6/3.5959*cm" />
+            </layer>
+            <layer id="8" inner_r="InnerTracker_Barrel_radius_2-2*cm+0.6/3.5959*cm" inner_z="InnerTracker_Barrel_half_length_2+2*cm" outer_r="InnerTracker_outer_radius-1*cm" vis="InterlinkVis">
+                <slice material="CarbonFiber" thickness="0.6/3.5959*cm" />
+            </layer>
+        </detector>
+
+
+        <detector name="InnerTrackerInterlink" type="TubeSupport_o1_v01" reflect="true" region="InnerTrackerEndcapRegion">
+            <envelope>
+                <shape type="Assembly"/>
+            </envelope>
+            <section start="InnerTracker_Barrel_half_length_1+2*cm"  end="InnerTracker_Barrel_half_length_2+2*cm"        rMin="InnerTracker_Barrel_radius_2-2*cm"  rMax="InnerTracker_Barrel_radius_2-2*cm+0.6/3.5959*cm"  material="CarbonFiber" name="InterlinkTube" vis="InterlinkVis"/>
+        </detector>
+
+        <detector name="InnerTrackerVertexCable" type="TubeSupport_o1_v01" reflect="true" region="BeampipeRegion">
+            <envelope>
+                <shape type="Assembly"/>
+            </envelope>
+            <section start="13.1*cm" end="495*mm" rMin="Vertex_outer_radius+0.5*mm" rMax="Vertex_outer_radius+0.5*mm+0.067*mm" material="Copper" name="VertexCableTube" vis="SiVertexCableVis"/>
+        </detector>
+
+
+        <detector name="BeampipeShell" type="ConicalSupport_o1_v01" reflect="true" region="BeampipeRegion">
+            <envelope>
+                <shape type="Assembly"/>
+            </envelope>
+            <section start="500*mm"  end="ConeBeamPipe_zmax"        rMin1="52.7*mm+VertexCoolingGap"  rMin2="ConeBeamPipe_rmax+VertexCoolingGap" rMax1="52.7*mm+VertexCoolingGap+VertexCoolingShellThickness"           rMax2="ConeBeamPipe_rmax+VertexCoolingGap+VertexCoolingShellThickness" material="CarbonFiber" name="ConeSupport" vis="SupportVis"/>
+            <section start="ConeBeamPipe_zmax" end="InnerTracker_half_length" rMin1="ConeBeamPipe_rmax+VertexCoolingGap" rMin2="ConeBeamPipe_rmax+VertexCoolingGap" rMax1="ConeBeamPipe_rmax+VertexCoolingGap+VertexCoolingShellThickness" rMax2="ConeBeamPipe_rmax+VertexCoolingGap+VertexCoolingShellThickness" material="CarbonFiber" name="TubeSupport" vis="SupportVis"/>
+        </detector>
+
+
+        <detector name="BeampipeShell2" type="TrackerEndcapSupport_o1_v01" reflect="true" region="BeampipeRegion">
+            <envelope>
+                <shape type="Assembly"/>
+            </envelope>
+            <layer id="0" inner_r="52.7*mm+VertexCoolingGap" inner_z="500*mm-2*VertexCoolingShellThickness" outer_r="Vertex_outer_radius+0.1*mm" vis="SupportVis">
+                <slice material="CarbonFiber" thickness="VertexCoolingShellThickness" />
+            </layer>
+            <comment> The next section is the cable for the vertex </comment>
+            <layer id="1" inner_r="52.7*mm+VertexCoolingGap" inner_z="495*mm" outer_r="Vertex_outer_radius" vis="SiVertexCableVis">
+                <slice material="Copper" thickness="0.067*mm" />
+            </layer>
+        </detector>
+
+
+        <detector name="BeampipeShell3" type="TrackerBarrelSupport_o1_v01" id="0"  reflect="true" region="BeampipeRegion">
+            <envelope>
+                <shape type="Assembly"/>
+            </envelope>
+            <layer id="4" inner_r="Vertex_outer_radius+0.1*cm" outer_z="500*mm" vis="SupportVis">
+                <slice material="CarbonFiber" thickness="VertexCoolingShellThickness" />
+            </layer>
+        </detector>
+
+    </detectors>
+
+    <plugins>
+        <plugin name="DD4hep_GenericSurfaceInstallerPlugin">
+            <argument value="InnerTrackerBarrel"/>
+            <argument value="dimension=2"/>
+            <argument value="u_x=1."/>
+            <argument value="v_y=1."/>
+            <argument value="n_z=1."/>
+        </plugin>
+        <plugin name="DD4hep_GenericSurfaceInstallerPlugin">
+            <argument value="InnerTrackerEndcap"/>
+            <argument value="dimension=2"/>
+            <argument value="u_x=1."/>
+            <argument value="v_y=1."/>
+            <argument value="n_z=1."/>
+        </plugin>
+    </plugins>
+
+</lccdd>

--- a/CLIC/compact/CLIC_o3_v09/LumiCal_o1_v01_01.xml
+++ b/CLIC/compact/CLIC_o3_v09/LumiCal_o1_v01_01.xml
@@ -1,0 +1,67 @@
+<lccdd>
+    
+    <define>
+            <constant name="LumiCal_cell_size" value="1*mm"/>
+    </define>
+    
+    <readouts>
+        <readout name="LumiCalCollection">
+	    <segmentation type="PolarGridRPhi"
+			  grid_size_r="(LumiCal_outer_radius-LumiCal_inner_radius)/64"
+			  grid_size_phi="360/48*degree"
+			  offset_r="LumiCal_inner_radius"
+			  offset_phi="360/48*degree*0.5"
+			  />
+	    <id>system:8,barrel:3,layer:8,slice:8,r:32:-16,phi:-16</id>
+        </readout>
+    </readouts>
+    
+    <detectors>
+        <detector name="LumiCal" type="LumiCal_o1_v01" vis="SeeThrough" id="DetID_LumiCal" readout="LumiCalCollection" >
+            
+            <!--             <type_flags type=" DetType_CALORIMETER + DetType_ELECTROMAGNETIC + DetType_ENDCAP + DetType_FORWARD"/> --> <!-- FLAGS ARE SET IN DRIVER FOR NOW -->
+
+            
+            <envelope vis="LCALVis">
+                <shape type="BooleanShape" operation="union" material="Air">
+                    <shape type="BooleanShape" operation="Intersection">
+                        <shape type="Box"  dx="world_side" dy="world_side" dz="world_side"/>
+                        <shape type="Tube"  rmin="LumiCal_inner_radius" rmax="LumiCal_outer_radius+env_safety" dz="LumiCal_dz+env_safety"/>
+                        <position x="tan(0.5*CrossingAngle)*(LumiCal_min_z+LumiCal_dz)" y="0" z="LumiCal_min_z+LumiCal_dz"/>
+                        <rotation x="0" y="0.5*CrossingAngle" z="0"/>
+                    </shape>
+                    <shape type="BooleanShape" operation="Intersection">
+                        <shape type="Box"  dx="world_side" dy="world_side" dz="world_side"/>
+                        <shape type="Tube"  rmin="LumiCal_inner_radius" rmax="LumiCal_outer_radius+env_safety" dz="LumiCal_dz+env_safety"/>
+                        <position x="tan(0.5*CrossingAngle)*(LumiCal_min_z+LumiCal_dz)" y="0" z="-(LumiCal_min_z+LumiCal_dz)"/>
+                        <rotation x="0" y="-0.5*CrossingAngle" z="0"/>
+                    </shape>
+                </shape>
+            </envelope>
+            
+            <parameter crossingangle="CrossingAngle" />
+            
+            <dimensions inner_r = "LumiCal_inner_radius"
+            inner_z = "LumiCal_min_z"
+            outer_r = "LumiCal_outer_radius"
+            modules = "12"
+            phi_sectors = "4"
+            r_sectors = "64"
+            phi_gap = "2*mm"
+            r_gap = "2*mm" />
+            
+            
+            <layer repeat="40" vis="SeeThrough">
+                <slice material = "TungstenDens24" thickness = "3.5*mm" 		   vis="BCLayerVis1" />
+                <slice material = "Air"     thickness = "0.1*mm" />
+                <slice material = "Silicon" thickness = "0.32*mm" 	sensitive = "yes"  vis="BCLayerVis2"/>
+                <slice material = "Copper"  thickness = "0.4*mm"                    vis="BCLayerVis3"/>
+            </layer>
+            
+            
+        </detector>
+    </detectors>
+    
+</lccdd>
+
+

--- a/CLIC/compact/CLIC_o3_v09/OuterTrackerBarrelModuleDown.xml
+++ b/CLIC/compact/CLIC_o3_v09/OuterTrackerBarrelModuleDown.xml
@@ -1,0 +1,27 @@
+<lccdd>
+    <!-- Build slices top-down from innermost slice (closest to IP) to outer-most (away from IP)-->
+    <module_component thickness="0.150*mm"  material="CarbonFiber"      info="Structure and cooling: CF Skins"      sensitive="false"/>
+    <module_component thickness="0.025*mm"  material="CarbonFiber"      info="Structure and cooling: Interface"     sensitive="false"/>
+    <module_component thickness="0.100*mm"  material="Epoxy"            info="Structure and cooling: Glue layer"    sensitive="false"/>
+    <module_component thickness="2.800*mm"  material="Rohacell_IG51"    info="Structure and cooling: Core"          sensitive="false"/>
+    <module_component thickness="0.700*mm"  material="Allcomp_K9"       info="Structure and cooling: Carbon Foam"   sensitive="false"/>
+    <module_component thickness="0.068*mm"  material="Kapton"           info="Structure and cooling: Cooling Pipe"  sensitive="false"/>
+    <module_component thickness="0.235*mm"  material="Water"            info="Structure and cooling: Cooling fluid" sensitive="false"/>
+    <module_component thickness="0.100*mm"  material="Epoxy"            info="Structure and cooling: Glue layer"    sensitive="false"/>
+    <module_component thickness="0.025*mm"  material="CarbonFiber"      info="Structure and cooling: Interface"     sensitive="false"/>
+    <module_component thickness="0.150*mm"  material="CarbonFiber"      info="Structure and cooling: CF Skins"      sensitive="false"/>
+
+    <module_component thickness="0.100*mm"  material="Epoxy"            info="Glue: Eccobond"                       sensitive="false"/>
+
+    <module_component thickness="0.100*mm"  material="Silicon"          info="Module: Sensor"                       sensitive="true"/>
+    <module_component thickness="0.100*mm"  material="Silicon"          info="Module: r/o ASIC"                     sensitive="false" />
+    <module_component thickness="0.050*mm"  material="Kapton"           info="Module: FPC insulating layer"         sensitive="false"/>
+    <module_component thickness="0.050*mm"  material="Aluminium"        info="Module: FPC metal layer"              sensitive="false"/>
+    <module_component thickness="0.050*mm"  material="Kapton"           info="Module: FPC insulating layer"         sensitive="false"/>
+
+    <module_component thickness="0.100*mm"  material="Epoxy"            info="Glue: Eccobond"                       sensitive="false"/>
+
+    <module_component thickness="0.100*mm"  material="Kapton"           info="Power bus: Insulating layer"          sensitive="false"/>
+    <module_component thickness="0.200*mm"  material="Aluminium"        info="Power bus: Conductor"                 sensitive="false"/>
+    <module_component thickness="0.100*mm"  material="Kapton"           info="Power bus: Insulating layer"          sensitive="false"/>
+</lccdd>

--- a/CLIC/compact/CLIC_o3_v09/OuterTrackerBarrelModuleUp.xml
+++ b/CLIC/compact/CLIC_o3_v09/OuterTrackerBarrelModuleUp.xml
@@ -1,0 +1,27 @@
+<lccdd>
+    <!-- Build slices top-down from innermost slice (closest to IP) to outer-most (away from IP)-->
+    <module_component thickness="0.100*mm"  material="Kapton"           info="Power bus: Insulating layer"          sensitive="false"/>
+    <module_component thickness="0.200*mm"  material="Aluminium"        info="Power bus: Conductor"                 sensitive="false"/>
+    <module_component thickness="0.100*mm"  material="Kapton"           info="Power bus: Insulating layer"          sensitive="false"/>
+
+    <module_component thickness="0.100*mm"  material="Epoxy"            info="Glue: Eccobond"                       sensitive="false"/>
+
+    <module_component thickness="0.050*mm"  material="Kapton"           info="Module: FPC insulating layer"         sensitive="false"/>
+    <module_component thickness="0.050*mm"  material="Aluminium"        info="Module: FPC metal layer"              sensitive="false"/>
+    <module_component thickness="0.050*mm"  material="Kapton"           info="Module: FPC insulating layer"         sensitive="false"/>
+    <module_component thickness="0.100*mm"  material="Silicon"          info="Module: r/o ASIC"                     sensitive="false" />
+    <module_component thickness="0.100*mm"  material="Silicon"          info="Module: Sensor"                       sensitive="true"/>
+
+    <module_component thickness="0.100*mm"  material="Epoxy"            info="Glue: Eccobond"                       sensitive="false"/>
+
+    <module_component thickness="0.150*mm"  material="CarbonFiber"      info="Structure and cooling: CF Skins"      sensitive="false"/>
+    <module_component thickness="0.025*mm"  material="CarbonFiber"      info="Structure and cooling: Interface"     sensitive="false"/>
+    <module_component thickness="0.100*mm"  material="Epoxy"            info="Structure and cooling: Glue layer"    sensitive="false"/>
+    <module_component thickness="0.235*mm"  material="Water"            info="Structure and cooling: Cooling fluid" sensitive="false"/>
+    <module_component thickness="0.068*mm"  material="Kapton"           info="Structure and cooling: Cooling Pipe"  sensitive="false"/>
+    <module_component thickness="0.700*mm"  material="Allcomp_K9"       info="Structure and cooling: Carbon Foam"   sensitive="false"/>
+    <module_component thickness="2.800*mm"  material="Rohacell_IG51"    info="Structure and cooling: Core"          sensitive="false"/>
+    <module_component thickness="0.100*mm"  material="Epoxy"            info="Structure and cooling: Glue layer"    sensitive="false"/>
+    <module_component thickness="0.025*mm"  material="CarbonFiber"      info="Structure and cooling: Interface"     sensitive="false"/>
+    <module_component thickness="0.150*mm"  material="CarbonFiber"      info="Structure and cooling: CF Skins"      sensitive="false"/>
+</lccdd>

--- a/CLIC/compact/CLIC_o3_v09/OuterTracker_o2_v06_01.xml
+++ b/CLIC/compact/CLIC_o3_v09/OuterTracker_o2_v06_01.xml
@@ -1,0 +1,207 @@
+<lccdd>
+    
+    <define>
+        <constant name="OuterTracker_Barrel_radius_0" value="819*mm"/>
+        <constant name="OuterTracker_Barrel_radius_1" value="1153*mm"/>
+        <constant name="OuterTracker_Barrel_radius_2" value="1486*mm"/>
+        
+        <constant name="OuterTracker_Barrel_half_length" value="1264*mm"/>
+        
+        <constant name="OuterTracker_Endcap_outer_radius" value="1430.2*mm"/>
+        <constant name="OuterTracker_Endcap_inner_radius" value="617.5*mm"/>
+        
+        <constant name="OuterTracker_Endcap_z_0" value="1310*mm"/>
+        <constant name="OuterTracker_Endcap_z_1" value="1617*mm"/>
+        <constant name="OuterTracker_Endcap_z_2" value="1883*mm"/>
+        <constant name="OuterTracker_Endcap_z_3" value="2190*mm"/>
+
+        <constant name="OuterTracker_Endcap_radius_0" value="617.5*mm"/>
+        <constant name="OuterTracker_Endcap_radius_1" value="888.4*mm"/>        
+        <constant name="OuterTracker_Endcap_radius_2" value="1189.4*mm"/>
+        
+    </define>
+    
+    <comment>Tracking detectors</comment>
+    <detectors>
+        <detector name="OuterTrackers" type="DD4hep_SubdetectorAssembly" vis="OTVis">
+            <shape name="OuterTrackersEnvelope" type="Tube" rmin="OuterTracker_inner_radius" rmax="OuterTracker_outer_radius" dz="OuterTracker_half_length" material="Air">
+            </shape>
+            <comment>Outer Tracker Assembly</comment>
+            <composite name="OuterTrackerBarrel"/>
+            <composite name="OuterTrackerEndcap"/>
+            <composite name="OuterTrackerBarrelSupport"/>
+            <composite name="OuterTrackerEndcapSupport"/>             
+        </detector>
+    </detectors>
+    
+    
+    <!--  Definition of the used visualization attributes    -->
+    <display>
+        <vis name="OuterTrackerLayerVis"   alpha="1.0" r="1.0" g="1.0" b="0.6" showDaughters="true" visible="true"/>
+        <vis name="OuterTrackerModuleVis"  alpha="0.1" r="0.0" g="1.0" b="0.6" showDaughters="false" visible="true"/>
+        <vis name="OuterTrackerForwardVis" alpha="1.0" r="0.8" g="0.1" b="0.1" showDaughters="false" visible="true"/>
+        <vis name="OuterTrackerInterlinkVis" alpha="1.0" r="0.078" g="0.12" b="0.59" showDaughters="true" visible="true"/>        
+    </display>
+    
+    <!--  Definition of the readout segmentation/definition  -->
+    <readouts>
+        <readout name="OuterTrackerBarrelCollection">
+            <id>${GlobalTrackerReadoutID}</id>
+        </readout>
+        <readout name="OuterTrackerEndcapCollection">
+            <id>${GlobalTrackerReadoutID}</id>
+        </readout>
+    </readouts>
+    
+
+    <detectors>
+    
+        <detector id="DetID_OT_Barrel" name="OuterTrackerBarrel" type="TrackerBarrel_o1_v05" readout="OuterTrackerBarrelCollection" region="OuterTrackerBarrelRegion">
+            <envelope vis="OTVis">
+                <shape type="Assembly"/>
+            </envelope>
+            <comment>Silicon Outer Tracker Barrel</comment>
+            
+            <type_flags type=" DetType_TRACKER + DetType_BARREL"/>
+
+            <module name="OuterTrackerBarrelModule_In" vis="OuterTrackerModuleVis">
+                <module_envelope width="30.1*mm" length="30.1*mm"/>
+                <include ref="OuterTrackerBarrelModuleUp.xml"/>
+            </module>
+	    
+	        <module name="OuterTrackerBarrelModule_Out" vis="OuterTrackerModuleVis">
+                <module_envelope width="30.1*mm" length="30.1*mm"/>
+                <include ref="OuterTrackerBarrelModuleDown.xml"/>
+            </module>
+
+
+            <layer module="OuterTrackerBarrelModule_In" id="0" vis="OuterTrackerLayerVis" type="4">
+                <rphi_layout phi_tilt="0*deg" nphi="46*4" phi0="0" rc="OuterTracker_Barrel_radius_0" dr="5.5*mm"/>
+                <z_layout dr="0" z0="OuterTracker_Barrel_half_length-15.05*mm" nz="84"/>
+            </layer>
+            <layer module="OuterTrackerBarrelModule_In" id="1" vis="OuterTrackerLayerVis" type="4">
+                <rphi_layout phi_tilt="0*deg" nphi="64*4" phi0="0" rc="OuterTracker_Barrel_radius_1" dr="5.5*mm"/>
+                <z_layout dr="0" z0="OuterTracker_Barrel_half_length-15.05*mm" nz="84"/>
+            </layer>
+            <layer module="OuterTrackerBarrelModule_Out" id="2" vis="OuterTrackerLayerVis" type="4">
+                <rphi_layout phi_tilt="0*deg" nphi="82*4" phi0="0" rc="OuterTracker_Barrel_radius_2" dr="5.5*mm"/>
+                <z_layout dr="0" z0="OuterTracker_Barrel_half_length-15.05*mm" nz="84"/>
+            </layer>
+        </detector>
+
+    
+        <detector id="DetID_OT_Endcap" name="OuterTrackerEndcap" type="TrackerEndcap_o2_v06" readout="OuterTrackerEndcapCollection" reflect="true" region="OuterTrackerEndcapRegion">
+            <envelope vis="OTVis">
+                <shape type="Assembly"/>
+            </envelope>
+            <comment>Silicon Outer Tracker Endcaps</comment>
+            
+            <type_flags type=" DetType_TRACKER + DetType_ENDCAP"/>
+
+            <module name="OuterTrackerEndcapModule_0_In" vis="OuterTrackerModuleVis">
+                <trd x="120.3*mm" y="270.9*mm"/>
+                <include ref="TrackerDiskModuleIn.xml"/>
+            </module>
+            <module name="OuterTrackerEndcapModule_1_In" vis="OuterTrackerModuleVis">
+                <trd x="180.6*mm" y="301*mm"/>
+                <include ref="TrackerDiskModuleIn.xml"/>
+            </module>
+            <module name="OuterTrackerEndcapModule_2_In" vis="OuterTrackerModuleVis">
+                <trd x="240.7*mm" y="240.7*mm"/>
+                <include ref="TrackerDiskModuleIn.xml"/>
+            </module>
+
+            <module name="OuterTrackerEndcapModule_0_Out" vis="OuterTrackerModuleVis">
+                <trd x="120.3*mm" y="270.9*mm"/>
+                <include ref="TrackerDiskModuleOut.xml"/>
+            </module>
+            <module name="OuterTrackerEndcapModule_1_Out" vis="OuterTrackerModuleVis">
+                <trd x="180.6*mm" y="301*mm"/>
+                <include ref="TrackerDiskModuleOut.xml"/>
+            </module>
+            <module name="OuterTrackerEndcapModule_2_Out" vis="OuterTrackerModuleVis">
+                <trd x="240.7*mm" y="240.7*mm"/>
+                <include ref="TrackerDiskModuleOut.xml"/>
+            </module>
+
+
+            <layer id="0">
+                <ring r="OuterTracker_Endcap_radius_0" zstart="OuterTracker_Endcap_z_0" nmodules="48" dz="3*mm" module="OuterTrackerEndcapModule_0_In" phi0="0"/>
+                <ring r="OuterTracker_Endcap_radius_1" zstart="OuterTracker_Endcap_z_0" nmodules="48" dz="3*mm" module="OuterTrackerEndcapModule_1_In" phi0="0"/>
+                <ring r="OuterTracker_Endcap_radius_2" zstart="OuterTracker_Endcap_z_0" nmodules="48" dz="3*mm" module="OuterTrackerEndcapModule_2_In" phi0="0"/>
+            </layer>
+            <layer id="1">
+                <ring r="OuterTracker_Endcap_radius_0" zstart="OuterTracker_Endcap_z_1" nmodules="48" dz="3*mm" module="OuterTrackerEndcapModule_0_Out" phi0="0"/>
+                <ring r="OuterTracker_Endcap_radius_1" zstart="OuterTracker_Endcap_z_1" nmodules="48" dz="3*mm" module="OuterTrackerEndcapModule_1_Out" phi0="0"/>
+                <ring r="OuterTracker_Endcap_radius_2" zstart="OuterTracker_Endcap_z_1" nmodules="48" dz="3*mm" module="OuterTrackerEndcapModule_2_Out" phi0="0"/>
+            </layer>    
+            <layer id="2">
+                <ring r="OuterTracker_Endcap_radius_0" zstart="OuterTracker_Endcap_z_2" nmodules="48" dz="3*mm" module="OuterTrackerEndcapModule_0_In" phi0="0"/>
+                <ring r="OuterTracker_Endcap_radius_1" zstart="OuterTracker_Endcap_z_2" nmodules="48" dz="3*mm" module="OuterTrackerEndcapModule_1_In" phi0="0"/>
+                <ring r="OuterTracker_Endcap_radius_2" zstart="OuterTracker_Endcap_z_2" nmodules="48" dz="3*mm" module="OuterTrackerEndcapModule_2_In" phi0="0"/>
+            </layer>    
+            <layer id="3">
+                <ring r="OuterTracker_Endcap_radius_0" zstart="OuterTracker_Endcap_z_3" nmodules="48" dz="3*mm" module="OuterTrackerEndcapModule_0_Out" phi0="0"/>
+                <ring r="OuterTracker_Endcap_radius_1" zstart="OuterTracker_Endcap_z_3" nmodules="48" dz="3*mm" module="OuterTrackerEndcapModule_1_Out" phi0="0"/>
+                <ring r="OuterTracker_Endcap_radius_2" zstart="OuterTracker_Endcap_z_3" nmodules="48" dz="3*mm" module="OuterTrackerEndcapModule_2_Out" phi0="0"/>
+            </layer>
+        </detector>
+
+
+        <detector name="OuterTrackerBarrelSupport" type="TrackerBarrelSupport_o1_v01" id="0" reflect="true" region="OuterTrackerBarrelRegion">
+            <envelope>
+                <shape type="Assembly"/>
+            </envelope>
+            <layer id="0" inner_r="OuterTracker_Barrel_radius_0+1*cm" outer_z="OuterTracker_Barrel_half_length" vis="SupportVis">
+                <slice material="CarbonFiber" thickness="0.26/3.5959*cm" />
+            </layer>
+            <layer id="1" inner_r="OuterTracker_Barrel_radius_1+1*cm" outer_z="OuterTracker_Barrel_half_length" vis="SupportVis">
+                <slice material="CarbonFiber" thickness="0.125/3.5959*cm" />
+            </layer>
+            <layer id="2" inner_r="OuterTracker_Barrel_radius_2-1*cm" outer_z="OuterTracker_Barrel_half_length" vis="SupportVis">
+                <slice material="CarbonFiber" thickness="0.125/3.5959*cm" />
+            </layer>
+        </detector>
+        
+         
+        <detector name="OuterTrackerEndcapSupport" type="TrackerEndcapSupport_o1_v01" reflect="true" region="OuterTrackerEndcapRegion">
+		   <envelope>
+                <shape type="Assembly"/>
+           </envelope>
+           <layer id="0" inner_r="OuterTracker_inner_radius" inner_z="OuterTracker_Endcap_z_0+1*cm" outer_r="OuterTracker_Endcap_outer_radius" vis="SupportVis">
+	           <slice material="CarbonFiber" thickness="0.365/3.5959*cm" />
+           </layer>
+           <layer id="1" inner_r="OuterTracker_inner_radius" inner_z="OuterTracker_Endcap_z_1-1*cm" outer_r="OuterTracker_Endcap_outer_radius" vis="SupportVis">
+	           <slice material="CarbonFiber" thickness="0.365/3.5959*cm" />
+           </layer>
+           <layer id="2" inner_r="OuterTracker_inner_radius" inner_z="OuterTracker_Endcap_z_2+1*cm" outer_r="OuterTracker_Endcap_outer_radius" vis="SupportVis">
+	           <slice material="CarbonFiber" thickness="0.365/3.5959*cm" />
+           </layer>
+           <layer id="3" inner_r="OuterTracker_inner_radius" inner_z="OuterTracker_Endcap_z_3-1*cm" outer_r="OuterTracker_Endcap_outer_radius" vis="SupportVis">
+	           <slice material="CarbonFiber" thickness="0.365/3.5959*cm" />
+           </layer>
+           <layer id="4" inner_r="OuterTracker_Barrel_radius_0-1*cm" inner_z="OuterTracker_Barrel_half_length+2*cm" outer_r="OuterTracker_outer_radius" vis="OuterTrackerInterlinkVis">
+	           <slice material="CarbonFiber" thickness="0.6/3.5959*cm" />
+           </layer>                    
+        </detector>
+
+    </detectors>
+    
+    <plugins>
+        <plugin name="DD4hep_GenericSurfaceInstallerPlugin">
+            <argument value="OuterTrackerBarrel"/>
+            <argument value="dimension=2"/>
+            <argument value="u_x=1."/>
+            <argument value="v_y=1."/>
+            <argument value="n_z=1."/>
+        </plugin>
+        <plugin name="DD4hep_GenericSurfaceInstallerPlugin">
+            <argument value="OuterTrackerEndcap"/>
+            <argument value="dimension=2"/>
+            <argument value="u_x=1."/>
+            <argument value="v_y=1."/>
+            <argument value="n_z=1."/>
+        </plugin>
+    </plugins>
+    
+</lccdd>

--- a/CLIC/compact/CLIC_o3_v09/Solenoid_o1_v01_01.xml
+++ b/CLIC/compact/CLIC_o3_v09/Solenoid_o1_v01_01.xml
@@ -1,0 +1,56 @@
+<lccdd>
+     
+    <define>
+        <constant name="SolenoidVacuumTank_thickness" value="40*mm"/>
+        <constant name="SolenoidCoil_thickness" value="344*mm"/>        
+    </define>
+    
+    
+    
+    <display>
+        <vis name="SolenoidBarrelLayerVis" alpha="1" r="0"    g="0.3"  b="0.3" showDaughters="false" visible="true"/>
+        <vis name="SolenoidCoilEndsVis"    alpha="1" r="0"    g="0.9"  b="0.9" showDaughters="false" visible="true"/>
+        <vis name="SolenoidVacuum"         alpha="0" r="1"    g="1"    b="1"   showDaughters="false" visible="true"/>        
+    </display>
+    
+    
+    
+    <comment>Solenoid</comment>
+    <detectors>
+        <detector name="Solenoid" type="DD4hep_SubdetectorAssembly" vis="SOLVis">
+            <shape type="Tube" rmin="Solenoid_inner_radius-2*env_safety" rmax="Solenoid_outer_radius+2*env_safety" dz="Solenoid_half_length+2*env_safety" material="Vacuum"/>
+            <composite name="SolenoidBarrel"/>
+            <composite name="SolenoidEndcaps"/> 
+        </detector>
+    </detectors>
+    
+    
+    
+    <detectors>
+        
+        <detector name="SolenoidBarrel" type="DD4hep_Solenoid_o1_v01" id="0" reflect="true">
+            <type_flags type=" DetType_COIL"/>
+            <envelope vis="SOLVis">
+                <shape type="Assembly"/>
+            </envelope>
+            
+            <layer id="1" inner_r="Solenoid_inner_radius" outer_z="Solenoid_half_length" vis="SolenoidBarrelLayerVis">
+                <slice material="Steel235" thickness="SolenoidVacuumTank_thickness"/>
+            </layer>
+            <layer id="2" inner_r="Solenoid_Coil_radius-SolenoidCoil_thickness/2.0" outer_z="Solenoid_Coil_half_length">
+                <slice material="Aluminium" thickness="SolenoidCoil_thickness" vis="SolenoidCoilEndsVis" />
+            </layer>
+            <layer id="3" inner_r="Solenoid_outer_radius-SolenoidVacuumTank_thickness" outer_z="Solenoid_half_length" vis="SolenoidBarrelLayerVis">
+                <slice material="Steel235" thickness="SolenoidVacuumTank_thickness"/>
+            </layer>
+        </detector>
+        
+        <detector name="SolenoidEndcaps" type="DD4hep_DiskTracker" id="0" reflect="true" vis="SolenoidBarrelLayerVis">
+            <layer id="1" inner_r="Solenoid_inner_radius+SolenoidVacuumTank_thickness" inner_z="Solenoid_half_length-SolenoidVacuumTank_thickness" outer_r="Solenoid_outer_radius-SolenoidVacuumTank_thickness" vis="SolenoidBarrelLayerVis">
+	        <slice material="Steel235" thickness="SolenoidVacuumTank_thickness/2.0" />
+          </layer>
+        </detector>
+    </detectors>
+</lccdd>
+
+

--- a/CLIC/compact/CLIC_o3_v09/TrackerDiskModuleIn.xml
+++ b/CLIC/compact/CLIC_o3_v09/TrackerDiskModuleIn.xml
@@ -1,0 +1,27 @@
+<lccdd>
+    <!-- Build slices top-down from innermost slice (closest to IP) to outer-most (away from IP)-->
+    <module_component thickness="0.100*mm"  material="Kapton"           info="Power bus: Insulating layer"          sensitive="false"/>
+    <module_component thickness="0.200*mm"  material="Aluminium"        info="Power bus: Conductor"                 sensitive="false"/>
+    <module_component thickness="0.100*mm"  material="Kapton"           info="Power bus: Insulating layer"          sensitive="false"/>
+
+    <module_component thickness="0.100*mm"  material="Epoxy"            info="Glue: Eccobond"                       sensitive="false"/>
+
+    <module_component thickness="0.050*mm"  material="Kapton"           info="Module: FPC insulating layer"         sensitive="false"/>
+    <module_component thickness="0.050*mm"  material="Aluminium"        info="Module: FPC metal layer"              sensitive="false"/>
+    <module_component thickness="0.050*mm"  material="Kapton"           info="Module: FPC insulating layer"         sensitive="false"/>
+    <module_component thickness="0.100*mm"  material="Silicon"          info="Module: r/o ASIC"                     sensitive="false" />
+    <module_component thickness="0.100*mm"  material="Silicon"          info="Module: Sensor"                       sensitive="true"/>
+
+    <module_component thickness="0.100*mm"  material="Epoxy"            info="Glue: Eccobond"                       sensitive="false"/>
+
+    <module_component thickness="0.150*mm"  material="CarbonFiber"      info="Structure and cooling: CF Skins"      sensitive="false"/>
+    <module_component thickness="0.025*mm"  material="CarbonFiber"      info="Structure and cooling: Interface"     sensitive="false"/>
+    <module_component thickness="0.100*mm"  material="Epoxy"            info="Structure and cooling: Glue layer"    sensitive="false"/>
+    <module_component thickness="0.235*mm"  material="Water"            info="Structure and cooling: Cooling fluid" sensitive="false"/>
+    <module_component thickness="0.068*mm"  material="Kapton"           info="Structure and cooling: Cooling Pipe"  sensitive="false"/>
+    <module_component thickness="0.700*mm"  material="Allcomp_K9"       info="Structure and cooling: Carbon Foam"   sensitive="false"/>
+    <module_component thickness="2.800*mm"  material="Rohacell_IG51"    info="Structure and cooling: Core"          sensitive="false"/>
+    <module_component thickness="0.100*mm"  material="Epoxy"            info="Structure and cooling: Glue layer"    sensitive="false"/>
+    <module_component thickness="0.025*mm"  material="CarbonFiber"      info="Structure and cooling: Interface"     sensitive="false"/>
+    <module_component thickness="0.150*mm"  material="CarbonFiber"      info="Structure and cooling: CF Skins"      sensitive="false"/>
+</lccdd>

--- a/CLIC/compact/CLIC_o3_v09/TrackerDiskModuleOut.xml
+++ b/CLIC/compact/CLIC_o3_v09/TrackerDiskModuleOut.xml
@@ -1,0 +1,27 @@
+<lccdd>
+    <!-- Build slices top-down from innermost slice (closest to IP) to outer-most (away from IP)-->
+    <module_component thickness="0.150*mm"  material="CarbonFiber"      info="Structure and cooling: CF Skins"      sensitive="false"/>
+    <module_component thickness="0.025*mm"  material="CarbonFiber"      info="Structure and cooling: Interface"     sensitive="false"/>
+    <module_component thickness="0.100*mm"  material="Epoxy"            info="Structure and cooling: Glue layer"    sensitive="false"/>
+    <module_component thickness="2.800*mm"  material="Rohacell_IG51"    info="Structure and cooling: Core"          sensitive="false"/>
+    <module_component thickness="0.700*mm"  material="Allcomp_K9"       info="Structure and cooling: Carbon Foam"   sensitive="false"/>
+    <module_component thickness="0.068*mm"  material="Kapton"           info="Structure and cooling: Cooling Pipe"  sensitive="false"/>
+    <module_component thickness="0.235*mm"  material="Water"            info="Structure and cooling: Cooling fluid" sensitive="false"/>
+    <module_component thickness="0.100*mm"  material="Epoxy"            info="Structure and cooling: Glue layer"    sensitive="false"/>
+    <module_component thickness="0.025*mm"  material="CarbonFiber"      info="Structure and cooling: Interface"     sensitive="false"/>
+    <module_component thickness="0.150*mm"  material="CarbonFiber"      info="Structure and cooling: CF Skins"      sensitive="false"/>
+
+    <module_component thickness="0.100*mm"  material="Epoxy"            info="Glue: Eccobond"                       sensitive="false"/>
+
+    <module_component thickness="0.100*mm"  material="Silicon"          info="Module: Sensor"                       sensitive="true"/>
+    <module_component thickness="0.100*mm"  material="Silicon"          info="Module: r/o ASIC"                     sensitive="false" />
+    <module_component thickness="0.050*mm"  material="Kapton"           info="Module: FPC insulating layer"         sensitive="false"/>
+    <module_component thickness="0.050*mm"  material="Aluminium"        info="Module: FPC metal layer"              sensitive="false"/>
+    <module_component thickness="0.050*mm"  material="Kapton"           info="Module: FPC insulating layer"         sensitive="false"/>
+
+    <module_component thickness="0.100*mm"  material="Epoxy"            info="Glue: Eccobond"                       sensitive="false"/>
+
+    <module_component thickness="0.100*mm"  material="Kapton"           info="Power bus: Insulating layer"          sensitive="false"/>
+    <module_component thickness="0.200*mm"  material="Aluminium"        info="Power bus: Conductor"                 sensitive="false"/>
+    <module_component thickness="0.100*mm"  material="Kapton"           info="Power bus: Insulating layer"          sensitive="false"/>
+</lccdd>

--- a/CLIC/compact/CLIC_o3_v09/Vertex_o2_v06_01.xml
+++ b/CLIC/compact/CLIC_o3_v09/Vertex_o2_v06_01.xml
@@ -1,0 +1,182 @@
+<lccdd>
+    
+    <comment>Tracking detectors</comment>
+    <detectors>
+        <detector name="Vertex" type="DD4hep_SubdetectorAssembly" vis="VXDVis">
+            <shape type="Tube" rmin="Vertex_inner_radius+env_safety" rmax="Vertex_outer_radius" dz="Vertex_half_length" material="Air"/>
+            <comment>Outer Tracker Assembly</comment>
+            <composite name="VertexBarrel"/>
+            <composite name="VertexEndcap"/>
+            <composite name="VertexVerticalCable"/>
+        </detector>
+    </detectors>
+    
+    
+    <display>
+        <vis name="SiVertexModuleVis"    alpha="1.0" r="1" g="1"    b="0.6"     showDaughters="true"  visible="false"/>
+        <vis name="SiVertexSensitiveVis" alpha="1.0" r="1" g="0.2"  b="0.2"     showDaughters="true"  visible="true"/>
+        <vis name="SiVertexPassiveVis"   alpha="1.0" r="0.274" g="0.274"  b="0.274"       showDaughters="true"  visible="true"/>
+        <vis name="SiVertexCableVis"     alpha="1.0" r="0.85" g="0.53"    b="0.4"       showDaughters="true"  visible="true"/>
+        <vis name="SiVertexAir"          alpha="1.0" r="0" g="0"    b="0"       showDaughters="false"  visible="false"/>
+    </display>
+    
+    <define>
+        <constant name="VertexBarrel_zmax" value="13.0*cm"/>
+        <constant name="VertexBarrel_r1" value="3.1*cm"/>
+        <constant name="VertexBarrel_r2" value="4.4*cm"/>
+        <constant name="VertexBarrel_r3" value="5.8*cm"/>
+        
+        <constant name="VertexBarrel_Sensitive_Thickness"   value="5.000000000e-02*mm"/>
+        <constant name="VertexBarrel_Support_Thickness"     value="14.000000000e-02*mm"/>
+        <constant name="VertexBarrel_DoubleLayer_Gap"       value="2.0*mm"/>
+        
+        <constant name="VertexBarrel_Layer1_width" value="13*mm"/>
+        <constant name="VertexBarrel_Layer2_width" value="24*mm"/>
+        <constant name="VertexBarrel_Layer3_width" value="23.5*mm"/>
+        
+        <constant name="VertexBarrel_Layer1_offset" value="2*mm"/>
+        <constant name="VertexBarrel_Layer2_offset" value="1*mm"/>
+        <constant name="VertexBarrel_Layer3_offset" value="1*mm"/>
+        
+        <constant name="VertexBarrel_Layer1_Staves" value="16"/>
+        <constant name="VertexBarrel_Layer2_Staves" value="12"/>
+        <constant name="VertexBarrel_Layer3_Staves" value="16"/>
+        
+        <constant name="VertexEndcap_rmax"   value="102*mm"/>
+        <constant name="VertexEndcap_zmin"   value="160*mm"/>
+        <constant name="VertexEndcapModules" value="8"/>
+        <constant name="VertexEndcapLayers"  value="3"/>
+        <constant name="VertexEndcap_zmax"   value="VertexEndcap_zmin+136*mm"/>
+        <constant name="VertexEndcap_dz"     value="(VertexEndcap_zmax-VertexEndcap_zmin)/(VertexEndcapModules*VertexEndcapLayers-1)"/>
+        <constant name="VertexEndcap_offset" value="0.3*cm"/>
+        <constant name="VertexEndcap_rmin1"  value="CentralBeamPipe_rmax + VertexEndcap_offset"/>
+        <constant name="VertexEndcap_rmin2"  value="CentralBeamPipe_rmax + VertexEndcap_offset"/>
+        <constant name="VertexEndcap_rmin3"  value="CentralBeamPipe_rmax + VertexEndcap_offset"/>
+        <constant name="VertexEndcap_rmin4"  value="CentralBeamPipe_rmax + VertexEndcap_offset"/>
+        <constant name="VertexEndcapModuleThickness" value="1.22*mm"/>
+        <constant name="VertexEndcapOverlap" value="1*mm"/>
+    </define>
+    
+    
+    
+    <!--  Definition of the readout segmentation/definition  -->
+    <readouts>
+        <readout name="VertexBarrelCollection">
+            <id>${GlobalTrackerReadoutID}</id>
+        </readout>
+        <readout name="VertexEndcapCollection">
+            <id>${GlobalTrackerReadoutID}</id>
+        </readout>
+    </readouts>
+    
+
+    <detectors>
+        <detector name="VertexBarrel" type="ZPlanarTracker" vis="VXDVis" id="DetID_VXD_Barrel" readout="VertexBarrelCollection"  region="VertexBarrelRegion">
+
+            <type_flags type=" DetType_TRACKER + DetType_PIXEL + DetType_VERTEX + DetType_BARREL"/>
+
+            <layer nLadders="VertexBarrel_Layer1_Staves" phi0="0" id="0">
+                <ladder    distance="VertexBarrel_r1" thickness="VertexBarrel_Support_Thickness" width="VertexBarrel_Layer1_width" length="VertexBarrel_zmax" offset="VertexBarrel_Layer1_offset"    material="Silicon"  vis="SiVertexPassiveVis"/>
+                <sensitive distance="VertexBarrel_r1+VertexBarrel_Support_Thickness" thickness="VertexBarrel_Sensitive_Thickness" width="VertexBarrel_Layer1_width" length="VertexBarrel_zmax" offset="VertexBarrel_Layer1_offset" material="Silicon" vis="SiVertexSensitiveVis" />
+            </layer>
+            <layer nLadders="VertexBarrel_Layer1_Staves" phi0="0" id="1">
+                <sensitive distance="VertexBarrel_r1+VertexBarrel_Support_Thickness+VertexBarrel_Sensitive_Thickness+VertexBarrel_DoubleLayer_Gap" thickness="VertexBarrel_Sensitive_Thickness" width="VertexBarrel_Layer1_width" length="VertexBarrel_zmax" offset="VertexBarrel_Layer1_offset" material="Silicon" vis="SiVertexSensitiveVis" />
+                <ladder    distance="VertexBarrel_r1+VertexBarrel_Support_Thickness+VertexBarrel_Sensitive_Thickness+VertexBarrel_DoubleLayer_Gap+VertexBarrel_Sensitive_Thickness" thickness="VertexBarrel_Support_Thickness" width="VertexBarrel_Layer1_width" length="VertexBarrel_zmax" offset="VertexBarrel_Layer1_offset"    material="Silicon"  vis="SiVertexPassiveVis" />
+            </layer>
+
+
+            <layer nLadders="VertexBarrel_Layer2_Staves" phi0="0" id="2">
+                <ladder    distance="VertexBarrel_r2" thickness="VertexBarrel_Support_Thickness" width="VertexBarrel_Layer2_width" length="VertexBarrel_zmax" offset="VertexBarrel_Layer2_offset"    material="Silicon" vis="SiVertexPassiveVis" />
+                <sensitive distance="VertexBarrel_r2+VertexBarrel_Support_Thickness" thickness="VertexBarrel_Sensitive_Thickness" width="VertexBarrel_Layer2_width" length="VertexBarrel_zmax" offset="VertexBarrel_Layer2_offset" material="Silicon" vis="SiVertexSensitiveVis"/>
+            </layer>
+            <layer nLadders="VertexBarrel_Layer2_Staves" phi0="0" id="3">
+                <sensitive distance="VertexBarrel_r2+VertexBarrel_Support_Thickness+VertexBarrel_Sensitive_Thickness+VertexBarrel_DoubleLayer_Gap" thickness="VertexBarrel_Sensitive_Thickness" width="VertexBarrel_Layer2_width" length="VertexBarrel_zmax" offset="VertexBarrel_Layer2_offset" material="Silicon" vis="SiVertexSensitiveVis"/>
+                <ladder    distance="VertexBarrel_r2+VertexBarrel_Support_Thickness+VertexBarrel_Sensitive_Thickness+VertexBarrel_DoubleLayer_Gap+VertexBarrel_Sensitive_Thickness" thickness="VertexBarrel_Support_Thickness" width="VertexBarrel_Layer2_width-1.2*mm" length="VertexBarrel_zmax" offset="VertexBarrel_Layer2_offset"    material="Silicon" vis="SiVertexPassiveVis" />
+            </layer>
+            
+            
+            <layer nLadders="VertexBarrel_Layer3_Staves" phi0="0" id="4">
+                <ladder    distance="VertexBarrel_r3" thickness="VertexBarrel_Support_Thickness" width="VertexBarrel_Layer3_width" length="VertexBarrel_zmax" offset="VertexBarrel_Layer3_offset"    material="Silicon" vis="SiVertexPassiveVis" />
+                <sensitive distance="VertexBarrel_r3+VertexBarrel_Support_Thickness" thickness="VertexBarrel_Sensitive_Thickness" width="VertexBarrel_Layer3_width" length="VertexBarrel_zmax" offset="VertexBarrel_Layer3_offset" material="Silicon" vis="SiVertexSensitiveVis"/>
+            </layer>
+            <layer nLadders="VertexBarrel_Layer3_Staves" phi0="0" id="5">
+                <sensitive distance="VertexBarrel_r3+VertexBarrel_Support_Thickness+VertexBarrel_Sensitive_Thickness+VertexBarrel_DoubleLayer_Gap" thickness="VertexBarrel_Sensitive_Thickness" width="VertexBarrel_Layer3_width" length="VertexBarrel_zmax" offset="VertexBarrel_Layer3_offset" material="Silicon" vis="SiVertexSensitiveVis"/>
+                <ladder    distance="VertexBarrel_r3+VertexBarrel_Support_Thickness+VertexBarrel_Sensitive_Thickness+VertexBarrel_DoubleLayer_Gap+VertexBarrel_Sensitive_Thickness" thickness="VertexBarrel_Support_Thickness" width="VertexBarrel_Layer3_width" length="VertexBarrel_zmax" offset="VertexBarrel_Layer3_offset"    material="Silicon" vis="SiVertexPassiveVis"/>
+            </layer>
+            
+        </detector>
+        
+        
+    </detectors>
+ 
+    <detectors>
+        <detector id="DetID_VXD_Endcap" name="VertexEndcap" type="VertexEndcap_o1_v06" readout="VertexEndcapCollection" reflect="true" region="VertexEndcapRegion">
+            <envelope vis="VXDVis">
+                <shape type="Assembly"/>
+            </envelope>
+            <comment>Vertex Detector Endcaps</comment>
+
+            <type_flags type=" DetType_TRACKER + DetType_PIXEL + DetType_VERTEX + DetType_ENDCAP"/>
+
+            <module name="SiVertexEndcapModule1" vis="SiVertexModuleVis">
+                <trd x1="VertexEndcap_rmin1 * tan(pi/(VertexEndcapModules))+VertexEndcapOverlap*sin(pi/VertexEndcapModules)" x2="VertexEndcap_rmax * tan(pi/(VertexEndcapModules))+VertexEndcapOverlap*sin(pi/VertexEndcapModules)" z="(VertexEndcap_rmax - VertexEndcap_rmin1) / 2" />
+                <!-- Build slices top-down from innermost slice (closest to IP) to outer-most (away from IP)-->
+                <module_component thickness="0.17*mm"  material="Silicon" vis="SiVertexPassiveVis"/>
+                <module_component thickness="0.05*mm"  material="Silicon" sensitive="true" vis="SiVertexSensitiveVis"/>
+                <module_component thickness="1.00*mm"  material="Air" vis="SiVertexAir" />
+            </module>
+
+            <module name="SiVertexEndcapModule2" vis="SiVertexModuleVis">
+                <trd x1="VertexEndcap_rmin1 * tan(pi/(VertexEndcapModules))+VertexEndcapOverlap*sin(pi/VertexEndcapModules)" x2="VertexEndcap_rmax * tan(pi/(VertexEndcapModules))+VertexEndcapOverlap*sin(pi/VertexEndcapModules)" z="(VertexEndcap_rmax - VertexEndcap_rmin1) / 2" />
+                <!-- Build slices top-down from innermost slice (closest to IP) to outer-most (away from IP)-->
+                <module_component thickness="1.00*mm"  material="Air" vis="SiVertexAir" />
+                <module_component thickness="0.05*mm"  material="Silicon" sensitive="true" vis="SiVertexSensitiveVis"/>
+                <module_component thickness="0.17*mm"  material="Silicon" vis="SiVertexPassiveVis"/>
+
+            </module>
+
+            <layer id="0"  vis="SiVertexLayerVis">
+                <ring r="(VertexEndcap_rmax + VertexEndcap_rmin1) / 2" zstart="VertexEndcap_zmin-VertexEndcapModuleThickness/2.0" nmodules="(int) VertexEndcapModules" dz="VertexEndcap_dz" phi0="pi/(VertexEndcapModules)" module="SiVertexEndcapModule1"/>
+            </layer>
+            <layer id="1"  vis="SiVertexLayerVis">
+                <ring r="(VertexEndcap_rmax + VertexEndcap_rmin1) / 2" zstart="VertexEndcap_zmin+VertexEndcapModuleThickness/2.0" nmodules="(int) VertexEndcapModules" dz="VertexEndcap_dz" phi0="pi/(VertexEndcapModules)" module="SiVertexEndcapModule2"/>
+            </layer>
+            <layer id="2"  vis="SiVertexLayerVis">
+                <ring r="(VertexEndcap_rmax + VertexEndcap_rmin2) / 2" zstart="VertexEndcap_zmin+VertexEndcapModules*VertexEndcap_dz-VertexEndcapModuleThickness/2.0" nmodules="(int) VertexEndcapModules" dz="VertexEndcap_dz" phi0="pi/(VertexEndcapModules)" module="SiVertexEndcapModule1"/>
+            </layer>
+            <layer id="3"  vis="SiVertexLayerVis">
+                <ring r="(VertexEndcap_rmax + VertexEndcap_rmin2) / 2" zstart="VertexEndcap_zmin+VertexEndcapModules*VertexEndcap_dz+VertexEndcapModuleThickness/2.0" nmodules="(int) VertexEndcapModules" dz="VertexEndcap_dz" phi0="pi/(VertexEndcapModules)" module="SiVertexEndcapModule2"/>
+            </layer>
+            <layer id="4"  vis="SiVertexLayerVis">
+                <ring r="(VertexEndcap_rmax + VertexEndcap_rmin3) / 2" zstart="VertexEndcap_zmin+2*VertexEndcapModules*VertexEndcap_dz-VertexEndcapModuleThickness/2.0" nmodules="(int) VertexEndcapModules" dz="VertexEndcap_dz" phi0="pi/(VertexEndcapModules)" module="SiVertexEndcapModule1"/>
+            </layer>
+            <layer id="5"  vis="SiVertexLayerVis">
+                <ring r="(VertexEndcap_rmax + VertexEndcap_rmin3) / 2" zstart="VertexEndcap_zmin+2*VertexEndcapModules*VertexEndcap_dz+VertexEndcapModuleThickness/2.0" nmodules="(int) VertexEndcapModules" dz="VertexEndcap_dz" phi0="pi/(VertexEndcapModules)" module="SiVertexEndcapModule2"/>
+            </layer>
+        </detector>
+
+        <detector name="VertexVerticalCable" type="TrackerEndcapSupport_o1_v01" reflect="true"  region="VertexEndcapRegion">
+            <envelope>
+                <shape type="Assembly"/>
+            </envelope>
+            <layer id="1" inner_r="VertexBarrel_r1" inner_z="VertexBarrel_zmax+1*mm" outer_r="Vertex_outer_radius-5*env_safety" vis="SiVertexCableVis">
+                <slice material="Copper" thickness="0.02*mm" />
+            </layer>
+        </detector>
+
+    </detectors>
+
+
+    <plugins>
+        <plugin name="DD4hep_GenericSurfaceInstallerPlugin">
+            <argument value="VertexEndcap"/>
+            <argument value="dimension=2"/>
+            <argument value="u_x=-1."/>
+            <argument value="v_z=1."/>
+            <argument value="n_y=1."/>
+        </plugin>
+    </plugins>
+    
+    
+    
+</lccdd>

--- a/CLIC/compact/CLIC_o3_v09/YokeBarrel_o1_v01_01.xml
+++ b/CLIC/compact/CLIC_o3_v09/YokeBarrel_o1_v01_01.xml
@@ -1,0 +1,68 @@
+<lccdd>
+    <!--  Definition of global dictionary constants          -->
+    <define>
+        <constant name="YokeBarrel_layers" value="7"/>
+        <constant name="YokeBarrel_layer_thickness" value="10.0*cm + 4.0*cm"/>
+        <constant name="Yoke_cell_size" value="3.0*cm"/>
+        
+    </define>
+    
+    <!--  Definition of the used visualization attributes    -->
+    <display>
+        <vis name="YokeBarrelVis"          alpha="1" r="1"    g="0.4"  b="0.62" showDaughters="true" visible="true"/>
+        <vis name="YokeStavesVis"    alpha="1" r="0"    g="0.7"  b="0.3" showDaughters="true" visible="true"/>
+        <vis name="YokeLayerVis"     alpha="1" r="0"    g="1"    b="0.3" showDaughters="true" visible="true"/>
+        <vis name="YokeSensorVis"    alpha="1" r="0.54" g="0.4"  b="0.41" visible="true"/>
+        <vis name="YokeAbsorberVis"  alpha="1" r="0.28" g="0.4"  b="0.62" visible="true"/>
+    </display>
+    
+    <!--  Definition of the readout segmentation/definition  -->
+    <readouts>
+        <readout name="YokeBarrelCollection">
+            <segmentation type="CartesianGridXY" grid_size_x="Yoke_cell_size" grid_size_y="Yoke_cell_size" />
+            <id>system:5,side:2,layer:9,module:8,stave:4,submodule:4,x:32:-16,y:-16</id>
+        </readout>
+    </readouts>
+    
+    
+    <detectors>
+        <detector id="DetID_Yoke_Barrel" name="YokeBarrel" type="GenericCalBarrel_o1_v01" readout="YokeBarrelCollection" vis="YOKEVis" calorimeterType="MUON_BARREL" gap="0.*cm" material="Steel235">
+            
+            <comment>Yoke Calorimeter Barrel</comment>
+            
+            <type_flags type=" DetType_CALORIMETER + DetType_MUON + DetType_BARREL"/>
+
+            
+            <envelope vis="YOKEVis">
+                <shape type="PolyhedraRegular" numsides="YokeBarrel_symmetry"  rmin="YokeBarrel_inner_radius-10*env_safety" rmax="YokeBarrel_outer_radius+10*env_safety" dz="2*YokeBarrel_half_length"  material = "Air" />
+                <rotation x="0*deg" y="0*deg" z="90*deg-180*deg/YokeBarrel_symmetry"/>
+            </envelope>
+            
+            <dimensions numsides="(int) YokeBarrel_symmetry" rmin="YokeBarrel_inner_radius" z="YokeBarrel_half_length * 2"/>
+            <staves vis="YokeStavesVis"/>
+            
+        
+            <layer repeat="(int) YokeBarrel_layers" vis="YokeLayerVis">
+                <slice material="Aluminium" thickness="0.1*cm" />
+                <slice material="Air" thickness="0.35*cm" />
+                <slice material="PyrexGlass" thickness="0.2*cm" />
+                <slice material="RPCGasDefault" thickness="0.2*cm" sensitive="yes" vis="YokeSensorVis"/>
+                <slice material="PyrexGlass" thickness="0.2*cm" />
+                <slice material="Air" thickness="0.35*cm" />
+                <slice material="Aluminium" thickness="0.1*cm" />
+                <slice material="Aluminium" thickness="0.1*cm" />
+                <slice material="Air" thickness="0.35*cm" />
+                <slice material="PyrexGlass" thickness="0.2*cm" />
+                <slice material="RPCGasDefault" thickness="0.2*cm" vis="YokeSensorVis"/>
+                <slice material="PyrexGlass" thickness="0.2*cm" />
+                <slice material="Air" thickness="0.35*cm" />
+                <slice material="Aluminium" thickness="0.1*cm" />
+                <slice material="Air" thickness="1.0*cm" />
+                <slice material="Iron" thickness="24.4*cm" vis="YokeAbsorberVis" radiator="yes"/>
+            </layer>
+            
+
+        </detector>
+    </detectors>
+    
+</lccdd>

--- a/CLIC/compact/CLIC_o3_v09/YokeEndcap_o1_v01_01.xml
+++ b/CLIC/compact/CLIC_o3_v09/YokeEndcap_o1_v01_01.xml
@@ -1,0 +1,69 @@
+<lccdd>
+
+    <!--  Definition of the readout segmentation/definition  -->
+    <readouts>
+        <readout name="YokeEndcapCollection">
+            <segmentation type="CartesianGridXY" grid_size_x="3.5" grid_size_y="3.5" />
+            <id>system:5,side:2,module:8,stave:4,layer:9,submodule:4,x:32:-16,y:-16</id>
+        </readout>
+    </readouts>
+
+        <!--  Definition of the used visualization attributes    -->
+    <display>
+        <vis name="YokeEndcapVis"          alpha="1" r="1"    g="0.4"  b="0.62" showDaughters="true" visible="true"/>
+    </display>
+
+    <!--  Includes for sensitives and support                -->
+    <detectors>
+        
+        <detector name="YokeEndcap" type="GenericCalEndcap_o1_v01" id="DetID_Yoke_Endcap" readout="YokeEndcapCollection" vis="YOKEVis" >
+            
+            <comment>Encap Yoke</comment>
+            
+            <type_flags type=" DetType_CALORIMETER + DetType_MUON + DetType_ENDCAP"/>
+
+            <envelope vis="YOKEVis">
+                <shape type="BooleanShape" operation="Subtraction" material="Air">
+                    <shape type="BooleanShape" operation="Subtraction">
+                        <shape type="PolyhedraRegular"  numsides="YokeEndcap_outer_symmetry" rmin="0" rmax="YokeEndcap_outer_radius+ 10.0*env_safety" dz="2.0*YokeEndcap_max_z+2*env_safety"/>
+                        <shape type="PolyhedraRegular"  numsides="YokeEndcap_outer_symmetry" rmin="0" rmax="YokeEndcap_outer_radius+ 100.0*env_safety" dz="2.0*YokeEndcap_min_z"/>
+                    </shape>
+                    <shape type="Tube"  rmin="0" rmax="YokeEndcap_inner_radius-env_safety" dz="2.0*YokeEndcap_max_z+4*env_safety"/>
+                </shape>
+                <rotation x="0*deg" y="0*deg" z="90*deg-180*deg/YokeEndcap_outer_symmetry"/>
+            </envelope>
+            
+            <dimensions nsides_inner="YokeEndcap_outer_symmetry" nsides_outer="YokeEndcap_outer_symmetry" zmin="YokeEndcap_min_z" rmin="YokeEndcap_inner_radius" rmax="YokeEndcap_outer_radius"/>
+            <layer repeat="6" vis="YokeEndcapLayerVis">
+                <slice material="Iron" thickness="19.7*cm"  vis="YokeAbsorberVis" radiator="yes"/>
+                <slice material="Aluminium" thickness="0.1*cm" />
+                <slice material="Air" thickness="0.35*cm" />
+                <slice material="PyrexGlass" thickness="0.2*cm" />
+                <slice material="RPCGasDefault" thickness="0.2*cm" sensitive="yes" vis="YokeSensorVis"/>
+                <slice material="PyrexGlass" thickness="0.2*cm" />
+                <slice material="Air" thickness="0.35*cm" />
+                <slice material="Aluminium" thickness="0.1*cm" />
+                <slice material="Aluminium" thickness="0.1*cm" />
+                <slice material="Air" thickness="0.35*cm" />
+                <slice material="PyrexGlass" thickness="0.2*cm" />
+                <slice material="RPCGasDefault" thickness="0.2*cm" vis="YokeSensorVis"/>
+                <slice material="PyrexGlass" thickness="0.2*cm" />
+                <slice material="Air" thickness="0.35*cm" />
+                <slice material="Aluminium" thickness="0.1*cm" />
+            </layer>
+            <layer repeat="1" vis="YokeEndcapLayerVis">
+                <slice material="Iron" thickness="9.8*cm"  vis="YokeAbsorberVis" radiator="yes"/>
+            </layer>
+        </detector>
+        
+    </detectors>
+    
+    
+    
+    
+    
+    
+    
+</lccdd>
+
+

--- a/CLIC/compact/CLIC_o3_v09/elements.xml
+++ b/CLIC/compact/CLIC_o3_v09/elements.xml
@@ -1,0 +1,354 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<materials>
+    <!--
+      +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+      ++++   Linear collider detector description in C++       ++++
+      ++++   DD4hep Detector description generator.            ++++
+      ++++                                                     ++++
+      ++++   Parser: TinyXML DOM mini-parser                   ++++
+      ++++                                                     ++++
+      ++++   Table of elements as defined in ROOT: 6.08/00     ++++
+      ++++                                                     ++++
+      ++++                              M.Frank CERN/LHCb      ++++
+      +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+  -->
+    <element Z="0" N="0" formula="VACUUM" name="VACUUM">
+        <atom type="A" unit="g/mole" value="0.00000000e+00" />
+    </element>
+    <element Z="1" N="1" formula="H" name="H">
+        <atom type="A" unit="g/mole" value="1.00794000e+00" />
+    </element>
+    <element Z="2" N="4" formula="HE" name="HE">
+        <atom type="A" unit="g/mole" value="4.00260200e+00" />
+    </element>
+    <element Z="3" N="7" formula="LI" name="LI">
+        <atom type="A" unit="g/mole" value="6.94100000e+00" />
+    </element>
+    <element Z="4" N="9" formula="BE" name="BE">
+        <atom type="A" unit="g/mole" value="9.01218000e+00" />
+    </element>
+    <element Z="5" N="11" formula="B" name="B">
+        <atom type="A" unit="g/mole" value="1.08110000e+01" />
+    </element>
+    <element Z="6" N="12" formula="C" name="C">
+        <atom type="A" unit="g/mole" value="1.20107000e+01" />
+    </element>
+    <element Z="7" N="14" formula="N" name="N">
+        <atom type="A" unit="g/mole" value="1.40067400e+01" />
+    </element>
+    <element Z="8" N="16" formula="O" name="O">
+        <atom type="A" unit="g/mole" value="1.59994000e+01" />
+    </element>
+    <element Z="9" N="19" formula="F" name="F">
+        <atom type="A" unit="g/mole" value="1.89984032e+01" />
+    </element>
+    <element Z="10" N="20" formula="NE" name="NE">
+        <atom type="A" unit="g/mole" value="2.01797000e+01" />
+    </element>
+    <element Z="11" N="23" formula="NA" name="NA">
+        <atom type="A" unit="g/mole" value="2.29897700e+01" />
+    </element>
+    <element Z="12" N="24" formula="MG" name="MG">
+        <atom type="A" unit="g/mole" value="2.43050000e+01" />
+    </element>
+    <element Z="13" N="27" formula="AL" name="AL">
+        <atom type="A" unit="g/mole" value="2.69815380e+01" />
+    </element>
+    <element Z="14" N="28" formula="SI" name="SI">
+        <atom type="A" unit="g/mole" value="2.80855000e+01" />
+    </element>
+    <element Z="15" N="31" formula="P" name="P">
+        <atom type="A" unit="g/mole" value="3.09737610e+01" />
+    </element>
+    <element Z="16" N="32" formula="S" name="S">
+        <atom type="A" unit="g/mole" value="3.20660000e+01" />
+    </element>
+    <element Z="17" N="35" formula="CL" name="CL">
+        <atom type="A" unit="g/mole" value="3.54527000e+01" />
+    </element>
+    <element Z="18" N="40" formula="AR" name="AR">
+        <atom type="A" unit="g/mole" value="3.99480000e+01" />
+    </element>
+    <element Z="19" N="39" formula="K" name="K">
+        <atom type="A" unit="g/mole" value="3.90983000e+01" />
+    </element>
+    <element Z="20" N="40" formula="CA" name="CA">
+        <atom type="A" unit="g/mole" value="4.00780000e+01" />
+    </element>
+    <element Z="21" N="45" formula="SC" name="SC">
+        <atom type="A" unit="g/mole" value="4.49559100e+01" />
+    </element>
+    <element Z="22" N="48" formula="TI" name="TI">
+        <atom type="A" unit="g/mole" value="4.78670000e+01" />
+    </element>
+    <element Z="23" N="51" formula="V" name="V">
+        <atom type="A" unit="g/mole" value="5.09415000e+01" />
+    </element>
+    <element Z="24" N="52" formula="CR" name="CR">
+        <atom type="A" unit="g/mole" value="5.19961000e+01" />
+    </element>
+    <element Z="25" N="55" formula="MN" name="MN">
+        <atom type="A" unit="g/mole" value="5.49380490e+01" />
+    </element>
+    <element Z="26" N="56" formula="FE" name="FE">
+        <atom type="A" unit="g/mole" value="5.58450000e+01" />
+    </element>
+    <element Z="27" N="59" formula="CO" name="CO">
+        <atom type="A" unit="g/mole" value="5.89332000e+01" />
+    </element>
+    <element Z="28" N="59" formula="NI" name="NI">
+        <atom type="A" unit="g/mole" value="5.86934000e+01" />
+    </element>
+    <element Z="29" N="64" formula="CU" name="CU">
+        <atom type="A" unit="g/mole" value="6.35460000e+01" />
+    </element>
+    <element Z="30" N="65" formula="ZN" name="ZN">
+        <atom type="A" unit="g/mole" value="6.53900000e+01" />
+    </element>
+    <element Z="31" N="70" formula="GA" name="GA">
+        <atom type="A" unit="g/mole" value="6.97230000e+01" />
+    </element>
+    <element Z="32" N="73" formula="GE" name="GE">
+        <atom type="A" unit="g/mole" value="7.26100000e+01" />
+    </element>
+    <element Z="33" N="75" formula="AS" name="AS">
+        <atom type="A" unit="g/mole" value="7.49216000e+01" />
+    </element>
+    <element Z="34" N="79" formula="SE" name="SE">
+        <atom type="A" unit="g/mole" value="7.89600000e+01" />
+    </element>
+    <element Z="35" N="80" formula="BR" name="BR">
+        <atom type="A" unit="g/mole" value="7.99040000e+01" />
+    </element>
+    <element Z="36" N="84" formula="KR" name="KR">
+        <atom type="A" unit="g/mole" value="8.38000000e+01" />
+    </element>
+    <element Z="37" N="85" formula="RB" name="RB">
+        <atom type="A" unit="g/mole" value="8.54678000e+01" />
+    </element>
+    <element Z="38" N="88" formula="SR" name="SR">
+        <atom type="A" unit="g/mole" value="8.76200000e+01" />
+    </element>
+    <element Z="39" N="89" formula="Y" name="Y">
+        <atom type="A" unit="g/mole" value="8.89058500e+01" />
+    </element>
+    <element Z="40" N="91" formula="ZR" name="ZR">
+        <atom type="A" unit="g/mole" value="9.12240000e+01" />
+    </element>
+    <element Z="41" N="93" formula="NB" name="NB">
+        <atom type="A" unit="g/mole" value="9.29063800e+01" />
+    </element>
+    <element Z="42" N="96" formula="MO" name="MO">
+        <atom type="A" unit="g/mole" value="9.59400000e+01" />
+    </element>
+    <element Z="43" N="98" formula="TC" name="TC">
+        <atom type="A" unit="g/mole" value="9.80000000e+01" />
+    </element>
+    <element Z="44" N="101" formula="RU" name="RU">
+        <atom type="A" unit="g/mole" value="1.01070000e+02" />
+    </element>
+    <element Z="45" N="103" formula="RH" name="RH">
+        <atom type="A" unit="g/mole" value="1.02905500e+02" />
+    </element>
+    <element Z="46" N="106" formula="PD" name="PD">
+        <atom type="A" unit="g/mole" value="1.06420000e+02" />
+    </element>
+    <element Z="47" N="108" formula="AG" name="AG">
+        <atom type="A" unit="g/mole" value="1.07868200e+02" />
+    </element>
+    <element Z="48" N="112" formula="CD" name="CD">
+        <atom type="A" unit="g/mole" value="1.12411000e+02" />
+    </element>
+    <element Z="49" N="115" formula="IN" name="IN">
+        <atom type="A" unit="g/mole" value="1.14818000e+02" />
+    </element>
+    <element Z="50" N="119" formula="SN" name="SN">
+        <atom type="A" unit="g/mole" value="1.18710000e+02" />
+    </element>
+    <element Z="51" N="122" formula="SB" name="SB">
+        <atom type="A" unit="g/mole" value="1.21760000e+02" />
+    </element>
+    <element Z="52" N="128" formula="TE" name="TE">
+        <atom type="A" unit="g/mole" value="1.27600000e+02" />
+    </element>
+    <element Z="53" N="127" formula="I" name="I">
+        <atom type="A" unit="g/mole" value="1.26904470e+02" />
+    </element>
+    <element Z="54" N="131" formula="XE" name="XE">
+        <atom type="A" unit="g/mole" value="1.31290000e+02" />
+    </element>
+    <element Z="55" N="133" formula="CS" name="CS">
+        <atom type="A" unit="g/mole" value="1.32905450e+02" />
+    </element>
+    <element Z="56" N="137" formula="BA" name="BA">
+        <atom type="A" unit="g/mole" value="1.37327000e+02" />
+    </element>
+    <element Z="57" N="139" formula="LA" name="LA">
+        <atom type="A" unit="g/mole" value="1.38905500e+02" />
+    </element>
+    <element Z="58" N="140" formula="CE" name="CE">
+        <atom type="A" unit="g/mole" value="1.40116000e+02" />
+    </element>
+    <element Z="59" N="141" formula="PR" name="PR">
+        <atom type="A" unit="g/mole" value="1.40907650e+02" />
+    </element>
+    <element Z="60" N="144" formula="ND" name="ND">
+        <atom type="A" unit="g/mole" value="1.44240000e+02" />
+    </element>
+    <element Z="61" N="145" formula="PM" name="PM">
+        <atom type="A" unit="g/mole" value="1.45000000e+02" />
+    </element>
+    <element Z="62" N="150" formula="SM" name="SM">
+        <atom type="A" unit="g/mole" value="1.50360000e+02" />
+    </element>
+    <element Z="63" N="152" formula="EU" name="EU">
+        <atom type="A" unit="g/mole" value="1.51964000e+02" />
+    </element>
+    <element Z="64" N="157" formula="GD" name="GD">
+        <atom type="A" unit="g/mole" value="1.57250000e+02" />
+    </element>
+    <element Z="65" N="159" formula="TB" name="TB">
+        <atom type="A" unit="g/mole" value="1.58925340e+02" />
+    </element>
+    <element Z="66" N="162" formula="DY" name="DY">
+        <atom type="A" unit="g/mole" value="1.62500000e+02" />
+    </element>
+    <element Z="67" N="165" formula="HO" name="HO">
+        <atom type="A" unit="g/mole" value="1.64930320e+02" />
+    </element>
+    <element Z="68" N="167" formula="ER" name="ER">
+        <atom type="A" unit="g/mole" value="1.67260000e+02" />
+    </element>
+    <element Z="69" N="169" formula="TM" name="TM">
+        <atom type="A" unit="g/mole" value="1.68934210e+02" />
+    </element>
+    <element Z="70" N="173" formula="YB" name="YB">
+        <atom type="A" unit="g/mole" value="1.73040000e+02" />
+    </element>
+    <element Z="71" N="175" formula="LU" name="LU">
+        <atom type="A" unit="g/mole" value="1.74967000e+02" />
+    </element>
+    <element Z="72" N="178" formula="HF" name="HF">
+        <atom type="A" unit="g/mole" value="1.78490000e+02" />
+    </element>
+    <element Z="73" N="181" formula="TA" name="TA">
+        <atom type="A" unit="g/mole" value="1.80947900e+02" />
+    </element>
+    <element Z="74" N="184" formula="W" name="W">
+        <atom type="A" unit="g/mole" value="1.83840000e+02" />
+    </element>
+    <element Z="75" N="186" formula="RE" name="RE">
+        <atom type="A" unit="g/mole" value="1.86207000e+02" />
+    </element>
+    <element Z="76" N="190" formula="OS" name="OS">
+        <atom type="A" unit="g/mole" value="1.90230000e+02" />
+    </element>
+    <element Z="77" N="192" formula="IR" name="IR">
+        <atom type="A" unit="g/mole" value="1.92217000e+02" />
+    </element>
+    <element Z="78" N="195" formula="PT" name="PT">
+        <atom type="A" unit="g/mole" value="1.95078000e+02" />
+    </element>
+    <element Z="79" N="197" formula="AU" name="AU">
+        <atom type="A" unit="g/mole" value="1.96966550e+02" />
+    </element>
+    <element Z="80" N="200" formula="HG" name="HG">
+        <atom type="A" unit="g/mole" value="2.00590000e+02" />
+    </element>
+    <element Z="81" N="204" formula="TL" name="TL">
+        <atom type="A" unit="g/mole" value="2.04383300e+02" />
+    </element>
+    <element Z="82" N="207" formula="PB" name="PB">
+        <atom type="A" unit="g/mole" value="2.07200000e+02" />
+    </element>
+    <element Z="83" N="209" formula="BI" name="BI">
+        <atom type="A" unit="g/mole" value="2.08980380e+02" />
+    </element>
+    <element Z="84" N="209" formula="PO" name="PO">
+        <atom type="A" unit="g/mole" value="2.09000000e+02" />
+    </element>
+    <element Z="85" N="210" formula="AT" name="AT">
+        <atom type="A" unit="g/mole" value="2.10000000e+02" />
+    </element>
+    <element Z="86" N="222" formula="RN" name="RN">
+        <atom type="A" unit="g/mole" value="2.22000000e+02" />
+    </element>
+    <element Z="87" N="223" formula="FR" name="FR">
+        <atom type="A" unit="g/mole" value="2.23000000e+02" />
+    </element>
+    <element Z="88" N="226" formula="RA" name="RA">
+        <atom type="A" unit="g/mole" value="2.26000000e+02" />
+    </element>
+    <element Z="89" N="227" formula="AC" name="AC">
+        <atom type="A" unit="g/mole" value="2.27000000e+02" />
+    </element>
+    <element Z="90" N="232" formula="TH" name="TH">
+        <atom type="A" unit="g/mole" value="2.32038100e+02" />
+    </element>
+    <element Z="91" N="231" formula="PA" name="PA">
+        <atom type="A" unit="g/mole" value="2.31035880e+02" />
+    </element>
+    <element Z="92" N="238" formula="U" name="U">
+        <atom type="A" unit="g/mole" value="2.38028900e+02" />
+    </element>
+    <element Z="93" N="237" formula="NP" name="NP">
+        <atom type="A" unit="g/mole" value="2.37000000e+02" />
+    </element>
+    <element Z="94" N="244" formula="PU" name="PU">
+        <atom type="A" unit="g/mole" value="2.44000000e+02" />
+    </element>
+    <element Z="95" N="243" formula="AM" name="AM">
+        <atom type="A" unit="g/mole" value="2.43000000e+02" />
+    </element>
+    <element Z="96" N="247" formula="CM" name="CM">
+        <atom type="A" unit="g/mole" value="2.47000000e+02" />
+    </element>
+    <element Z="97" N="247" formula="BK" name="BK">
+        <atom type="A" unit="g/mole" value="2.47000000e+02" />
+    </element>
+    <element Z="98" N="251" formula="CF" name="CF">
+        <atom type="A" unit="g/mole" value="2.51000000e+02" />
+    </element>
+    <element Z="99" N="252" formula="ES" name="ES">
+        <atom type="A" unit="g/mole" value="2.52000000e+02" />
+    </element>
+    <element Z="100" N="257" formula="FM" name="FM">
+        <atom type="A" unit="g/mole" value="2.57000000e+02" />
+    </element>
+    <element Z="101" N="258" formula="MD" name="MD">
+        <atom type="A" unit="g/mole" value="2.58000000e+02" />
+    </element>
+    <element Z="102" N="259" formula="NO" name="NO">
+        <atom type="A" unit="g/mole" value="2.59000000e+02" />
+    </element>
+    <element Z="103" N="262" formula="LR" name="LR">
+        <atom type="A" unit="g/mole" value="2.62000000e+02" />
+    </element>
+    <element Z="104" N="261" formula="RF" name="RF">
+        <atom type="A" unit="g/mole" value="2.61000000e+02" />
+    </element>
+    <element Z="105" N="262" formula="DB" name="DB">
+        <atom type="A" unit="g/mole" value="2.62000000e+02" />
+    </element>
+    <element Z="106" N="263" formula="SG" name="SG">
+        <atom type="A" unit="g/mole" value="2.63000000e+02" />
+    </element>
+    <element Z="107" N="262" formula="BH" name="BH">
+        <atom type="A" unit="g/mole" value="2.62000000e+02" />
+    </element>
+    <element Z="108" N="265" formula="HS" name="HS">
+        <atom type="A" unit="g/mole" value="2.65000000e+02" />
+    </element>
+    <element Z="109" N="266" formula="MT" name="MT">
+        <atom type="A" unit="g/mole" value="2.66000000e+02" />
+    </element>
+    <element Z="110" N="269" formula="UUN" name="UUN">
+        <atom type="A" unit="g/mole" value="2.69000000e+02" />
+    </element>
+    <element Z="111" N="272" formula="UUU" name="UUU">
+        <atom type="A" unit="g/mole" value="2.72000000e+02" />
+    </element>
+    <element Z="112" N="277" formula="UUB" name="UUB">
+        <atom type="A" unit="g/mole" value="2.77000000e+02" />
+    </element>
+</materials>

--- a/CLIC/compact/CLIC_o3_v09/materials.xml
+++ b/CLIC/compact/CLIC_o3_v09/materials.xml
@@ -1,0 +1,211 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<materials>
+
+    <!--
+     Air by weight from
+     
+     http://www.engineeringtoolbox.com/air-composition-24_212.html
+     -->
+    <material name="Air">
+        <D type="density" unit="g/cm3" value="0.0012"/>
+        <fraction n="0.754" ref="N"/>
+        <fraction n="0.234" ref="O"/>
+        <fraction n="0.012" ref="Ar"/>
+    </material>
+
+    <material name="Vacuum">
+        <D type="density" unit="g/cm3" value="0.0000000001" />
+        <fraction n="0.754" ref="N"/>
+        <fraction n="0.234" ref="O"/>
+        <fraction n="0.012" ref="Ar"/>
+    </material>
+
+    <material formula="Be" name="Beryllium" state="solid" >
+        <D type="density" unit="g/cm3" value="1.848" />
+        <composite n="1" ref="Be" />
+    </material>
+
+    <material name="beam" state="gas">
+        <D unit="g/cm3" value="1.7e-14"/>
+        <fraction n="0.363" ref="H"/>
+        <fraction n="0.363" ref="N"/>
+        <fraction n="0.117" ref="C"/>
+        <fraction n="0.157" ref="O"/>
+    </material>
+
+    <material formula="Fe" name="Iron" state="solid" >
+        <D type="density" unit="g/cm3" value="7.874" />
+        <composite n="1" ref="Fe" />
+    </material>
+
+    <material formula="Si" name="Silicon" state="solid" >
+        <D type="density" unit="g/cm3" value="2.329" />
+        <composite n="1" ref="Si" />
+    </material>
+
+    <material formula="Cu" name="Copper" state="solid" >
+        <D type="density" unit="g/cm3" value="8.960" />
+        <composite n="1" ref="Cu" />
+    </material>
+
+
+    <material formula="C" name="Carbon" state="solid" >
+        <D type="density" unit="g/cm3" value="2" />
+        <composite n="1" ref="C" />
+    </material>
+
+    <material formula="Al" name="Aluminium" state="solid" >
+        <D type="density" unit="g/cm3" value="2.699" />
+        <composite n="1" ref="Al" />
+    </material>
+
+
+
+
+    <material name="Epoxy">
+        <D type="density" value="1.3" unit="g/cm3"/>
+        <composite n="44" ref="H"/>
+        <composite n="15" ref="C"/>
+        <composite n="7" ref="O"/>
+    </material>
+
+    <material name="CarbonFiber">
+        <D type="density" value="1.5" unit="g/cm3"/>
+        <fraction n="0.60" ref="C"/>
+        <fraction n="0.40" ref="Epoxy"/>
+    </material>
+
+    <material name="CarbonFiber_25D">
+        <D type="density" value="0.375" unit="g/cm3"/>
+        <fraction n="0.60" ref="C"/>
+        <fraction n="0.40" ref="Epoxy"/>
+    </material>
+
+    <material name="Kapton">
+        <D value="1.43" unit="g/cm3" />
+        <composite n="22" ref="C"/>
+        <composite n="10" ref="H" />
+        <composite n="2" ref="N" />
+        <composite n="5" ref="O" />
+    </material>
+
+    <material name="Water">
+        <D value="1" unit="g/cm3" />
+        <composite n="2" ref="H" />
+        <composite n="1" ref="O" />
+    </material>
+
+    <material name="Rohacell_IG51">
+        <D type="density" value="0.051" unit="g/cm3"/>
+        <composite n="9" ref="C"/>
+        <composite n="13" ref="H"/>
+        <composite n="2" ref="O"/>
+        <composite n="1" ref="N"/>
+    </material>
+
+    <material name="Allcomp_K9">
+        <D type="density" value="0.22" unit="g/cm3"/>
+        <fraction n="0.60" ref="C"/>
+        <fraction n="0.40" ref="Epoxy"/>
+    </material>
+
+    <material name="TungstenDens24">
+        <D value="17.8" unit="g/cm3"/>
+        <fraction n="0.93" ref="W"/>
+        <fraction n="0.061" ref="Ni"/>
+        <fraction n="0.009" ref="Fe"/>
+    </material>
+
+    <material name="Quartz">
+        <D type="density" value="2.2" unit="g/cm3"/>
+        <composite n="1" ref="Si"/>
+        <composite n="2" ref="O"/>
+    </material>
+
+    <material name="G10">
+        <D type="density" value="1.7" unit="g/cm3"/>
+        <fraction n="0.08" ref="Cl"/>
+        <fraction n="0.773" ref="Quartz"/>
+        <fraction n="0.147" ref="Epoxy"/>
+    </material>
+
+    <material name="GroundOrHVMix" state="solid">
+        <D unit="g/cm3" value="5.19"/>
+        <fraction n="0.003" ref="H"/>
+        <fraction n="0.094" ref="C"/>
+        <fraction n="0.010" ref="N"/>
+        <fraction n="0.028" ref="O"/>
+        <fraction n="0.863" ref="Cu"/>
+    </material>
+
+    <material name="siPCBMix" state="solid">
+        <D unit="g/cm3" value="5.05"/>
+        <fraction n="0.014" ref="Cl"/>
+        <fraction n="0.083" ref="O"/>
+        <fraction n="0.065" ref="Si"/>
+        <fraction n="0.003" ref="H"/>
+        <fraction n="0.014" ref="C"/>
+        <fraction n="0.818" ref="Cu"/>
+    </material>
+
+    <material name="Steel235">
+        <D value="7.85" unit="g/cm3"/>
+        <fraction n="0.998" ref="Fe"/>
+        <fraction n="0.002" ref="C"/>
+    </material>
+
+    <material name="Polystyrene">
+        <D value="1.032" unit="g/cm3"/>
+        <composite n="19" ref="C"/>
+        <composite n="21" ref="H"/>
+    </material>
+
+    <material name="PCB" state="solid">
+        <D unit="g/cm3" value="1.7"/>
+        <fraction n="0.180" ref="Si"/>
+        <fraction n="0.405" ref="O"/>
+        <fraction n="0.278" ref="C"/>
+        <fraction n="0.068" ref="H"/>
+        <fraction n="0.067" ref="Br"/>
+    </material>
+
+    <material name="SiliconOxide">
+        <D type="density" value="2.65" unit="g/cm3"/>
+        <composite n="1" ref="Si"/>
+        <composite n="2" ref="O"/>
+    </material>
+
+    <material name="BoronOxide">
+        <D type="density" value="2.46" unit="g/cm3"/>
+        <composite n="2" ref="B"/>
+        <composite n="3" ref="O"/>
+    </material>
+
+    <material name="SodiumOxide">
+        <D type="density" value="2.65" unit="g/cm3"/>
+        <composite n="2" ref="Na"/>
+        <composite n="1" ref="O"/>
+    </material>
+
+    <material name="AluminiumOxide">
+        <D type="density" value="3.89" unit="g/cm3"/>
+        <composite n="2" ref="Al"/>
+        <composite n="3" ref="O"/>
+    </material>
+
+    <material name="PyrexGlass">
+        <D type="density" value="2.23" unit="g/cm3"/>
+        <fraction n="0.806" ref="SiliconOxide"/>
+        <fraction n="0.130" ref="BoronOxide"/>
+        <fraction n="0.040" ref="SodiumOxide"/>
+        <fraction n="0.023" ref="AluminiumOxide"/>
+    </material>
+
+    <material name="RPCGasDefault" state="gas">
+        <D type="density" value="0.0037" unit="g/cm3"/>
+        <composite n="209" ref="C"/>
+        <composite n="239" ref="H"/>
+        <composite n="381" ref="F"/>
+    </material>
+
+</materials>

--- a/CLIC/compact/CLIC_o3_v09/materials.xml
+++ b/CLIC/compact/CLIC_o3_v09/materials.xml
@@ -208,4 +208,10 @@
         <composite n="381" ref="F"/>
     </material>
 
+    <material name="G4_POLYSTYRENE">
+        <D type="density" value="1.06" unit="g/cm3"/>
+        <fraction n="0.077418" ref="H"/>
+        <fraction n="0.922582" ref="C"/>
+    </material>
+
 </materials>

--- a/CLIC/compact/CLIC_o3_v09/materials.xml
+++ b/CLIC/compact/CLIC_o3_v09/materials.xml
@@ -154,12 +154,6 @@
         <fraction n="0.002" ref="C"/>
     </material>
 
-    <material name="Polystyrene">
-        <D value="1.032" unit="g/cm3"/>
-        <composite n="19" ref="C"/>
-        <composite n="21" ref="H"/>
-    </material>
-
     <material name="PCB" state="solid">
         <D unit="g/cm3" value="1.7"/>
         <fraction n="0.180" ref="Si"/>

--- a/lcgeoTests/CMakeLists.txt
+++ b/lcgeoTests/CMakeLists.txt
@@ -75,7 +75,12 @@ SET_TESTS_PROPERTIES( t_${test_name} PROPERTIES FAIL_REGULAR_EXPRESSION  "Except
 
 SET( test_name "test_CLIC_o3_v08" )
 ADD_TEST( t_${test_name} "${CMAKE_INSTALL_PREFIX}/bin/run_test_${PackageName}.sh"
-        ddsim --compactFile=${CMAKE_SOURCE_DIR}/CLIC/compact/CLIC_o3_v08/CLIC_o3_v08.xml --runType=batch -G -N=1 --outputFile=testCLIC_o3_v07.slcio )
+        ddsim --compactFile=${CMAKE_SOURCE_DIR}/CLIC/compact/CLIC_o3_v08/CLIC_o3_v08.xml --runType=batch -G -N=1 --outputFile=testCLIC_o3_v08.slcio )
+SET_TESTS_PROPERTIES( t_${test_name} PROPERTIES FAIL_REGULAR_EXPRESSION  "Exception;EXCEPTION;ERROR;Error" )
+
+SET( test_name "test_CLIC_o3_v09" )
+ADD_TEST( t_${test_name} "${CMAKE_INSTALL_PREFIX}/bin/run_test_${PackageName}.sh"
+        ddsim --compactFile=${CMAKE_SOURCE_DIR}/CLIC/compact/CLIC_o3_v09/CLIC_o3_v09.xml --runType=batch -G -N=1 --outputFile=testCLIC_o3_v09.slcio )
 SET_TESTS_PROPERTIES( t_${test_name} PROPERTIES FAIL_REGULAR_EXPRESSION  "Exception;EXCEPTION;ERROR;Error" )
 
 SET( test_name "test_steeringFile" )
@@ -101,4 +106,6 @@ ADD_TEST( t_SensThickness_Clic_o3_v7 "${CMAKE_INSTALL_PREFIX}/bin/run_test_${Pac
           ${CMAKE_INSTALL_PREFIX}/bin/TestSensThickness ${CMAKE_SOURCE_DIR}/CLIC/compact/CLIC_o3_v07/CLIC_o3_v07.xml 300 50 )
 ADD_TEST( t_SensThickness_Clic_o3_v8 "${CMAKE_INSTALL_PREFIX}/bin/run_test_${PackageName}.sh"
           ${CMAKE_INSTALL_PREFIX}/bin/TestSensThickness ${CMAKE_SOURCE_DIR}/CLIC/compact/CLIC_o3_v08/CLIC_o3_v08.xml 100 50 )
+ADD_TEST( t_SensThickness_Clic_o3_v9 "${CMAKE_INSTALL_PREFIX}/bin/run_test_${PackageName}.sh"
+        ${CMAKE_INSTALL_PREFIX}/bin/TestSensThickness ${CMAKE_SOURCE_DIR}/CLIC/compact/CLIC_o3_v09/CLIC_o3_v09.xml 100 50 )
 


### PR DESCRIPTION
BEGINRELEASENOTES
- New model of CLIC detector CLIC_o3_v09, the only change to CLIC_o3_v08 is the Polystyrene -> G4_POLYSTYRENE in the HCal barrel and endcap. This changes the density of the scintilator from 1.032 to 1.06 g/cm3.

ENDRELEASENOTES