### PR TITLE
Use MutliCollections configuration to split SiEcal into preShower in ILD_o1_v05

### DIFF
--- a/ILD/compact/ILD_o1_v05/ILD_o1_v05.xml
+++ b/ILD/compact/ILD_o1_v05/ILD_o1_v05.xml
@@ -482,15 +482,27 @@
 
 	<readout name="EcalBarrelCollection">
 	  <segmentation type="WaferGridXY" grid_size_x="Ecal_cells_size" grid_size_y="Ecal_cells_size" offset_x="Ecal_cells_size/2.0"  offset_y="Ecal_cells_size/2.0" identifier_groupMGWafer="layer"/>
+	  <hits_collections>
+            <hits_collection name="EcalBarrelCollection_preShower"  key="layer" key_value="0x0"/>
+            <hits_collection name="EcalBarrelCollection" key="layer" key_min="0x1"   key_max="0xFF"/>
+	  </hits_collections>
 	  <id>system:5,module:3,stave:4,tower:3,layer:6,wafer:6,x:32:-16,y:-16</id>
 	</readout>
 	<readout name="EcalEndcapsCollection">
 	  <segmentation type="WaferGridXY" grid_size_x="Ecal_cells_size" grid_size_y="Ecal_cells_size" offset_x="Ecal_cells_size/2.0"  offset_y="Ecal_cells_size/2.0" identifier_groupMGWafer="tower"/>
+	  <hits_collections>
+            <hits_collection name="EcalEndcapsCollection_preShower"  key="layer" key_value="0x0"/>
+            <hits_collection name="EcalEndcapsCollection" key="layer" key_min="0x1"   key_max="0xFF"/>
+	  </hits_collections>
 	  <id>system:5,module:3,stave:3,tower:5,layer:6,wafer:6,x:32:-16,y:-16</id>
 	</readout>
 
 	<readout name="EcalEndcapRingCollection">
 	  <segmentation type="CartesianGridXY" grid_size_x="Ecal_cells_size" grid_size_y="Ecal_cells_size"/>
+	  <hits_collections>
+            <hits_collection name="EcalEndcapRingCollection_preShower"  key="layer" key_value="0x0"/>
+            <hits_collection name="EcalEndcapRingCollection" key="layer" key_min="0x1"   key_max="0xFF"/>
+	  </hits_collections>
 	  <id>system:5,module:3,stave:4,tower:3,layer:6,x:32:-16,y:-16</id>
 	</readout>
 


### PR DESCRIPTION
https://github.com/iLCSoft/ILDConfig/blob/master/StandardConfig/lcgeo_current/ddsim_steer.py#L22
After this update, the line 22 is no necessary, may be remove.
Without line 22, "ddsim_steer.py" will be identical for all ILD modules. 


BEGINRELEASENOTES
- Use MutliCollections configuration to split SiEcal into preShower inside ILD_o1_v05.
   - "CaloPreShowerSDAction" is not necessary in "ddsim_steer.py"
   - The same  "ddsim_steer.py" in ILDConfig will work for all ILD modules.

ENDRELEASENOTES