### PR TITLE
DDSim: Add printout of execution time at the end of simulation

### DIFF
--- a/DDSim/DDSim/DD4hepSimulation.py
+++ b/DDSim/DDSim/DD4hepSimulation.py
@@ -481,6 +481,11 @@ class DD4hepSimulation(object):
     kernel.run()
     kernel.terminate()
 
+    userTime, sysTime,_cuTime, _csTime, _elapsedTime = os.times()
+    if self.printLevel <= 3:
+      print "DDSim            INFO  Execution Time: %3.2f s (User), %3.2f s (System)"% (userTime, sysTime)
+
+
   def __setMagneticFieldOptions(self, simple):
     """ create and configure the magnetic tracking setup """
     field = simple.addConfig('Geant4FieldTrackingSetupAction/MagFieldTrackingSetup')


### PR DESCRIPTION
whitespace to emulate the output from DD4hep
Solves #56
```
...
Geant4Kernel     INFO  ++ Terminate Geant4 and delete associated actions.
DDSim            INFO  Execution Time: 10.28 s (User), 0.29 s (System)
```


BEGINRELEASENOTES
- DDSim: Added printout of execution time at the end of simulation

ENDRELEASENOTES