### PR TITLE
Fix envelope

### DIFF
--- a/ILD/compact/ILD_common_v01/BeamCal08.xml
+++ b/ILD/compact/ILD_common_v01/BeamCal08.xml
@@ -22,7 +22,7 @@
 		     rmax="BeamCal_outer_radius + env_safety" 
 		     dz="BeamCal_max_z/COS_halfCrossingAngle + env_safety"/>
 	      <!-- Incoming beampipe cutout -->
-	      <shape type="Tube" rmin="0.0" rmax="BeamCal_tubeIncoming_radius - env_safety" 
+	      <shape type="Tube" rmin="0.0" rmax="BCal_TubeIncomingRadius + BCal_TubeIncomingClearance - env_safety"
 		     dz="BeamCal_max_z*2.0 +env_safety"/>
 	      <rotation x="0" y="ILC_Main_Crossing_Angle" z="0"/>
 	      <position x="0" y="0" z="0"/>
@@ -51,7 +51,7 @@
 		     rmax="BeamCal_outer_radius + env_safety" 
 		     dz="BeamCal_max_z/COS_halfCrossingAngle + env_safety"/>
 	      <!-- Incoming beampipe cutout -->
-	      <shape type="Tube" rmin="0.0" rmax="BeamCal_tubeIncoming_radius - env_safety" 
+	      <shape type="Tube" rmin="0.0" rmax="BCal_TubeIncomingRadius + BCal_TubeIncomingClearance - env_safety"
 		     dz="BeamCal_max_z*2.0 + env_safety"/>
 	      <rotation x="0" y="-ILC_Main_Crossing_Angle" z="0"/>
 	      <position x="0" y="0" z="0"/>
@@ -83,7 +83,7 @@
 
   <parameter crossingangle="ILC_Main_Crossing_Angle"
 	     cutoutspanningangle="BCal_cutoutSpanning"
-	     incomingbeampiperadius="BCal_TubeIncomingRadius"
+	     incomingbeampiperadius="BCal_TubeIncomingRadius + BCal_TubeIncomingClearance"
 	     />
   
   <dimensions inner_r = "BCal_rInner"

--- a/ILD/compact/ILD_common_v01/BeamCal08.xml
+++ b/ILD/compact/ILD_common_v01/BeamCal08.xml
@@ -12,35 +12,61 @@
 	<shape type="Box" dx="BeamCal_outer_radius*2.0" dy="BeamCal_outer_radius*2.0" dz="BeamCal_max_z*2.0"/>
 
 	<shape type="BooleanShape" operation="Union" material="Air">
+
 	  <!-- -z -->
 	  <shape type="BooleanShape" operation="Subtraction" material="Air">
+
 	    <shape type="BooleanShape" operation="Subtraction" material="Air">
+	      <!-- BeamCal -->
 	      <shape type="Tube" rmin="BeamCal_inner_radius - env_safety" 
 		     rmax="BeamCal_outer_radius + env_safety" 
 		     dz="BeamCal_max_z/COS_halfCrossingAngle + env_safety"/>
+	      <!-- Incoming beampipe cutout -->
 	      <shape type="Tube" rmin="0.0" rmax="BeamCal_tubeIncoming_radius - env_safety" 
 		     dz="BeamCal_max_z*2.0 +env_safety"/>
 	      <rotation x="0" y="ILC_Main_Crossing_Angle" z="0"/>
 	      <position x="0" y="0" z="0"/>
 	    </shape>
-	    <shape type="Tube" rmin="0" rmax="BeamCal_outer_radius + 1.5*env_safety"
-		   dz="BeamCal_min_z/COS_halfCrossingAngle+BeamCal_thickness - env_safety"/>
+
+	    <!-- Volume to subtract from center to z_min -->
+	    <shape type="BooleanShape" operation="Union" material="Air">
+	      <!-- Tungsten radius -->
+	      <shape type="Tube" rmin="BCal_rGraphite + 1*env_safety" rmax="BeamCal_outer_radius + 1.5*env_safety"
+		     dz="BeamCal_min_z/COS_halfCrossingAngle+BeamCal_thickness + BCal_dGraphite/COS_halfCrossingAngle - env_safety"/>
+	      <!-- Graphite radius -->
+	      <shape type="Tube" rmin="0" rmax="BCal_rGraphite  + 1.5*env_safety"
+		     dz="BeamCal_min_z/COS_halfCrossingAngle+BeamCal_thickness - env_safety"/>
+	      <position x="0" y="0" z="0"/>
+	    </shape>
+
 	    <position x="0" y="0" z="BeamCal_thickness"/>
 	  </shape>
-  
+
 	  <!-- +z -->
 	  <shape type="BooleanShape" operation="Subtraction" material="Air">
+
 	    <shape type="BooleanShape" operation="Subtraction" material="Air">
+	      <!-- BeamCal -->
 	      <shape type="Tube" rmin="BeamCal_inner_radius - env_safety" 
 		     rmax="BeamCal_outer_radius + env_safety" 
 		     dz="BeamCal_max_z/COS_halfCrossingAngle + env_safety"/>
+	      <!-- Incoming beampipe cutout -->
 	      <shape type="Tube" rmin="0.0" rmax="BeamCal_tubeIncoming_radius - env_safety" 
 		     dz="BeamCal_max_z*2.0 + env_safety"/>
 	      <rotation x="0" y="-ILC_Main_Crossing_Angle" z="0"/>
 	      <position x="0" y="0" z="0"/>
 	    </shape>
-	    <shape type="Tube" rmin="0" rmax="BeamCal_outer_radius + 1.5*env_safety"
-		   dz="BeamCal_min_z/COS_halfCrossingAngle+BeamCal_thickness - env_safety"/>
+
+	    <!-- Volume to subtract from center to z_min -->
+	    <shape type="BooleanShape" operation="Union" material="Air">
+	      <!-- Tungsten radius -->
+	      <shape type="Tube" rmin="BCal_rGraphite + 1*env_safety" rmax="BeamCal_outer_radius + 1.5*env_safety"
+		     dz="BeamCal_min_z/COS_halfCrossingAngle+BeamCal_thickness + BCal_dGraphite/COS_halfCrossingAngle - env_safety"/>
+	      <!-- Graphite radius -->
+	      <shape type="Tube" rmin="0" rmax="BCal_rGraphite  + 1.5*env_safety"
+		     dz="BeamCal_min_z/COS_halfCrossingAngle+BeamCal_thickness - env_safety"/>
+	      <position x="0" y="0" z="0"/>
+	    </shape>
 	    <position x="0" y="0" z="-BeamCal_thickness"/>
 	  </shape>
 

--- a/ILD/compact/ILD_common_v01/envelope_defs.xml
+++ b/ILD/compact/ILD_common_v01/envelope_defs.xml
@@ -151,7 +151,6 @@
   <constant name="BeamCal_outer_radius"          value="BCal_rOuter"/>
   <constant name="BeamCal_min_z"                 value="LHcal_zend + LHcal_BCal_clearance - top_BCal_dGraphite"/>
   <constant name="BeamCal_max_z"                 value="BeamCal_min_z + BeamCal_thickness"/>
-  <constant name="BeamCal_tubeIncoming_radius"   value="top_BeamCal_tubeIncoming_radius"/>
 
 
   <constant name="Lcal_inner_radius" value="top_Lcal_inner_radius"/>

--- a/ILD/compact/ILD_common_v01/fcal_defs.xml
+++ b/ILD/compact/ILD_common_v01/fcal_defs.xml
@@ -40,7 +40,7 @@
   <constant name="BCal_dAbsorber" value="3.5*mm"/>
   <constant name="BCal_dGraphite" value="top_BCal_dGraphite"/>
   <constant name="BCal_rGraphite" value="LHCal_inner_radius-10.0*mm"/>
-  <constant name="BCal_nLayers" value="30"/>
+  <constant name="BCal_nLayers" value="top_BCal_nLayers"/>
   <constant name="BeamCal_cell_size" value="3.5*mm"/>
 
 

--- a/ILD/compact/ILD_common_v01/fcal_defs.xml
+++ b/ILD/compact/ILD_common_v01/fcal_defs.xml
@@ -36,7 +36,8 @@
 
   <constant name="BCal_cutoutSpanning" value="45*degree"/>
   <constant name="BCal_SpanningPhi" value="360*degree-BCal_cutoutSpanning"/>
-  <constant name="BCal_TubeIncomingRadius" value="15*mm"/>
+  <constant name="BCal_TubeIncomingRadius" value="top_BeamCal_tubeIncoming_radius"/>
+  <constant name="BCal_TubeIncomingClearance" value="top_BeamCal_tubeIncoming_clearance"/>
   <constant name="BCal_dAbsorber" value="3.5*mm"/>
   <constant name="BCal_dGraphite" value="top_BCal_dGraphite"/>
   <constant name="BCal_rGraphite" value="LHCal_inner_radius-10.0*mm"/>

--- a/ILD/compact/ILD_common_v01/top_defs_common_v01.xml
+++ b/ILD/compact/ILD_common_v01/top_defs_common_v01.xml
@@ -101,6 +101,7 @@ subdetector-specific ones are in separate files
   <constant name="top_BCal_dGraphite"                value="80*mm"/>
   <constant name="top_BeamCal_thickness"             value="top_BCal_dGraphite + top_BCal_nLayers*top_BeamCal_layerThickness"/>
   <constant name="top_BeamCal_tubeIncoming_radius"   value="15.0*mm"/>
+  <constant name="top_BeamCal_tubeIncoming_clearance"   value="1.0*mm"/> <!-- Allow some clearance -->
   <constant name="BCal_rInner" value="17.8*mm"/>
   <constant name="BCal_rOuter" value="140*mm"/>
 

--- a/ILD/compact/ILD_common_v01/top_defs_common_v01.xml
+++ b/ILD/compact/ILD_common_v01/top_defs_common_v01.xml
@@ -96,11 +96,13 @@ subdetector-specific ones are in separate files
   <constant name="LHcal_BCal_clearance" value="35*mm"/>
 
   <!-- beamcal -->
-  <constant name="top_BeamCal_thickness"             value="220.0024*mm"/>
+  <constant name="top_BCal_nLayers"                  value="30"/>
+  <constant name="top_BeamCal_layerThickness"        value="4.0008*mm"/>
+  <constant name="top_BCal_dGraphite"                value="80*mm"/>
+  <constant name="top_BeamCal_thickness"             value="top_BCal_dGraphite + top_BCal_nLayers*top_BeamCal_layerThickness"/>
   <constant name="top_BeamCal_tubeIncoming_radius"   value="15.0*mm"/>
   <constant name="BCal_rInner" value="17.8*mm"/>
   <constant name="BCal_rOuter" value="140*mm"/>
-  <constant name="top_BCal_dGraphite" value="80*mm"/>
 
 
   <!-- the beam tube -->

--- a/ILD/compact/extra_stuff/BeamCalOnly2.xml
+++ b/ILD/compact/extra_stuff/BeamCalOnly2.xml
@@ -127,12 +127,12 @@
     <vis name="FTDCylVis"       alpha="0.45" r="0.2"  g="0.9" b="0.98" showDaughters="true" visible="true"/>
     <vis name="FTDCablesVis"    alpha="1.0"  r="0.0"  g="0.9" b="0.0"  showDaughters="true" visible="true"/>
     
-    <vis name="MyBeamCalVis"  alpha="0.5"  r="1.0" g="1.0"  b="1.0" showDaughters="true"  visible="false"/>
-    <vis name="LayerVis1"     alpha="0.1"  r="1.0" g="0.0"  b="0.0" showDaughters="true"  visible="true"/>
-    <vis name="BCLayerVis1"   alpha="0.1"  r="1.0" g="0.0"  b="0.0" showDaughters="true"  visible="true"/>
-    <vis name="BCLayerVis2"   alpha="0.1"  r="0.0" g="1.0"  b="0.0" showDaughters="true"  visible="true"/>
-    <vis name="BCLayerVis3"   alpha="0.1"  r="0.0" g="0.0"  b="1.0" showDaughters="true"  visible="true"/>
-    <vis name="BCLayerVis4"   alpha="0.1"  r="1.0" g="0.0"  b="1.0" showDaughters="true"  visible="true"/>
+    <vis name="MyBeamCalVis"  alpha="1.0"  r="1.0" g="1.0"  b="1.0" showDaughters="true"  visible="false"/>
+    <vis name="LayerVis1"     alpha="0.9"  r="0.1" g="0.0"  b="0.0" showDaughters="true"  visible="true"/>
+    <vis name="BCLayerVis1"   alpha="1.0"  r="1.0" g="0.0"  b="0.0" showDaughters="true"  visible="true"/>
+    <vis name="BCLayerVis2"   alpha="1.0"  r="0.0" g="1.0"  b="0.0" showDaughters="true"  visible="true"/>
+    <vis name="BCLayerVis3"   alpha="1.0"  r="0.0" g="0.0"  b="1.0" showDaughters="true"  visible="true"/>
+    <vis name="BCLayerVis4"   alpha="1.0"  r="1.0" g="0.0"  b="1.0" showDaughters="true"  visible="true"/>
 
     <vis name="ILD_FCALVis" alpha="1.0" r="0.67" g="0.66"  b="0.67" showDaughters="true"  visible="true"/>
 


### PR DESCRIPTION

BEGINRELEASENOTES

- Corrected BeamCal envelope for the new dimensions of the graphite absorber.
- Consolidated some BeamCal parameters. Removed a redundant parameter for the incoming beam pipe radius.
- Added clearance between BeamCal and the incoming beam pipe.

ENDRELEASENOTES