### PR TITLE
SEcal05* drivers: remove hardcoded number of carbon fibre layers

### DIFF
--- a/ILD/compact/ILD_common_v01/SEcal05_siw_Barrel.xml
+++ b/ILD/compact/ILD_common_v01/SEcal05_siw_Barrel.xml
@@ -22,9 +22,9 @@
         <slice material = "G4_AIR"         thickness = "Ecal_Slab_glue_gap"                      vis="Invisible" />
         <slice material = "Si"             thickness = "Ecal_Si_thickness" sensitive = "yes"     vis="Invisible"    />
         <slice material = "GroundOrHVMix"  thickness = "Ecal_Slab_ground_thickness"              vis="Invisible" />
-        <slice material = "CarbonFiber"    thickness = "Ecal_fiber_thickness"                    vis="Invisible" />
-        <slice material = "G4_W"           thickness = "Ecal_radiator_layers_set1_thickness"   vis="BlueVis"   radiator="yes"/>
-        <slice material = "CarbonFiber"    thickness = "Ecal_fiber_thickness"                    vis="Invisible" />
+        <slice material = "CarbonFiber"    thickness = "Ecal_fiber_thickness_slabAbs"           vis="Invisible" />
+        <slice material = "G4_W"           thickness = "Ecal_radiator_layers_set1_thickness"     vis="BlueVis"   radiator="yes"/>
+        <slice material = "CarbonFiber"    thickness = "Ecal_fiber_thickness_slabAbs"           vis="Invisible" />
         <slice material = "GroundOrHVMix"  thickness = "Ecal_Slab_ground_thickness"              vis="Invisible" />
         <slice material = "Si"             thickness = "Ecal_Si_thickness" sensitive = "yes"     vis="Invisible"    />
         <slice material = "G4_AIR"         thickness = "Ecal_Slab_glue_gap"                      vis="Invisible" />
@@ -39,9 +39,9 @@
         <slice material = "G4_AIR"         thickness = "Ecal_Slab_glue_gap"                      vis="Invisible" />
         <slice material = "Si"             thickness = "Ecal_Si_thickness" sensitive = "yes"     vis="Invisible"    />
         <slice material = "GroundOrHVMix"  thickness = "Ecal_Slab_ground_thickness"              vis="Invisible" />
-        <slice material = "CarbonFiber"    thickness = "Ecal_fiber_thickness"                    vis="Invisible" />
-        <slice material = "G4_W"           thickness = "Ecal_radiator_layers_set2_thickness"   vis="BlueVis"   radiator="yes"/>
-        <slice material = "CarbonFiber"    thickness = "Ecal_fiber_thickness"                    vis="Invisible" />
+        <slice material = "CarbonFiber"    thickness = "Ecal_fiber_thickness_slabAbs"            vis="Invisible" />
+        <slice material = "G4_W"           thickness = "Ecal_radiator_layers_set2_thickness"     vis="BlueVis"   radiator="yes"/>
+        <slice material = "CarbonFiber"    thickness = "Ecal_fiber_thickness_slabAbs"            vis="Invisible" />
         <slice material = "GroundOrHVMix"  thickness = "Ecal_Slab_ground_thickness"              vis="Invisible" />
         <slice material = "Si"             thickness = "Ecal_Si_thickness" sensitive = "yes"     vis="Invisible"    />
         <slice material = "G4_AIR"         thickness = "Ecal_Slab_glue_gap"                      vis="Invisible" />

--- a/ILD/compact/ILD_common_v01/SEcal05_siw_ECRing.xml
+++ b/ILD/compact/ILD_common_v01/SEcal05_siw_ECRing.xml
@@ -29,9 +29,9 @@
         <slice material = "Si"             thickness = "Ecal_Si_thickness" sensitive = "yes"     vis="RedVis"    />
         <!--slice material = "groundMix"      thickness = "Ecal_Slab_ground_thickness" /-->
         <slice material = "GroundOrHVMix"  thickness = "Ecal_Slab_ground_thickness"              vis="Invisible" />
-        <slice material = "CarbonFiber"         thickness = "Ecal_fiber_thickness"                    vis="Invisible" />
+        <slice material = "CarbonFiber"         thickness = "Ecal_fiber_thickness_slabAbs"                    vis="Invisible" />
         <slice material = "G4_W"   thickness = "Ecal_radiator_layers_set1_thickness"   vis="GreenVis"   />
-        <slice material = "CarbonFiber"         thickness = "Ecal_fiber_thickness"                    vis="Invisible" />
+        <slice material = "CarbonFiber"         thickness = "Ecal_fiber_thickness_slabAbs"                    vis="Invisible" />
         <!--slice material = "groundMix"      thickness = "Ecal_Slab_ground_thickness" /-->
         <slice material = "GroundOrHVMix"  thickness = "Ecal_Slab_ground_thickness"              vis="Invisible" />
         <slice material = "Si"             thickness = "Ecal_Si_thickness" sensitive = "yes"     vis="RedVis"    />
@@ -48,9 +48,9 @@
         <slice material = "Si"             thickness = "Ecal_Si_thickness" sensitive = "yes"     vis="RedVis"    />
         <!--slice material = "groundMix"      thickness = "Ecal_Slab_ground_thickness" /-->
         <slice material = "GroundOrHVMix"  thickness = "Ecal_Slab_ground_thickness"              vis="Invisible" />
-        <slice material = "CarbonFiber"         thickness = "Ecal_fiber_thickness"                    vis="Invisible" />
+        <slice material = "CarbonFiber"         thickness = "Ecal_fiber_thickness_slabAbs"                    vis="Invisible" />
         <slice material = "G4_W"   thickness = "Ecal_radiator_layers_set2_thickness"   vis="GreenVis"   />
-        <slice material = "CarbonFiber"         thickness = "Ecal_fiber_thickness"                    vis="Invisible" />
+        <slice material = "CarbonFiber"         thickness = "Ecal_fiber_thickness_slabAbs"                    vis="Invisible" />
         <!--slice material = "groundMix"      thickness = "Ecal_Slab_ground_thickness" /-->
         <slice material = "GroundOrHVMix"  thickness = "Ecal_Slab_ground_thickness"              vis="Invisible" />
         <slice material = "Si"             thickness = "Ecal_Si_thickness" sensitive = "yes"     vis="RedVis"    />

--- a/ILD/compact/ILD_common_v01/SEcal05_siw_Endcaps.xml
+++ b/ILD/compact/ILD_common_v01/SEcal05_siw_Endcaps.xml
@@ -28,9 +28,9 @@
     <slice material = "Si"             thickness = "Ecal_Si_thickness" sensitive = "yes"     vis="RedVis"    />
     <!--slice material = "groundMix"      thickness = "Ecal_Slab_ground_thickness" /-->
     <slice material = "GroundOrHVMix"  thickness = "Ecal_Slab_ground_thickness"              vis="Invisible" />
-    <slice material = "CarbonFiber"         thickness = "Ecal_fiber_thickness"                    vis="Invisible" />
+    <slice material = "CarbonFiber"         thickness = "Ecal_fiber_thickness_slabAbs"       vis="Invisible" />
     <slice material = "G4_W"   thickness = "Ecal_radiator_layers_set1_thickness"   vis="BlueVis"   />
-    <slice material = "CarbonFiber"         thickness = "Ecal_fiber_thickness"                    vis="Invisible" />
+    <slice material = "CarbonFiber"         thickness = "Ecal_fiber_thickness_slabAbs"                    vis="Invisible" />
     <!--slice material = "groundMix"      thickness = "Ecal_Slab_ground_thickness" /-->
     <slice material = "GroundOrHVMix"  thickness = "Ecal_Slab_ground_thickness"              vis="Invisible" />
     <slice material = "Si"             thickness = "Ecal_Si_thickness" sensitive = "yes"     vis="RedVis"    />
@@ -48,9 +48,9 @@
     <slice material = "Si"             thickness = "Ecal_Si_thickness" sensitive = "yes"     vis="RedVis"    />
     <!--slice material = "groundMix"      thickness = "Ecal_Slab_ground_thickness" /-->
     <slice material = "GroundOrHVMix"  thickness = "Ecal_Slab_ground_thickness"              vis="Invisible" />
-    <slice material = "CarbonFiber"         thickness = "Ecal_fiber_thickness"                    vis="Invisible" />
+    <slice material = "CarbonFiber"         thickness = "Ecal_fiber_thickness_slabAbs"                    vis="Invisible" />
     <slice material = "G4_W"   thickness = "Ecal_radiator_layers_set2_thickness"   vis="BlueVis"   />
-    <slice material = "CarbonFiber"         thickness = "Ecal_fiber_thickness"                    vis="Invisible" />
+    <slice material = "CarbonFiber"         thickness = "Ecal_fiber_thickness_slabAbs"                    vis="Invisible" />
     <!--slice material = "groundMix"      thickness = "Ecal_Slab_ground_thickness" /-->
     <slice material = "GroundOrHVMix"  thickness = "Ecal_Slab_ground_thickness"              vis="Invisible" />
     <slice material = "Si"             thickness = "Ecal_Si_thickness" sensitive = "yes"     vis="RedVis"    />

--- a/ILD/compact/ILD_common_v01/ecal_defs.xml
+++ b/ILD/compact/ILD_common_v01/ecal_defs.xml
@@ -11,7 +11,9 @@
   <constant name="Ecal_radiator_layers_set3_thickness" value="0*mm"/>
 
   <constant name="Ecal_barrel_number_of_towers" value="5"/>
-  <constant name="Ecal_fiber_thickness" value=".15*mm"/>
+  <constant name="Ecal_fiber_thickness_slabAbs" value="0.15*mm"/>
+  <constant name="Ecal_fiber_thickness_structure" value="2*0.15*mm"/>
+  <constant name="Ecal_fiber_thickness_alveolus" value="3*0.15*mm"/>
   <constant name="Ecal_front_face_thickness" value="0*mm"/>
   <constant name="Ecal_lateral_face_thickness" value="2*mm"/>
   <constant name="Ecal_support_thickness" value="8.6*mm"/>

--- a/detector/calorimeter/SEcal05_Barrel.cpp
+++ b/detector/calorimeter/SEcal05_Barrel.cpp
@@ -153,8 +153,8 @@ static Ref_t create_detector(LCDD& lcdd, xml_h element, SensitiveDetector sens) 
   //====================================================================
 
   // some hardcoded values!
-  const int N_FIBERS_W_STRUCTURE = 2; // number of CF layers around absorber layers in the structure
-  const int N_FIBERS_ALVEOLUS    = 3; // number of CF layers used to make alveolus
+  //  const int N_FIBERS_W_STRUCTURE = 2; // number of CF layers around absorber layers in the structure
+  //  const int N_FIBERS_ALVEOLUS    = 3; // number of CF layers used to make alveolus
 
   //  read other parameters from compact.xml file
 
@@ -180,7 +180,15 @@ static Ref_t create_detector(LCDD& lcdd, xml_h element, SensitiveDetector sens) 
   double Ecal_front_face_thickness          = lcdd.constant<double>("Ecal_front_face_thickness");
   double Ecal_lateral_face_thickness        = lcdd.constant<double>("Ecal_lateral_face_thickness");
   double Ecal_Slab_H_fiber_thickness        = lcdd.constant<double>("Ecal_Slab_H_fiber_thickness");
-  double Ecal_fiber_thickness               = lcdd.constant<double>("Ecal_fiber_thickness");
+
+  
+  //  double Ecal_fiber_thickness               = lcdd.constant<double>("Ecal_fiber_thickness");
+  // some hardcoded values!
+  // const int N_FIBERS_W_STRUCTURE = 2; // number of CF layers around absorber layers in the structure
+  // const int N_FIBERS_ALVEOLUS    = 3; // number of CF layers used to make alveolus
+  double Ecal_fiber_thickness_structure = lcdd.constant<double>("Ecal_fiber_thickness_structure"); // absorber wrapping thickness
+  double Ecal_fiber_thickness_alveolus  = lcdd.constant<double>("Ecal_fiber_thickness_alveolus"); // alveolar wall thickness
+
   double Ecal_Slab_shielding                = lcdd.constant<double>("Ecal_Slab_shielding");
 
   // first layer is preshower?
@@ -197,8 +205,6 @@ static Ref_t create_detector(LCDD& lcdd, xml_h element, SensitiveDetector sens) 
   int Ecal_cells_across_megatile            = lcdd.constant <int> ("Ecal_cells_across_megatile" );
   int Ecal_strips_across_megatile           = lcdd.constant <int> ("Ecal_strips_across_megatile");
   int Ecal_strips_along_megatile            = lcdd.constant <int> ("Ecal_strips_along_megatile" );
-
-  //  float Ecal_plugLength                     = lcdd.constant<double>("Ecal_Slab_Plug_length");
 
   float Ecal_plugLength = 0.;
   try {
@@ -231,8 +237,8 @@ static Ref_t create_detector(LCDD& lcdd, xml_h element, SensitiveDetector sens) 
   helper.checkLayerConsistency();
 
   // structural CF thicknesses
-  helper.setCFthickness( N_FIBERS_W_STRUCTURE*Ecal_fiber_thickness,
-                         N_FIBERS_ALVEOLUS*Ecal_fiber_thickness,
+  helper.setCFthickness( Ecal_fiber_thickness_structure,  // was N_FIBERS_W_STRUCTURE*Ecal_fiber_thickness, : updated DJ
+			 Ecal_fiber_thickness_alveolus,   //     N_FIBERS_ALVEOLUS*Ecal_fiber_thickness,
                          Ecal_front_face_thickness,
                          Ecal_support_thickness);
 
@@ -292,7 +298,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h element, SensitiveDetector sens) 
 			 alv_width,
 			 Ecal_n_wafers_per_tower,
 			 Ecal_lateral_face_thickness,
-                         N_FIBERS_ALVEOLUS * Ecal_fiber_thickness + Ecal_Slab_H_fiber_thickness + Ecal_Slab_shielding,
+			 Ecal_fiber_thickness_alveolus + Ecal_Slab_H_fiber_thickness + Ecal_Slab_shielding,
                          Ecal_guard_ring_size );
 
   // shape of barrel module

--- a/detector/calorimeter/SEcal05_Endcaps.cpp
+++ b/detector/calorimeter/SEcal05_Endcaps.cpp
@@ -96,13 +96,10 @@ static Ref_t create_detector(LCDD& lcdd, xml_h element, SensitiveDetector sens) 
   //
   //====================================================================
   
-  // hardcoded numbers....better to add to xmk description
-  const int N_FIBERS_W_STRUCTURE = 2; 
-  const int N_FIBERS_ALVEOLUS = 3;
-
   //  read parameters from compact.xml file
   double Ecal_Slab_shielding                = lcdd.constant<double>("Ecal_Slab_shielding");
-  double Ecal_fiber_thickness               = lcdd.constant<double>("Ecal_fiber_thickness");
+  double Ecal_fiber_thickness_structure = lcdd.constant<double>("Ecal_fiber_thickness_structure"); // absorber wrapping thickness
+  double Ecal_fiber_thickness_alveolus  = lcdd.constant<double>("Ecal_fiber_thickness_alveolus"); // alveolar wall thickness
   
   double EcalBarrel_inner_radius                  = lcdd.constant<double>("TPC_outer_radius") +lcdd.constant<double>("Ecal_Tpc_gap");
   int    Ecal_barrel_z_modules              = lcdd.constant<int>("Ecal_barrel_z_modules");
@@ -183,8 +180,8 @@ static Ref_t create_detector(LCDD& lcdd, xml_h element, SensitiveDetector sens) 
   helper.checkLayerConsistency();
 
   // set structural CF thicknesses
-  helper.setCFthickness( N_FIBERS_W_STRUCTURE*Ecal_fiber_thickness,
-                         N_FIBERS_ALVEOLUS*Ecal_fiber_thickness,
+  helper.setCFthickness( Ecal_fiber_thickness_structure,
+                         Ecal_fiber_thickness_alveolus,
                          Ecal_front_face_thickness,
                          Ecal_support_thickness);
 
@@ -255,7 +252,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h element, SensitiveDetector sens) 
 			 barrel_alv_width,
 			 Ecal_n_wafers_per_tower,
 			 Ecal_lateral_face_thickness,
-                         N_FIBERS_ALVEOLUS * Ecal_fiber_thickness + Ecal_Slab_H_fiber_thickness + Ecal_Slab_shielding,
+                         Ecal_fiber_thickness_alveolus + Ecal_Slab_H_fiber_thickness + Ecal_Slab_shielding,
 			 Ecal_guard_ring_size );
 
 


### PR DESCRIPTION
BEGINRELEASENOTES
- improve SEcal05 drivers and compact description for ILD models
     - remove hard-coded numbers of carbon fiber layers (in alveolii, around absorber plates) in SEcal05* drivers: more flexible.
    - now parameterize in terms of total CF thickness, rather than thickness of one sheet multiplied by number of sheets: easier to understand, more flexible.
    - associated changes required in compact descriptions

ENDRELEASENOTES