### PR TITLE
enforce definition of tracker volume in ddsim

### DIFF
--- a/DDSim/DDSim/DD4hepSimulation.py
+++ b/DDSim/DDSim/DD4hepSimulation.py
@@ -76,7 +76,6 @@ class DD4hepSimulation(object):
     self._errorMessages = []
     self._dumpParameter = False
     self._dumpSteeringFile = False
-    self.enableDetailedHitsAndParticleInfo = False
 
     ## objects for extended configuration option
     self.output = Output()
@@ -397,25 +396,9 @@ class DD4hepSimulation(object):
     part.enableUI()
 
 
-    if self.enableDetailedHitsAndParticleInfo:
-      #---- debug code from Markus for detailed dumps of hits and MC-truth assignement ------
-      # Add the particle dumper to associate the MC truth
-      evt = DDG4.EventAction(kernel,"Geant4ParticleDumpAction/ParticleDump")
-      kernel.eventAction().adopt(evt)
-      evt.enableUI()
-      # Add the hit dumper BEFORE any hit truth is fixed
-      evt = DDG4.EventAction(kernel,"Geant4HitDumpAction/RawDump")
-      kernel.eventAction().adopt(evt)
-      evt.enableUI()
-      # Add the hit dumper to the event action sequence
-      evt = DDG4.EventAction(kernel,"Geant4HitTruthHandler/HitTruth")
-      kernel.eventAction().adopt(evt)
-      evt.enableUI()
-      # Add the hit dumper AFTER any hit truth is fixed. We should see the reduced track references
-      evt = DDG4.EventAction(kernel,"Geant4HitDumpAction/HitDump")
-      kernel.eventAction().adopt(evt)
-      evt.enableUI()
-      
+    if self.part.enableDetailedHitsAndParticleInfo:
+      self.part.setDumpDetailedParticleInfo( kernel, DDG4 )
+
     #----------------------------------
 
 

--- a/DDSim/DDSim/DD4hepSimulation.py
+++ b/DDSim/DDSim/DD4hepSimulation.py
@@ -76,6 +76,7 @@ class DD4hepSimulation(object):
     self._errorMessages = []
     self._dumpParameter = False
     self._dumpSteeringFile = False
+    self.enableDetailedHitsAndParticleInfo = False
 
     ## objects for extended configuration option
     self.output = Output()
@@ -394,13 +395,48 @@ class DD4hepSimulation(object):
     part.MinDistToParentVertex= self.part.minDistToParentVertex
     part.OutputLevel = self.output.part
     part.enableUI()
+
+
+    if self.enableDetailedHitsAndParticleInfo:
+      #---- debug code from Markus for detailed dumps of hits and MC-truth assignement ------
+      # Add the particle dumper to associate the MC truth
+      evt = DDG4.EventAction(kernel,"Geant4ParticleDumpAction/ParticleDump")
+      kernel.eventAction().adopt(evt)
+      evt.enableUI()
+      # Add the hit dumper BEFORE any hit truth is fixed
+      evt = DDG4.EventAction(kernel,"Geant4HitDumpAction/RawDump")
+      kernel.eventAction().adopt(evt)
+      evt.enableUI()
+      # Add the hit dumper to the event action sequence
+      evt = DDG4.EventAction(kernel,"Geant4HitTruthHandler/HitTruth")
+      kernel.eventAction().adopt(evt)
+      evt.enableUI()
+      # Add the hit dumper AFTER any hit truth is fixed. We should see the reduced track references
+      evt = DDG4.EventAction(kernel,"Geant4HitDumpAction/HitDump")
+      kernel.eventAction().adopt(evt)
+      evt.enableUI()
+      
+    #----------------------------------
+
+
+
+
     user = DDG4.Action(kernel,"Geant4TCUserParticleHandler/UserParticleHandler")
     try:
       user.TrackingVolume_Zmax = DDG4.tracker_region_zmax
       user.TrackingVolume_Rmax = DDG4.tracker_region_rmax
-    except AttributeError as e:
-      print "No Attribute: ", str(e)
 
+      print " *** definition of tracker region *** "
+      print "    tracker_region_zmax = " ,  user.TrackingVolume_Zmax
+      print "    tracker_region_rmax = " ,  user.TrackingVolume_Rmax
+      print " ************************************ "
+
+    except AttributeError as e:
+      print "ERROR - attribute of tracker region missing in detector model   ", str(e)
+      print "   make sure to specify the global constants tracker_region_zmax and tracker_region_rmax "
+      print "   this is needed for the MC-truth link of created sim-hits  !  "
+      exit(1)
+      
     #  user.enableUI()
     part.adopt(user)
 

--- a/DDSim/DDSim/Helper/ParticleHandler.py
+++ b/DDSim/DDSim/Helper/ParticleHandler.py
@@ -14,7 +14,6 @@ class ParticleHandler( ConfigHelper ):
     self._printStartTracking = False
     self._minDistToParentVertex = 2.2e-14*mm
     self._enableDetailedHitsAndParticleInfo = False
-    self._enableDetailedHitsAndParticleInfo_HELP = "print out lots of info about MCHistory"
 
   @property
   def enableDetailedHitsAndParticleInfo(self):

--- a/DDSim/DDSim/Helper/ParticleHandler.py
+++ b/DDSim/DDSim/Helper/ParticleHandler.py
@@ -18,7 +18,7 @@ class ParticleHandler( ConfigHelper ):
 
   @property
   def enableDetailedHitsAndParticleInfo(self):
-    """Enamble lots of printout on simulated hits and MC-truth inforamation"""
+    """Enable lots of printout on simulated hits and MC-truth information"""
     return self._enableDetailedHitsAndParticleInfo
 
   @enableDetailedHitsAndParticleInfo.setter

--- a/DDSim/DDSim/Helper/ParticleHandler.py
+++ b/DDSim/DDSim/Helper/ParticleHandler.py
@@ -13,6 +13,18 @@ class ParticleHandler( ConfigHelper ):
     self._printEndTracking = False
     self._printStartTracking = False
     self._minDistToParentVertex = 2.2e-14*mm
+    self._enableDetailedHitsAndParticleInfo = False
+    self._enableDetailedHitsAndParticleInfo_HELP = "print out lots of info about MCHistory"
+
+  @property
+  def enableDetailedHitsAndParticleInfo(self):
+    """Enamble lots of printout on simulated hits and MC-truth inforamation"""
+    return self._enableDetailedHitsAndParticleInfo
+
+  @enableDetailedHitsAndParticleInfo.setter
+  def enableDetailedHitsAndParticleInfo( self, val ):
+    self._enableDetailedHitsAndParticleInfo = val
+
 
   @property
   def minDistToParentVertex( self ):
@@ -63,3 +75,22 @@ class ParticleHandler( ConfigHelper ):
   @printEndTracking.setter
   def printEndTracking( self, val ):
     self._printEndTracking = val
+
+  def setDumpDetailedParticleInfo( self, kernel, DDG4 ):
+    #---- debug code from Markus for detailed dumps of hits and MC-truth assignement ------
+    # Add the particle dumper to associate the MC truth
+    evt = DDG4.EventAction(kernel,"Geant4ParticleDumpAction/ParticleDump")
+    kernel.eventAction().adopt(evt)
+    evt.enableUI()
+    # Add the hit dumper BEFORE any hit truth is fixed
+    evt = DDG4.EventAction(kernel,"Geant4HitDumpAction/RawDump")
+    kernel.eventAction().adopt(evt)
+    evt.enableUI()
+    # Add the hit dumper to the event action sequence
+    evt = DDG4.EventAction(kernel,"Geant4HitTruthHandler/HitTruth")
+    kernel.eventAction().adopt(evt)
+    evt.enableUI()
+    # Add the hit dumper AFTER any hit truth is fixed. We should see the reduced track references
+    evt = DDG4.EventAction(kernel,"Geant4HitDumpAction/HitDump")
+    kernel.eventAction().adopt(evt)
+    evt.enableUI()

--- a/SiD/compact/SiD_o1_v01/SiD_o1_v01.xml
+++ b/SiD/compact/SiD_o1_v01/SiD_o1_v01.xml
@@ -117,6 +117,11 @@
     <constant name="SolenoidEndcapAirgapThickness" value="19.0*cm"/>
     <constant name="Solenoid_Coil_half_length" value="Solenoid_half_length-SolenoidEndcapCryostatThickness-SolenoidEndcapAirgapThickness"/>
     <constant name="Solenoid_outer_radius" value="3429*mm"/>
+
+
+    <constant name="tracker_region_rmax" value="0.5*(SiTracker_outer_radius+ECalBarrel_rmin)" />  
+    <constant name="tracker_region_zmax" value="ECalBarrel_half_length" />
+
   </define>
 
   <limits>


### PR DESCRIPTION
 - add option to enable debug output actions for hits from Markus



BEGINRELEASENOTES
- enforce definition of tracker volume in ddsim - models need to define:
        - tracker_region_zmax
        - tracker_region_rmax
- this is needed to ensure that the MCTruth link for hits works correctly
- allow to enable additional DebugDumpActions with *enableDetailedHitsAndParticleInfo*
ENDRELEASENOTES