### PR TITLE
fix hcal endcap envelopes in ILD models: add cable gap to cryostat, a…

### DIFF
--- a/ILD/compact/ILD_common_v01/Hcal_Endcaps_SD_v01.xml
+++ b/ILD/compact/ILD_common_v01/Hcal_Endcaps_SD_v01.xml
@@ -1,23 +1,19 @@
 <detector id="ILDDetID_HCAL_ENDCAP" name="HcalEndcap" type="Hcal_Endcaps_SD_v01" readout="HcalEndcapsCollection"  vis="SeeThrough" calorimeterType="HAD_ENDCAP">
  <comment>Hadron Calorimeter Endcap</comment>
- <envelope vis="ILD_HCALVis">
-       <shape type="BooleanShape" operation="Subtraction" material="Air">
-         <shape type="BooleanShape" operation="Subtraction" material="Air" >
-           <shape type="PolyhedraRegular"  numsides="HcalEndcap_symmetry" rmin="0"
-	         rmax="HcalEndcap_outer_radius + env_safety" dz="2.0*HcalEndcap_max_z + env_safety" material="Air"/>     
-           <shape type="PolyhedraRegular"  numsides="HcalEndcap_symmetry" rmin="0"
-	         rmax="HcalEndcap_outer_radius + env_safety" dz="2.0*HcalEndcap_max_z - env_safety" material="Air"/>     
-         </shape>
-         <shape type="Box" dx="HcalEndcap_inner_radius - env_safety" dy="HcalEndcap_inner_radius - env_safety"
-                dz="HcalEndcap_max_z + env_safety"/> 
-         <rotation x="0" y="0" z="0"/> 
-         </shape>
-         <rotation x="0" y="0" z="0"/> 
- <!--   
-            <shape type="Tube" rmin="0.0" rmax="HcalEndcap_outer_radius + env_safety" dz="HcalEndcap_max_z + env_safety"/>
-            <shape type="Tube" rmin="0.0" rmax="HcalEndcap_outer_radius + 2.0*env_safety" dz="HcalEndcap_min_z - env_safety"/>
--->
- </envelope>
+
+
+    <envelope vis="ILD_HCALVis">    
+      <shape type="BooleanShape" operation="Subtraction" material="Air"><!--2. create center box hole -->
+        <shape type="BooleanShape" operation="Subtraction" material="Air"><!--1. create Endcaps envelope -->
+          <shape type="Tube" rmin="0.0" rmax="HcalEndcap_outer_radius + env_safety" dz="HcalEndcap_max_z + env_safety"/>
+          <shape type="Tube" rmin="0.0" rmax="HcalEndcap_outer_radius + 2.0*env_safety" dz="HcalEndcap_min_z - env_safety"/>
+        </shape>
+        <shape type="Box" dx="HcalEndcap_inner_radius - env_safety" dy="HcalEndcap_inner_radius - env_safety" 
+               dz="HcalEndcap_max_z + 2.0*env_safety"/>
+      </shape>
+      <rotation x="0" y="0" z="0"/>
+    </envelope>
+
     <type_flags type=" DetType_CALORIMETER + DetType_ENDCAP + DetType_HADRONIC " />
     <material name="Steel304L"/><!-- radiator and the thickness has been defined in the main xml file-->
     <staves  material = "Steel235"  vis="SeeThrough"/>

--- a/ILD/compact/ILD_common_v01/envelope_defs.xml
+++ b/ILD/compact/ILD_common_v01/envelope_defs.xml
@@ -93,15 +93,15 @@
   <constant name="EcalEndcap_symmetry"        value="Ecal_Hcal_symmetry"/>
 
   <constant name="HcalEndcap_inner_radius"    value="Hcal_endcap_center_box_size/2.0"/>
-  <constant name="HcalEndcap_outer_radius"    value="Hcal_outer_radius"/>
+  <constant name="HcalEndcap_outer_radius"    value="Hcal_outer_radius - Hcal_endcap_cryostat_gap"/>
   <constant name="HcalEndcap_min_z"           value="Hcal_endcap_zmin"/>
   <constant name="HcalEndcap_max_z"           value="HcalEndcap_min_z+Hcal_endcap_thickness"/>
 
+  <constant name="HcalEndcapRing_symmetry"        value="Ecal_Hcal_symmetry"/>
   <constant name="HcalEndcapRing_inner_radius"    value="EcalEndcap_outer_radius+Hcal_radial_ring_inner_gap"/>
-  <constant name="HcalEndcapRing_outer_radius"    value="Hcal_outer_radius*cos(pi/Ecal_Hcal_symmetry)"/>
+  <constant name="HcalEndcapRing_outer_radius"    value="HcalEndcap_outer_radius*cos(pi/HcalEndcapRing_symmetry)"/>
   <constant name="HcalEndcapRing_min_z"           value="EcalEndcap_min_z"/>
   <constant name="HcalEndcapRing_max_z"           value="EcalEndcap_max_z"/>
-  <constant name="HcalEndcapRing_symmetry"        value="Ecal_Hcal_symmetry"/>
 
   <constant name="Coil_inner_radius"    value="Hcal_outer_radius+Hcal_Coil_additional_gap"/>
   <constant name="Coil_outer_radius"    value="Hcal_outer_radius+Hcal_Coil_additional_gap+Coil_thickness"/>

--- a/ILD/compact/ILD_common_v01/top_defs_common_v01.xml
+++ b/ILD/compact/ILD_common_v01/top_defs_common_v01.xml
@@ -60,8 +60,8 @@ subdetector-specific ones are in separate files
   <constant name="Hcal_endcap_center_box_size" value="700.0*mm"/>
   <constant name="Hcal_endcap_zmin" value="2650*mm" />
   <constant name="Hcal_endcap_thickness" value="1287.0*mm"/>
-
   <constant name="Hcal_radial_ring_inner_gap" value="50*mm"/>
+  <constant name="Hcal_endcap_cryostat_gap" value="170*mm"/>
 
   <!-- coil -->
   <constant name="Coil_extra_size" value="1522*mm"/>


### PR DESCRIPTION
…dd geom for SDhcal

BEGINRELEASENOTES
- Changes to HCAL endcap envelopes in ILD_l/s* models
        - in all ILD_l/s* models, reduce radial size of hcal endcap envelopes to leave space for cables. cryo-hcal endcap gap is controlled by parameter Hcal_endcap_cryostat_gap, set to 170 mm.
       - in ILD_?2 models, change SDHCAL endcap envelope shape to tube (same as other models)
ENDRELEASENOTES