### PR TITLE
ILD models: fix overlap of FTD envelope with beampipe

### DIFF
--- a/ILD/compact/ILD_common_v01/envelope_defs.xml
+++ b/ILD/compact/ILD_common_v01/envelope_defs.xml
@@ -36,9 +36,11 @@
   <constant name="TUBE_IPOuterTube_start_radius"  value="TUBE_IPInnerBulge_end_innerradius"/>
   <constant name="TUBE_IPOuterBulge_end_z"        value="top_Lcal_z_begin - TUBE_Lcal_clearance"/>
   <constant name="TUBE_IPOuterBulge_end_radius"   value="Lcal_outer_radius-LumiCal_tubebulge_overshoot"/>
-  <constant name="TUBE_IPInnerBulge_end_envradius"   value="TUBE_IPInnerBulge_end_innerradius + TUBE_maxthick"/>
+  <constant name="TUBE_IPInnerBulge_end_envradius"   value="TUBE_IPInnerBulge_end_innerradius + TUBE_inner_maxthick"/>
   <constant name="TUBE_IPOuterTube_end_envradius"    value="TUBE_IPInnerBulge_end_envradius"/>
-  <constant name="TUBE_IPOuterBulge_end_envradius"   value="TUBE_IPOuterBulge_end_radius+TUBE_maxthick"/>
+
+  <constant name="TUBE_IPOuterBulge_start_envradius"   value="TUBE_IPInnerBulge_end_innerradius+TUBE_outer_maxthick"/>
+  <constant name="TUBE_IPOuterBulge_end_envradius"   value="TUBE_IPOuterBulge_end_radius+TUBE_outer_maxthick"/>
 
 
 
@@ -60,7 +62,7 @@
   <constant name="TPC_outer_radius"    value="top_TPC_outer_radius"/>
   <constant name="TPC_half_length"     value="TPC_Ecal_Hcal_barrel_halfZ"/>
 
-  <constant name="FTD_inner_radius"    value=" TUBE_IPOuterTube_end_envradius + env_safety"/>
+  <constant name="FTD_inner_radius"    value=" TUBE_IPOuterBulge_start_envradius + env_safety"/>
   <constant name="FTD_outer_radius_1"  value=" SIT_inner_radius   - env_safety"/>
   <constant name="FTD_outer_radius_2"  value=" SIT_outer_radius_1 - env_safety"/>
   <constant name="FTD_outer_radius"    value=" TPC_inner_radius - env_safety"/>

--- a/ILD/compact/ILD_common_v01/top_defs_common_v01.xml
+++ b/ILD/compact/ILD_common_v01/top_defs_common_v01.xml
@@ -120,7 +120,10 @@ subdetector-specific ones are in separate files
   <constant name="TUBE_Lcal_clearance" value="20*mm"/>
 
   <!-- space left for envelopes (counting from inner beampipe surface) -->
-  <constant name="TUBE_maxthick" value="1.5*mm"/>
+  <!-- for inner tube, inner cone, outer tube -->
+  <constant name="TUBE_inner_maxthick" value="1.0*mm"/> 
+  <!-- for outer bulge: include thickness for cables, and the angle effect (should be at least TUBE_secondCone_part4_thickness/TUBE_secondCone_cosOpeningAngle) -->
+  <constant name="TUBE_outer_maxthick" value="3.0*mm"/> 
 
 
 


### PR DESCRIPTION

BEGINRELEASENOTES
- For ILD models: increase inner radius of FTD envelope, to avoid overlap with beampipe of finite thickness.
ENDRELEASENOTES