### PR TITLE
Remove deprecated DDRec extensions

### DIFF
--- a/detector/calorimeter/ECalBarrel_o1_v02_geo.cpp
+++ b/detector/calorimeter/ECalBarrel_o1_v02_geo.cpp
@@ -21,8 +21,6 @@
 #include "XML/Utilities.h"
 #include "DDRec/DetectorData.h"
 #include "DDSegmentation/Segmentation.h"
-#include "DDRec/Extensions/LayeringExtensionImpl.h"
-#include "DDRec/Extensions/SubdetectorExtensionImpl.h"
 
 using namespace std;
 using namespace DD4hep;
@@ -75,18 +73,6 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
     double        ry        = sqrt(supportRailCS)/2;            // support rail thickness
     double        outer_r   = (inner_r + mod_z)/std::cos(hphi); // r_outer of actual module
     
-    // Create extension objects for reconstruction -----------------
-    DDRec::LayeringExtensionImpl* layeringExtension = new DDRec::LayeringExtensionImpl;
-    DDRec::SubdetectorExtensionImpl* subDetExtension = new DDRec::SubdetectorExtensionImpl(sdet);
-    Position layerNormal(0,0,1); // FG: defines direction of thickness in Box for layer slices
-
-    subDetExtension->setIsBarrel(true) ;
-    subDetExtension->setNSides( 12 ) ;
-    // subDetExtension->setPhi0( 0 ) ;
-    subDetExtension->setRMin( inner_r ) ;
-    subDetExtension->setRMax( outer_r ) ; // or r_max ?
-    subDetExtension->setZMin( 0. ) ;
-    subDetExtension->setZMax( x_dim.z()/2 ) ;
 
     // Create caloData object to extend driver with data required for reconstruction
     // See http://cern.ch/go/z8tp to learn how quantities are calculated
@@ -366,8 +352,6 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
     envelope.setAttributes(lcdd,x_det.regionStr(),x_det.limitsStr(),x_det.visStr());
     
     sdet.addExtension< DDRec::LayeredCalorimeterData >( caloData ) ;
-    sdet.addExtension< DDRec::LayeringExtension >( layeringExtension ) ;
-    sdet.addExtension< DDRec::SubdetectorExtension >( subDetExtension ) ;
         
     return sdet;
 }

--- a/detector/calorimeter/ECalBarrel_o1_v03_geo.cpp
+++ b/detector/calorimeter/ECalBarrel_o1_v03_geo.cpp
@@ -22,8 +22,6 @@
 #include "XML/Utilities.h"
 #include "DDRec/DetectorData.h"
 #include "DDSegmentation/Segmentation.h"
-#include "DDRec/Extensions/LayeringExtensionImpl.h"
-#include "DDRec/Extensions/SubdetectorExtensionImpl.h"
 
 using namespace std;
 using namespace DD4hep;
@@ -78,17 +76,6 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
     double        outer_r   = (inner_r + mod_z)/std::cos(hphi); // r_outer of actual module
     
     // Create extension objects for reconstruction -----------------
-    DDRec::LayeringExtensionImpl* layeringExtension = new DDRec::LayeringExtensionImpl;
-    DDRec::SubdetectorExtensionImpl* subDetExtension = new DDRec::SubdetectorExtensionImpl(sdet);
-    Position layerNormal(0,0,1); // FG: defines direction of thickness in Box for layer slices
-
-    subDetExtension->setIsBarrel(true) ;
-    subDetExtension->setNSides( 12 ) ;
-    // subDetExtension->setPhi0( 0 ) ;
-    subDetExtension->setRMin( inner_r ) ;
-    subDetExtension->setRMax( outer_r ) ; // or r_max ?
-    subDetExtension->setZMin( 0. ) ;
-    subDetExtension->setZMax( x_dim.z()/2 ) ;
 
     // Create caloData object to extend driver with data required for reconstruction
     // See http://cern.ch/go/z8tp to learn how quantities are calculated
@@ -372,8 +359,6 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
     envelope.setAttributes(lcdd,x_det.regionStr(),x_det.limitsStr(),x_det.visStr());
     
     sdet.addExtension< DDRec::LayeredCalorimeterData >( caloData ) ;
-    sdet.addExtension< DDRec::LayeringExtension >( layeringExtension ) ;
-    sdet.addExtension< DDRec::SubdetectorExtension >( subDetExtension ) ;
         
     return sdet;
 }

--- a/detector/calorimeter/SEcal04_Barrel.cpp
+++ b/detector/calorimeter/SEcal04_Barrel.cpp
@@ -13,9 +13,6 @@
 #include "XML/Layering.h"
 #include "TGeoTrd2.h"
 
-#include "DDRec/Extensions/LayeringExtensionImpl.h"
-#include "DDRec/Extensions/SubdetectorExtensionImpl.h"
-//#include "DDRec/Surface.h"
 #include "XML/Utilities.h"
 #include "DDRec/DetectorData.h"
 #include "DDSegmentation/WaferGridXY.h"
@@ -317,17 +314,6 @@ static Ref_t create_detector(LCDD& lcdd, xml_h element, SensitiveDetector sens) 
 
 
     // ------------- create extension objects for reconstruction -----------------
-    DDRec::LayeringExtensionImpl* layeringExtension = new DDRec::LayeringExtensionImpl ;
-    DDRec::SubdetectorExtensionImpl* subDetExtension = new DDRec::SubdetectorExtensionImpl( sdet )  ;
-    Position layerNormal(0,0,1); //fg: defines direction of thickness in Box for layer slices
-    
-    subDetExtension->setIsBarrel(true) ;
-    subDetExtension->setNSides( 8 ) ;
-    //    subDetExtension->setPhi0( 0 ) ;
-    subDetExtension->setRMin( Ecal_inner_radius ) ;
-    subDetExtension->setRMax( ( Ecal_inner_radius + module_thickness ) / cos( M_PI/8. ) ) ;
-    subDetExtension->setZMin( 0. ) ;
-    subDetExtension->setZMax( Ecal_Barrel_halfZ ) ;
     
     //========== fill data for reconstruction ============================
     DDRec::LayeredCalorimeterData* caloData = new DDRec::LayeredCalorimeterData ;
@@ -788,8 +774,6 @@ static Ref_t create_detector(LCDD& lcdd, xml_h element, SensitiveDetector sens) 
     // Set envelope volume attributes.
     envelope.setAttributes(lcdd,x_det.regionStr(),x_det.limitsStr(),x_det.visStr());
     
-    sdet.addExtension< DDRec::LayeringExtension >( layeringExtension ) ;
-    sdet.addExtension< DDRec::SubdetectorExtension >( subDetExtension ) ;
     sdet.addExtension< DDRec::LayeredCalorimeterData >( caloData ) ; 
 
 

--- a/detector/calorimeter/SEcal04_Barrel_v01.cpp
+++ b/detector/calorimeter/SEcal04_Barrel_v01.cpp
@@ -13,9 +13,6 @@
 #include "XML/Layering.h"
 #include "TGeoTrd2.h"
 
-#include "DDRec/Extensions/LayeringExtensionImpl.h"
-#include "DDRec/Extensions/SubdetectorExtensionImpl.h"
-//#include "DDRec/Surface.h"
 #include "XML/Utilities.h"
 #include "DDRec/DetectorData.h"
 
@@ -315,17 +312,6 @@ static Ref_t create_detector(LCDD& lcdd, xml_h element, SensitiveDetector sens) 
 
 
     // ------------- create extension objects for reconstruction -----------------
-    DDRec::LayeringExtensionImpl* layeringExtension = new DDRec::LayeringExtensionImpl ;
-    DDRec::SubdetectorExtensionImpl* subDetExtension = new DDRec::SubdetectorExtensionImpl( sdet )  ;
-    Position layerNormal(0,0,1); //fg: defines direction of thickness in Box for layer slices
-    
-    subDetExtension->setIsBarrel(true) ;
-    subDetExtension->setNSides( 8 ) ;
-    //    subDetExtension->setPhi0( 0 ) ;
-    subDetExtension->setRMin( Ecal_inner_radius ) ;
-    subDetExtension->setRMax( ( Ecal_inner_radius + module_thickness ) / cos( M_PI/8. ) ) ;
-    subDetExtension->setZMin( 0. ) ;
-    subDetExtension->setZMax( Ecal_Barrel_halfZ ) ;
     
     //========== fill data for reconstruction ============================
     DDRec::LayeredCalorimeterData* caloData = new DDRec::LayeredCalorimeterData ;
@@ -662,8 +648,6 @@ static Ref_t create_detector(LCDD& lcdd, xml_h element, SensitiveDetector sens) 
     // Set envelope volume attributes.
     envelope.setAttributes(lcdd,x_det.regionStr(),x_det.limitsStr(),x_det.visStr());
     
-    sdet.addExtension< DDRec::LayeringExtension >( layeringExtension ) ;
-    sdet.addExtension< DDRec::SubdetectorExtension >( subDetExtension ) ;
     sdet.addExtension< DDRec::LayeredCalorimeterData >( caloData ) ; 
 
 

--- a/detector/calorimeter/SEcal05_Barrel.cpp
+++ b/detector/calorimeter/SEcal05_Barrel.cpp
@@ -14,8 +14,6 @@
 #include "XML/Layering.h"
 #include "TGeoTrd2.h"
 
-#include "DDRec/Extensions/LayeringExtensionImpl.h"
-#include "DDRec/Extensions/SubdetectorExtensionImpl.h"
 #include "XML/Utilities.h"
 #include "DDRec/DetectorData.h"
 
@@ -356,16 +354,6 @@ static Ref_t create_detector(LCDD& lcdd, xml_h element, SensitiveDetector sens) 
 
   // ------------- create extension objects for reconstruction -----------------
 
-  DDRec::LayeringExtensionImpl* layeringExtension = new DDRec::LayeringExtensionImpl ;
-  DDRec::SubdetectorExtensionImpl* subDetExtension = new DDRec::SubdetectorExtensionImpl( sdet )  ;
-  Position layerNormal(0,0,1); //fg: defines direction of thickness in Box for layer slices
-  subDetExtension->setIsBarrel( true ) ;
-  subDetExtension->setNSides( nsides ) ;
-  subDetExtension->setRMin( Ecal_inner_radius ) ;
-  subDetExtension->setRMax( ( Ecal_inner_radius + module_thickness ) / cos( M_PI/nsides ) ) ; // this is to the external corner (fix djeans)
-  subDetExtension->setZMin( 0. ) ;
-  subDetExtension->setZMax( Ecal_Barrel_halfZ ) ;
-
   caloData->layoutType = DDRec::LayeredCalorimeterData::BarrelLayout ;
   caloData->inner_symmetry = nsides  ;
   caloData->outer_symmetry = nsides  ;
@@ -433,8 +421,6 @@ static Ref_t create_detector(LCDD& lcdd, xml_h element, SensitiveDetector sens) 
   // Set envelope volume attributes.
   envelope.setAttributes(lcdd,x_det.regionStr(),x_det.limitsStr(),x_det.visStr());
 
-  sdet.addExtension< DDRec::LayeringExtension      >( layeringExtension ) ;
-  sdet.addExtension< DDRec::SubdetectorExtension   >( subDetExtension ) ;
   sdet.addExtension< DDRec::LayeredCalorimeterData >( caloData ) ;
 
   //  cout << "finished SEcal05_Barrel" << endl;


### PR DESCRIPTION

BEGINRELEASENOTES
- remove unused and deprecated (https://github.com/AIDASoft/DD4hep/pull/165 ) DDRec extensions LayeringExtension/SubdetectorExtensions from Ecal drivers

ENDRELEASENOTES