### PR TITLE
Update beampipe

### DIFF
--- a/ILD/compact/ILD_common_v01/Beampipe_o1_v01_01.xml
+++ b/ILD/compact/ILD_common_v01/Beampipe_o1_v01_01.xml
@@ -19,7 +19,7 @@
   <section type ="Center"
            start="TUBE_firstCone_zStart"                               end="TUBE_firstCone_zEnd"
            rMin1="TUBE_firstCone_rInnerStart"                          rMin2="TUBE_firstCone_rInnerEnd"
-           rMax1="TUBE_firstCone_rInnerStart+TUBE_firstCone_thickness" rMax2="TUBE_firstCone_rInnerEnd+TUBE_firstCone_thickness"
+           rMax1="TUBE_firstCone_rInnerStart+TUBE_firstCone_RadThickness" rMax2="TUBE_firstCone_rInnerEnd+TUBE_firstCone_RadThickness"
            material="G4_Be" name="IPInnerBulge" />
 
   <!-- second cylinder -->
@@ -33,25 +33,25 @@
   <section type ="Center" 
            start="TUBE_secondCone_part1_zStart"                                end="TUBE_secondCone_part1_zEnd"
            rMin1="TUBE_secondCone_part1_rInnerStart"                             rMin2="TUBE_secondCone_part1_rInnerEnd"
-           rMax1="TUBE_secondCone_part1_rInnerStart+TUBE_secondCone_part1_thickness"  rMax2="TUBE_secondCone_part1_rInnerEnd+TUBE_secondCone_part1_thickness"
+           rMax1="TUBE_secondCone_part1_rInnerStart+TUBE_secondCone_part1_RadThickness"  rMax2="TUBE_secondCone_part1_rInnerEnd+TUBE_secondCone_part1_RadThickness"
            material="G4_Be" name="IPOuterTube" />
 
   <section type ="Center" 
            start="TUBE_secondCone_part2_zStart"                                end="TUBE_secondCone_part2_zEnd"
            rMin1="TUBE_secondCone_part2_rInnerStart"                             rMin2="TUBE_secondCone_part2_rInnerEnd"
-           rMax1="TUBE_secondCone_part2_rInnerStart+TUBE_secondCone_part2_thickness"  rMax2="TUBE_secondCone_part2_rInnerEnd+TUBE_secondCone_part2_thickness"
+           rMax1="TUBE_secondCone_part2_rInnerStart+TUBE_secondCone_part2_RadThickness"  rMax2="TUBE_secondCone_part2_rInnerEnd+TUBE_secondCone_part2_RadThickness"
            material="G4_Be" name="IPOuterTube" />
 
   <section type ="Center" 
            start="TUBE_secondCone_part3_zStart"                                end="TUBE_secondCone_part3_zEnd"
            rMin1="TUBE_secondCone_part3_rInnerStart"                             rMin2="TUBE_secondCone_part3_rInnerEnd"
-           rMax1="TUBE_secondCone_part3_rInnerStart+TUBE_secondCone_part3_thickness"  rMax2="TUBE_secondCone_part3_rInnerEnd+TUBE_secondCone_part3_thickness"
+           rMax1="TUBE_secondCone_part3_rInnerStart+TUBE_secondCone_part3_RadThickness"  rMax2="TUBE_secondCone_part3_rInnerEnd+TUBE_secondCone_part3_RadThickness"
            material="G4_Be" name="IPOuterTube" />
 
   <section type ="Center" 
            start="TUBE_secondCone_part4_zStart"                                end="TUBE_secondCone_part4_zEnd"
            rMin1="TUBE_secondCone_part4_rInnerStart"                             rMin2="TUBE_secondCone_part4_rInnerEnd"
-           rMax1="TUBE_secondCone_part4_rInnerStart+TUBE_secondCone_part4_thickness"  rMax2="TUBE_secondCone_part4_rInnerEnd+TUBE_secondCone_part4_thickness"
+           rMax1="TUBE_secondCone_part4_rInnerStart+TUBE_secondCone_part4_RadThickness"  rMax2="TUBE_secondCone_part4_rInnerEnd+TUBE_secondCone_part4_RadThickness"
            material="G4_Be" name="IPOuterTube" />
 
 

--- a/ILD/compact/ILD_common_v01/Beampipe_o1_v01_01.xml
+++ b/ILD/compact/ILD_common_v01/Beampipe_o1_v01_01.xml
@@ -34,25 +34,25 @@
            start="TUBE_secondCone_part1_zStart"                                end="TUBE_secondCone_part1_zEnd"
            rMin1="TUBE_secondCone_part1_rInnerStart"                             rMin2="TUBE_secondCone_part1_rInnerEnd"
            rMax1="TUBE_secondCone_part1_rInnerStart+TUBE_secondCone_part1_RadThickness"  rMax2="TUBE_secondCone_part1_rInnerEnd+TUBE_secondCone_part1_RadThickness"
-           material="G4_Be" name="IPOuterTube" />
+           material="BeampipeBeCableMix" name="IPOuterTube" />
 
   <section type ="Center" 
            start="TUBE_secondCone_part2_zStart"                                end="TUBE_secondCone_part2_zEnd"
            rMin1="TUBE_secondCone_part2_rInnerStart"                             rMin2="TUBE_secondCone_part2_rInnerEnd"
            rMax1="TUBE_secondCone_part2_rInnerStart+TUBE_secondCone_part2_RadThickness"  rMax2="TUBE_secondCone_part2_rInnerEnd+TUBE_secondCone_part2_RadThickness"
-           material="G4_Be" name="IPOuterTube" />
+           material="BeampipeBeCableMix" name="IPOuterTube" />
 
   <section type ="Center" 
            start="TUBE_secondCone_part3_zStart"                                end="TUBE_secondCone_part3_zEnd"
            rMin1="TUBE_secondCone_part3_rInnerStart"                             rMin2="TUBE_secondCone_part3_rInnerEnd"
            rMax1="TUBE_secondCone_part3_rInnerStart+TUBE_secondCone_part3_RadThickness"  rMax2="TUBE_secondCone_part3_rInnerEnd+TUBE_secondCone_part3_RadThickness"
-           material="G4_Be" name="IPOuterTube" />
+           material="BeampipeBeCableMix" name="IPOuterTube" />
 
   <section type ="Center" 
            start="TUBE_secondCone_part4_zStart"                                end="TUBE_secondCone_part4_zEnd"
            rMin1="TUBE_secondCone_part4_rInnerStart"                             rMin2="TUBE_secondCone_part4_rInnerEnd"
            rMax1="TUBE_secondCone_part4_rInnerStart+TUBE_secondCone_part4_RadThickness"  rMax2="TUBE_secondCone_part4_rInnerEnd+TUBE_secondCone_part4_RadThickness"
-           material="G4_Be" name="IPOuterTube" />
+           material="BeampipeBeCableMix" name="IPOuterTube" />
 
 
   <section type ="PunchedCenter"         
@@ -137,3 +137,4 @@
 
 
 </detector>
+

--- a/ILD/compact/ILD_common_v01/materials.xml
+++ b/ILD/compact/ILD_common_v01/materials.xml
@@ -541,4 +541,12 @@
       <fraction n="0.020" ref="Mn" />
     </material>
 
+    <!-- to model beampipe with 2mm Be + 0.7mm Cu cables (calc by DJeans) -->
+    <material name="BeampipeBeCableMix">
+      <D type="density" value="3.69" unit="g/cm3" />
+       <fraction n="0.806" ref="Be" />
+       <fraction n="0.194" ref="Cu" />
+    </material>
+
+
   </materials>

--- a/ILD/compact/ILD_common_v01/top_defs_common_v01.xml
+++ b/ILD/compact/ILD_common_v01/top_defs_common_v01.xml
@@ -108,7 +108,7 @@ subdetector-specific ones are in separate files
 
   <!-- the beam tube -->
   <constant name="TUBE_IPInnerTube_end_z"         value="80*mm"/>
-  <constant name="TUBE_central_inner_radius" value="14.*mm"/>
+  <constant name="TUBE_central_inner_radius" value="13.5*mm"/>
   <constant name="TUBE_central_thickness" value="0.5*mm"/>
 
   <constant name="TUBE_IPInnerBulge_end_z"        value="150*mm"/>

--- a/ILD/compact/ILD_common_v01/tube_defs.xml
+++ b/ILD/compact/ILD_common_v01/tube_defs.xml
@@ -9,6 +9,18 @@
   <constant name="TUBE_firstCone_rInnerStart" value="TUBE_innerCylinder_rInner"/>
   <constant name="TUBE_firstCone_rInnerEnd" value="TUBE_IPInnerBulge_end_innerradius"/>
   <constant name="TUBE_firstCone_thickness" value="0.75*mm"/>
+  <!--
+     D. Jeans, update april 2017
+     in this driver, we have to define the what I call the radial thickness
+     this is the thickness in the radial direction, not that perpendicular to the surface.
+     in the cones, we increase the thickness by a factor 1/cos(theta), where theta is the cone angle (half opening angle)
+     (previously the nominal thickness was used as the radial thickness)
+    -->
+  <constant name="TUBE_firstCone_dz" value="TUBE_firstCone_zEnd-TUBE_firstCone_zStart"/>
+  <constant name="TUBE_firstCone_dr" value="TUBE_firstCone_rInnerEnd-TUBE_firstCone_rInnerStart"/>
+  <constant name="TUBE_firstCone_costh" value="TUBE_firstCone_dz/sqrt( TUBE_firstCone_dz**2. + TUBE_firstCone_dr**2. )"/>
+  <constant name="TUBE_firstCone_RadThickness" value="TUBE_firstCone_thickness/TUBE_firstCone_costh"/>
+
 
   <constant name="TUBE_secondCylinder_zStart"    value="TUBE_firstCone_zEnd"/>
   <constant name="TUBE_secondCylinder_zEnd"      value="230*mm"/>
@@ -24,7 +36,6 @@
   <constant name="TUBE_cupola_thickness" value="2*mm"/>
   <constant name="TUBE_cupola_zEnd" value="TUBE_IPOuterBulge_end_z"/>
 
-
   <!-- this was an aborted attempt to model the cupola more precisely -->
   <!-- constant name="TUBE_cupola_radius" value="400*mm"/ -->
   <!-- constant name="TUBE_fillet_radius" value="50*mm"/ -->
@@ -34,31 +45,40 @@
   <!-- constant name="TUBE_secondCone_tanOpeningAngle" value="(TUBE_secondCone_rMax-TUBE_secondCylinder_rInner)/(TUBE_coneCupolaIntersection_z-TUBE_secondCylinder_zEnd)"/ -->
 
   <constant name="TUBE_secondCone_tanOpeningAngle" value="(TUBE_secondCone_rMax-TUBE_secondCylinder_rInner)/(TUBE_cupola_zEnd-TUBE_secondCylinder_zEnd)"/>
+  <constant name="TUBE_secondCone_cosOpeningAngle" value="1./( 1. + TUBE_secondCone_tanOpeningAngle**2 )"/>
 
   <constant name="TUBE_secondCone_part1_zStart" value="TUBE_secondCylinder_zEnd"/>
   <constant name="TUBE_secondCone_part1_zEnd" value="FTD_disk3_zPosRelToTpcLength*TPC_Ecal_Hcal_barrel_halfZ"/>
   <constant name="TUBE_secondCone_part1_rInnerStart" value="TUBE_secondCylinder_rInner"/>
   <constant name="TUBE_secondCone_part1_rInnerEnd" value="TUBE_secondCone_part1_rInnerStart + TUBE_secondCone_tanOpeningAngle*(TUBE_secondCone_part1_zEnd-TUBE_secondCone_part1_zStart)"/>
-  <constant name="TUBE_secondCone_part1_thickness" value="0.85*mm"/>
+  <constant name="TUBE_secondCone_part1_thickness" value="2.*mm"/>
+  <constant name="TUBE_secondCone_part1_RadThickness" value="TUBE_secondCone_part1_thickness/TUBE_secondCone_cosOpeningAngle"/>
 
   <constant name="TUBE_secondCone_part2_zStart" value="TUBE_secondCone_part1_zEnd"/>
   <constant name="TUBE_secondCone_part2_zEnd" value="FTD_disk4_zPosRelToTpcLength*TPC_Ecal_Hcal_barrel_halfZ"/>
   <constant name="TUBE_secondCone_part2_rInnerStart" value="TUBE_secondCone_part1_rInnerEnd"/>
   <constant name="TUBE_secondCone_part2_rInnerEnd" value="TUBE_secondCone_part2_rInnerStart + TUBE_secondCone_tanOpeningAngle*(TUBE_secondCone_part2_zEnd-TUBE_secondCone_part2_zStart)"/>
-  <constant name="TUBE_secondCone_part2_thickness" value="1.0*mm"/>
+  <constant name="TUBE_secondCone_part2_thickness" value="2.*mm"/>
+  <constant name="TUBE_secondCone_part2_RadThickness" value="TUBE_secondCone_part2_thickness/TUBE_secondCone_cosOpeningAngle"/>
 
   <constant name="TUBE_secondCone_part3_zStart" value="TUBE_secondCone_part2_zEnd"/>
   <constant name="TUBE_secondCone_part3_zEnd" value="FTD_disk5_zPosRelToTpcLength*TPC_Ecal_Hcal_barrel_halfZ"/>
   <constant name="TUBE_secondCone_part3_rInnerStart" value="TUBE_secondCone_part2_rInnerEnd"/>
   <constant name="TUBE_secondCone_part3_rInnerEnd" value="TUBE_secondCone_part3_rInnerStart + TUBE_secondCone_tanOpeningAngle*(TUBE_secondCone_part3_zEnd-TUBE_secondCone_part3_zStart)"/>
-  <constant name="TUBE_secondCone_part3_thickness" value="1.3*mm"/>
+  <constant name="TUBE_secondCone_part3_thickness" value="2.*mm"/>
+  <constant name="TUBE_secondCone_part3_RadThickness" value="TUBE_secondCone_part3_thickness/TUBE_secondCone_cosOpeningAngle"/>
 
   <constant name="TUBE_secondCone_part4_zStart" value="TUBE_secondCone_part3_zEnd"/>
   <!-- constant name="TUBE_secondCone_part4_zEnd" value="TUBE_coneCupolaIntersection_z"/ -->
   <constant name="TUBE_secondCone_part4_zEnd" value="TUBE_cupola_zEnd"/>
   <constant name="TUBE_secondCone_part4_rInnerStart" value="TUBE_secondCone_part3_rInnerEnd"/>
   <constant name="TUBE_secondCone_part4_rInnerEnd" value="TUBE_secondCone_part4_rInnerStart + TUBE_secondCone_tanOpeningAngle*(TUBE_secondCone_part4_zEnd-TUBE_secondCone_part4_zStart)"/>
-  <constant name="TUBE_secondCone_part4_thickness" value="1.5*mm"/>
+  <constant name="TUBE_secondCone_part4_thickness" value="2.*mm"/>
+  <constant name="TUBE_secondCone_part4_RadThickness" value="TUBE_secondCone_part4_thickness/TUBE_secondCone_cosOpeningAngle"/>
+
+
+
+
   
   <!-- the tube going through lumical -->
   <constant name="TUBE_lumiTube_zStart" value="TUBE_cupola_zEnd+TUBE_cupola_thickness"/>

--- a/ILD/compact/ILD_common_v01/tube_defs.xml
+++ b/ILD/compact/ILD_common_v01/tube_defs.xml
@@ -51,21 +51,22 @@
   <constant name="TUBE_secondCone_part1_zEnd" value="FTD_disk3_zPosRelToTpcLength*TPC_Ecal_Hcal_barrel_halfZ"/>
   <constant name="TUBE_secondCone_part1_rInnerStart" value="TUBE_secondCylinder_rInner"/>
   <constant name="TUBE_secondCone_part1_rInnerEnd" value="TUBE_secondCone_part1_rInnerStart + TUBE_secondCone_tanOpeningAngle*(TUBE_secondCone_part1_zEnd-TUBE_secondCone_part1_zStart)"/>
-  <constant name="TUBE_secondCone_part1_thickness" value="2.*mm"/>
+  <!-- include 0.7mm thickness for the cables -->
+  <constant name="TUBE_secondCone_part1_thickness" value="2.7*mm"/> 
   <constant name="TUBE_secondCone_part1_RadThickness" value="TUBE_secondCone_part1_thickness/TUBE_secondCone_cosOpeningAngle"/>
 
   <constant name="TUBE_secondCone_part2_zStart" value="TUBE_secondCone_part1_zEnd"/>
   <constant name="TUBE_secondCone_part2_zEnd" value="FTD_disk4_zPosRelToTpcLength*TPC_Ecal_Hcal_barrel_halfZ"/>
   <constant name="TUBE_secondCone_part2_rInnerStart" value="TUBE_secondCone_part1_rInnerEnd"/>
   <constant name="TUBE_secondCone_part2_rInnerEnd" value="TUBE_secondCone_part2_rInnerStart + TUBE_secondCone_tanOpeningAngle*(TUBE_secondCone_part2_zEnd-TUBE_secondCone_part2_zStart)"/>
-  <constant name="TUBE_secondCone_part2_thickness" value="2.*mm"/>
+  <constant name="TUBE_secondCone_part2_thickness" value="2.7*mm"/>
   <constant name="TUBE_secondCone_part2_RadThickness" value="TUBE_secondCone_part2_thickness/TUBE_secondCone_cosOpeningAngle"/>
 
   <constant name="TUBE_secondCone_part3_zStart" value="TUBE_secondCone_part2_zEnd"/>
   <constant name="TUBE_secondCone_part3_zEnd" value="FTD_disk5_zPosRelToTpcLength*TPC_Ecal_Hcal_barrel_halfZ"/>
   <constant name="TUBE_secondCone_part3_rInnerStart" value="TUBE_secondCone_part2_rInnerEnd"/>
   <constant name="TUBE_secondCone_part3_rInnerEnd" value="TUBE_secondCone_part3_rInnerStart + TUBE_secondCone_tanOpeningAngle*(TUBE_secondCone_part3_zEnd-TUBE_secondCone_part3_zStart)"/>
-  <constant name="TUBE_secondCone_part3_thickness" value="2.*mm"/>
+  <constant name="TUBE_secondCone_part3_thickness" value="2.7*mm"/>
   <constant name="TUBE_secondCone_part3_RadThickness" value="TUBE_secondCone_part3_thickness/TUBE_secondCone_cosOpeningAngle"/>
 
   <constant name="TUBE_secondCone_part4_zStart" value="TUBE_secondCone_part3_zEnd"/>
@@ -73,7 +74,7 @@
   <constant name="TUBE_secondCone_part4_zEnd" value="TUBE_cupola_zEnd"/>
   <constant name="TUBE_secondCone_part4_rInnerStart" value="TUBE_secondCone_part3_rInnerEnd"/>
   <constant name="TUBE_secondCone_part4_rInnerEnd" value="TUBE_secondCone_part4_rInnerStart + TUBE_secondCone_tanOpeningAngle*(TUBE_secondCone_part4_zEnd-TUBE_secondCone_part4_zStart)"/>
-  <constant name="TUBE_secondCone_part4_thickness" value="2.*mm"/>
+  <constant name="TUBE_secondCone_part4_thickness" value="2.7*mm"/>
   <constant name="TUBE_secondCone_part4_RadThickness" value="TUBE_secondCone_part4_thickness/TUBE_secondCone_cosOpeningAngle"/>
 
 
@@ -86,6 +87,5 @@
   <constant name="TUBE_lumiTube_thickness" value="1*mm"/>
   <constant name="TUBE_lumiTube_rInner" value="Lcal_inner_radius-TUBE_lumiTube_thickness-1*mm"/>
 
-  
 
 </define>


### PR DESCRIPTION

BEGINRELEASENOTES
various updates to beampipe description:
- inner radius of central tube reduced from 14 to 13.5mm to match DBD
- tube thickness in conical regions corrected for the cone angle
- second cone: now made of Be-Cu mix, and given uniform thickness of 2.7mm. this is to simulate a 2mm-thick Be beampipe with 0.7mm of Cu cables around it.
ENDRELEASENOTES