### PR TITLE
Adapt namespaces

### DIFF
--- a/DDSim/DDSim/DD4hepSimulation.py
+++ b/DDSim/DDSim/DD4hepSimulation.py
@@ -235,16 +235,16 @@ class DD4hepSimulation(object):
       exit(1)
 
   @staticmethod
-  def getDetectorLists( lcdd ):
-    ''' get lists of trackers and calorimeters that are defined in lcdd (the compact xml file)'''
+  def getDetectorLists( detectorDescription ):
+    ''' get lists of trackers and calorimeters that are defined in detectorDescription (the compact xml file)'''
     import DDG4
   #  if len(detectorList):
   #    print " subset list of detectors given - will only instantiate these: " , detectorList
     trackers,calos = [],[]
-    for i in lcdd.detectors():
+    for i in detectorDescription.detectors():
       det = DDG4.DetElement(i.second.ptr())
       name = det.name()
-      sd =  lcdd.sensitiveDetector( name )
+      sd =  detectorDescription.sensitiveDetector( name )
       if sd.isValid():
         detType = sd.type()
   #      if len(detectorList) and not(name in detectorList):
@@ -273,9 +273,9 @@ class DD4hepSimulation(object):
     #kernel.setOutputLevel('Compact',1)
 
     kernel.loadGeometry("file:"+ self.compactFile )
-    lcdd = kernel.lcdd()
+    detectorDescription = kernel.detectorDescription()
 
-    DDG4.importConstants( lcdd )
+    DDG4.importConstants( detectorDescription )
 
   #----------------------------------------------------------------------------------
 
@@ -433,9 +433,9 @@ class DD4hepSimulation(object):
       exit(1)
 
     #=================================================================================
-    # get lists of trackers and calorimeters in lcdd
+    # get lists of trackers and calorimeters in detectorDescription
 
-    trk,cal = self.getDetectorLists( lcdd )
+    trk,cal = self.getDetectorLists( detectorDescription )
 
     # ---- add the trackers:
     try:

--- a/FCalTB/setup/FCalTB_2014.cpp
+++ b/FCalTB/setup/FCalTB_2014.cpp
@@ -3,41 +3,50 @@
 
 #include <string>
 
-using namespace DD4hep;
-using namespace DD4hep::Geometry;
+using dd4hep::Assembly;
+using dd4hep::Box;
+using dd4hep::DetElement;
+using dd4hep::Detector;
+using dd4hep::Layering;
+using dd4hep::Material;
+using dd4hep::PlacedVolume;
+using dd4hep::Position;
+using dd4hep::Ref_t;
+using dd4hep::SensitiveDetector;
+using dd4hep::Tube;
+using dd4hep::Volume;
 
-
-static DD4hep::Geometry::Ref_t create_detector(DD4hep::Geometry::LCDD& lcdd,
-					       xml_h xmlHandle,
-					       DD4hep::Geometry::SensitiveDetector sens) {
+static Ref_t create_detector(Detector& theDetector,
+                             xml_h xmlHandle,
+                             SensitiveDetector sens) {
 
   std::cout << __PRETTY_FUNCTION__  << std::endl;
   std::cout << "Here is my TestBeamSetup"  << std::endl;
   std::cout << " and this is the sensitive detector: " << &sens  << std::endl;
   sens.setType("calorimeter");
   //Materials
-  DD4hep::Geometry::Material air = lcdd.air();
+  Material air = theDetector.air();
 
   //Access to the XML File
   xml_det_t xmlTestBeamSetup = xmlHandle;
   const std::string detName = xmlTestBeamSetup.nameStr();
 
  //--------------------------------
-  DD4hep::Geometry::Assembly assembly( detName + "_assembly"  ) ;
+  Assembly assembly( detName + "_assembly"  ) ;
   //--------------------------------
 
   //Parameters we have to know about
-  DD4hep::XML::Component xmlParameter = xmlTestBeamSetup.child(_Unicode(parameter));
+  dd4hep::xml::Component xmlParameter = xmlTestBeamSetup.child(_Unicode(parameter));
   const double sensorCentreOffset = xmlParameter.attr< double >(_Unicode(sensorCentreOffset));
   const double squareSideLength   = xmlParameter.attr< double >(_Unicode(squareSideLength));
 
-  DD4hep::XML::Dimension dimensions =  xmlTestBeamSetup.dimensions();
+  dd4hep::xml::Dimension dimensions =  xmlTestBeamSetup.dimensions();
 
   //TestBeamSetup Dimensions
   const double lcalInnerR = dimensions.inner_r();
   const double lcalOuterR = dimensions.outer_r();
   const double lcalInnerZ = dimensions.inner_z();
-  const double lcalThickness = DD4hep::Layering( xmlTestBeamSetup ).totalThickness();
+  const double lcalThickness = Layering( xmlTestBeamSetup ).totalThickness();
   const double lcalCentreZ = lcalInnerZ+lcalThickness*0.5;
   const double startAngle = -15*dd4hep::deg+90*dd4hep::degree;
   const double endAngle   =  15*dd4hep::deg+90*dd4hep::degree;
@@ -50,9 +59,9 @@ static DD4hep::Geometry::Ref_t create_detector(DD4hep::Geometry::LCDD& lcdd,
 
 
   //Envelope to place the layers in
-  DD4hep::Geometry::Box envelopeBox (squareSideLength*0.5, squareSideLength*0.5, lcalThickness*0.5);
-  DD4hep::Geometry::Volume envelopeVol(detName+"_envelope",envelopeBox,air);
-  envelopeVol.setVisAttributes(lcdd,xmlTestBeamSetup.visStr());
+  Box envelopeBox (squareSideLength*0.5, squareSideLength*0.5, lcalThickness*0.5);
+  Volume envelopeVol(detName+"_envelope",envelopeBox,air);
+  envelopeVol.setVisAttributes(theDetector,xmlTestBeamSetup.visStr());
 
   ////////////////////////////////////////////////////////////////////////////////
   // Create all the layers
@@ -61,14 +70,14 @@ static DD4hep::Geometry::Ref_t create_detector(DD4hep::Geometry::LCDD& lcdd,
   //Loop over all the layer (repeat=NN) sections
   //This is the starting point to place all layers, we need this when we have more than one layer block
   double referencePosition = -lcalThickness*0.5;
-  for(DD4hep::XML::Collection_t coll(xmlTestBeamSetup,_U(layer)); coll; ++coll)  {
-    DD4hep::XML::Component xmlLayer(coll); //we know this thing is a layer
+  for(dd4hep::xml::Collection_t coll(xmlTestBeamSetup,_U(layer)); coll; ++coll)  {
+    dd4hep::xml::Component xmlLayer(coll); //we know this thing is a layer
 
 
     //This just calculates the total size of a single layer
     //Why no convenience function for this?
     double layerThickness = 0;
-    for(DD4hep::XML::Collection_t l(xmlLayer,_U(slice)); l; ++l)
+    for(dd4hep::xml::Collection_t l(xmlLayer,_U(slice)); l; ++l)
       layerThickness += xml_comp_t(l).thickness();
 
     std::cout << "Total Length "    << lcalThickness/dd4hep::cm  << " cm" << std::endl;
@@ -77,50 +86,50 @@ static DD4hep::Geometry::Ref_t create_detector(DD4hep::Geometry::LCDD& lcdd,
     //Loop for repeat=NN
     for(int i=0, repeat=xmlLayer.repeat(); i<repeat; ++i)  {
 
-      std::string layer_name = detName + DD4hep::XML::_toString(thisLayerId,"_layer%d");
-      DD4hep::Geometry::Box layer_base(squareSideLength*0.5, squareSideLength*0.5, layerThickness*0.5);
+      std::string layer_name = detName + dd4hep::xml::_toString(thisLayerId,"_layer%d");
+      Box layer_base(squareSideLength*0.5, squareSideLength*0.5, layerThickness*0.5);
 
-      DD4hep::Geometry::Volume layer_vol(layer_name,layer_base,air);
+      Volume layer_vol(layer_name,layer_base,air);
 
       int sliceID=1;
       double inThisLayerPosition = -layerThickness*0.5;
-      for(DD4hep::XML::Collection_t collSlice(xmlLayer,_U(slice)); collSlice; ++collSlice)  {
-	DD4hep::XML::Component compSlice = collSlice;
+      for(dd4hep::xml::Collection_t collSlice(xmlLayer,_U(slice)); collSlice; ++collSlice)  {
+	dd4hep::xml::Component compSlice = collSlice;
 	const double      sliceThickness = compSlice.thickness();
-	const std::string sliceName = layer_name + DD4hep::XML::_toString(sliceID,"slice%d");
-	DD4hep::Geometry::Material   slice_mat  = lcdd.material(compSlice.materialStr());
+	const std::string sliceName = layer_name + dd4hep::xml::_toString(sliceID,"slice%d");
+	Material   slice_mat  = theDetector.material(compSlice.materialStr());
 
 
 	const std::string& sliceType = compSlice.attr< std::string >(_Unicode(type));
 
 	if ( sliceType.compare("Square") == 0 ){
 
-	  DD4hep::Geometry::Box sliceBase(squareSideLength*0.5,squareSideLength*0.5,sliceThickness/2);
-	  DD4hep::Geometry::Volume slice_vol (sliceName,sliceBase,slice_mat);
+	  Box sliceBase(squareSideLength*0.5,squareSideLength*0.5,sliceThickness/2);
+	  Volume slice_vol (sliceName,sliceBase,slice_mat);
 
 	  if ( compSlice.isSensitive() )  {
 	    slice_vol.setSensitiveDetector(sens);
 	  }
 
-	  slice_vol.setAttributes(lcdd,compSlice.regionStr(),compSlice.limitsStr(),compSlice.visStr());
-	  DD4hep::Geometry::PlacedVolume pv =
+	  slice_vol.setAttributes(theDetector,compSlice.regionStr(),compSlice.limitsStr(),compSlice.visStr());
+	  PlacedVolume pv =
 	    layer_vol.placeVolume(slice_vol,
-				  DD4hep::Geometry::Position(0,0.0,inThisLayerPosition+sliceThickness*0.5));
+				  Position(0,0.0,inThisLayerPosition+sliceThickness*0.5));
 	  pv.addPhysVolID("slice",sliceID);
 
 	} else {
 
 
-	  DD4hep::Geometry::Tube sliceBase(lcalInnerR,lcalOuterR,sliceThickness/2, startAngle, endAngle);
-	  DD4hep::Geometry::Volume slice_vol (sliceName,sliceBase,slice_mat);
+	  Tube sliceBase(lcalInnerR,lcalOuterR,sliceThickness/2, startAngle, endAngle);
+	  Volume slice_vol (sliceName,sliceBase,slice_mat);
 
 	  if ( compSlice.isSensitive() )  {
 	    slice_vol.setSensitiveDetector(sens);
 	  }
 
-	  slice_vol.setAttributes(lcdd,compSlice.regionStr(),compSlice.limitsStr(),compSlice.visStr());
-	  DD4hep::Geometry::PlacedVolume pv = layer_vol.placeVolume(slice_vol,
-								    DD4hep::Geometry::Position(0,-offsetArc,inThisLayerPosition+sliceThickness*0.5));
+	  slice_vol.setAttributes(theDetector,compSlice.regionStr(),compSlice.limitsStr(),compSlice.visStr());
+	  PlacedVolume pv = layer_vol.placeVolume(slice_vol,
+								    Position(0,-offsetArc,inThisLayerPosition+sliceThickness*0.5));
 	  pv.addPhysVolID("slice",sliceID);
 
       }//not a square
@@ -135,11 +144,11 @@ static DD4hep::Geometry::Ref_t create_detector(DD4hep::Geometry::LCDD& lcdd,
 
       //Why are we doing this for each layer, this just needs to be done once and then placed multiple times
       //Do we need unique IDs for each piece?
-      layer_vol.setVisAttributes(lcdd,xmlLayer.visStr());
+      layer_vol.setVisAttributes(theDetector,xmlLayer.visStr());
 
-      DD4hep::Geometry::Position layer_pos(0,0,referencePosition+0.5*layerThickness);
+      Position layer_pos(0,0,referencePosition+0.5*layerThickness);
       referencePosition += layerThickness;
-      DD4hep::Geometry::PlacedVolume pv = envelopeVol.placeVolume(layer_vol,layer_pos);
+      PlacedVolume pv = envelopeVol.placeVolume(layer_vol,layer_pos);
       pv.addPhysVolID("layer",thisLayerId);
 
       ++thisLayerId;
@@ -148,14 +157,14 @@ static DD4hep::Geometry::Ref_t create_detector(DD4hep::Geometry::LCDD& lcdd,
 
   }// for all layer collections
 
-  const DD4hep::Geometry::Position bcForwardPos ( 0.0 , -centreSquare, lcalCentreZ);
+  const Position bcForwardPos ( 0.0 , -centreSquare, lcalCentreZ);
 
-  DD4hep::Geometry::DetElement TestBeamSetups ( detName, xmlTestBeamSetup.id() );
-  DD4hep::Geometry::DetElement sdet ( "TestBeamSetup01", xmlTestBeamSetup.id() );
+  DetElement TestBeamSetups ( detName, xmlTestBeamSetup.id() );
+  DetElement sdet ( "TestBeamSetup01", xmlTestBeamSetup.id() );
 
-  DD4hep::Geometry::Volume motherVol = lcdd.pickMotherVolume(sdet);
+  Volume motherVol = theDetector.pickMotherVolume(sdet);
 
-  DD4hep::Geometry::PlacedVolume pv =
+  PlacedVolume pv =
     assembly.placeVolume(envelopeVol, bcForwardPos );
   pv.addPhysVolID("system",xmlTestBeamSetup.id());
   pv.addPhysVolID("barrel", 1);

--- a/detector/CaloTB/CaloPrototype_v01.cpp
+++ b/detector/CaloTB/CaloPrototype_v01.cpp
@@ -15,9 +15,20 @@
 #include <vector>
 
 using namespace std;
-using namespace DD4hep;
-using namespace DD4hep::Geometry;
-using namespace lcgeo ;
+
+using dd4hep::BUILD_ENVELOPE;
+using dd4hep::Box;
+using dd4hep::DetElement;
+using dd4hep::Detector;
+using dd4hep::Layer;
+using dd4hep::Layering;
+using dd4hep::Material;
+using dd4hep::PlacedVolume;
+using dd4hep::Position;
+using dd4hep::Ref_t;
+using dd4hep::SensitiveDetector;
+using dd4hep::Volume;
+using dd4hep::_toString;
 
 // workaround for DD4hep v00-14 (and older) 
 #ifndef DD4HEP_VERSION_GE
@@ -25,7 +36,7 @@ using namespace lcgeo ;
 #endif
 
 
-static Ref_t create_detector(LCDD& lcdd, xml_h element, SensitiveDetector sens)  {
+static Ref_t create_detector(Detector& theDetector, xml_h element, SensitiveDetector sens)  {
 
   xml_det_t   x_det       = element;
   string      det_name    = x_det.nameStr();
@@ -36,15 +47,15 @@ static Ref_t create_detector(LCDD& lcdd, xml_h element, SensitiveDetector sens) 
 
   // --- create an envelope volume and position it into the world ---------------------
   
-  Volume envelope = XML::createPlacedEnvelope( lcdd,  element , sdet ) ;
+  Volume envelope = dd4hep::xml::createPlacedEnvelope( theDetector,  element , sdet ) ;
   
-  XML::setDetectorTypeFlag( element, sdet ) ;
+  dd4hep::xml::setDetectorTypeFlag( element, sdet ) ;
   
-  if( lcdd.buildType() == BUILD_ENVELOPE ) return sdet ;
+  if( theDetector.buildType() == BUILD_ENVELOPE ) return sdet ;
 
   //-----------------------------------------------------------------------------------
 
-  Material      air               = lcdd.air();
+  Material      air               = theDetector.air();
 
   sens.setType("calorimeter");
 
@@ -59,7 +70,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h element, SensitiveDetector sens) 
   double      Calo_dim_y          = dim.y();
   double      Calo_dim_z          = dim.z();
 
-  printout( DD4hep::DEBUG,  "building SamplingCaloBoxPrototype_v01",
+  printout( dd4hep::DEBUG,  "building SamplingCaloBoxPrototype_v01",
 	    "Calo_dim_x : %e    Calo_dim_y: %e    Calo_dim_z: %e ",
   	    Calo_dim_x, Calo_dim_y, Calo_dim_z) ;
 
@@ -110,7 +121,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h element, SensitiveDetector sens) 
                 xml_comp_t x_slice = k;
                 string slice_name = _toString(slice_number, "slice%d");
                 double slice_thickness = x_slice.thickness();
-                Material slice_material = lcdd.material(x_slice.materialStr());
+                Material slice_material = theDetector.material(x_slice.materialStr());
                 DetElement slice(layer, slice_name, slice_number);
 
                 slice_pos_z += slice_thickness / 2;
@@ -125,7 +136,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h element, SensitiveDetector sens) 
 
                 
                 // Set region, limitset, and vis.
-                slice_vol.setAttributes(lcdd, x_slice.regionStr(), x_slice.limitsStr(), x_slice.visStr());
+                slice_vol.setAttributes(theDetector, x_slice.regionStr(), x_slice.limitsStr(), x_slice.visStr());
                 // slice PlacedVolume
                 PlacedVolume slice_phv = layer_vol.placeVolume(slice_vol, Position(0, 0, slice_pos_z));
                 slice_phv.addPhysVolID("slice", slice_number);
@@ -139,7 +150,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h element, SensitiveDetector sens) 
             
             
             // Set region, limitset, and vis.
-            layer_vol.setAttributes(lcdd, x_layer.regionStr(), x_layer.limitsStr(), x_layer.visStr());
+            layer_vol.setAttributes(theDetector, x_layer.regionStr(), x_layer.limitsStr(), x_layer.visStr());
            
             // Layer position in Z within the stave.
             layer_pos_z += layer_thickness / 2;

--- a/detector/CaloTB/CaloPrototype_v02.cpp
+++ b/detector/CaloTB/CaloPrototype_v02.cpp
@@ -16,9 +16,22 @@
 #include <vector>
 
 using namespace std;
-using namespace DD4hep;
-using namespace DD4hep::Geometry;
-using namespace lcgeo ;
+
+using dd4hep::BUILD_ENVELOPE;
+using dd4hep::Box;
+using dd4hep::DetElement;
+using dd4hep::Detector;
+using dd4hep::Layer;
+using dd4hep::Layering;
+using dd4hep::Material;
+using dd4hep::PlacedVolume;
+using dd4hep::Position;
+using dd4hep::Readout;
+using dd4hep::Ref_t;
+using dd4hep::Segmentation;
+using dd4hep::SensitiveDetector;
+using dd4hep::Volume;
+using dd4hep::_toString;
 
 // workaround for DD4hep v00-14 (and older) 
 #ifndef DD4HEP_VERSION_GE
@@ -26,7 +39,7 @@ using namespace lcgeo ;
 #endif
 
 
-static Ref_t create_detector(LCDD& lcdd, xml_h element, SensitiveDetector sens)  {
+static Ref_t create_detector(Detector& theDetector, xml_h element, SensitiveDetector sens)  {
 
   xml_det_t   x_det       = element;
   string      det_name    = x_det.nameStr();
@@ -37,15 +50,15 @@ static Ref_t create_detector(LCDD& lcdd, xml_h element, SensitiveDetector sens) 
 
   // --- create an envelope volume and position it into the world ---------------------
   
-  Volume envelope = XML::createPlacedEnvelope( lcdd,  element , sdet ) ;
+  Volume envelope = dd4hep::xml::createPlacedEnvelope( theDetector,  element , sdet ) ;
   
-  XML::setDetectorTypeFlag( element, sdet ) ;
+  dd4hep::xml::setDetectorTypeFlag( element, sdet ) ;
   
-  if( lcdd.buildType() == BUILD_ENVELOPE ) return sdet ;
+  if( theDetector.buildType() == BUILD_ENVELOPE ) return sdet ;
 
   //-----------------------------------------------------------------------------------
 
-  Material      air               = lcdd.air();
+  Material      air               = theDetector.air();
 
   sens.setType("calorimeter");
 
@@ -60,7 +73,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h element, SensitiveDetector sens) 
   double      Calo_dim_y          = dim.y();
   double      Calo_dim_z          = dim.z();
 
-  printout( DD4hep::DEBUG,  "building SamplingCaloBoxPrototype_v01",
+  printout( dd4hep::DEBUG,  "building SamplingCaloBoxPrototype_v01",
 	    "Calo_dim_x : %e    Calo_dim_y: %e    Calo_dim_z: %e ",
   	    Calo_dim_x, Calo_dim_y, Calo_dim_z) ;
 
@@ -73,8 +86,8 @@ static Ref_t create_detector(LCDD& lcdd, xml_h element, SensitiveDetector sens) 
   //unused: double cell_sizeY      = cellSizeVector[1];
 
   // check if we have a TiledLayerGridXY segmentation :
-  DD4hep::DDSegmentation::TiledLayerGridXY* tileSeg = 
-    dynamic_cast< DD4hep::DDSegmentation::TiledLayerGridXY*>( seg.segmentation() ) ;
+  dd4hep::DDSegmentation::TiledLayerGridXY* tileSeg = 
+    dynamic_cast< dd4hep::DDSegmentation::TiledLayerGridXY*>( seg.segmentation() ) ;
 
   //access the layer identifier via the segmentation.
   //the layer identifier is defined in the compact xml file.
@@ -127,7 +140,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h element, SensitiveDetector sens) 
                 xml_comp_t x_slice = k;
                 string slice_name = _toString(slice_number, "slice%d");
                 double slice_thickness = x_slice.thickness();
-                Material slice_material = lcdd.material(x_slice.materialStr());
+                Material slice_material = theDetector.material(x_slice.materialStr());
                 DetElement slice(layer, slice_name, slice_number);
 
                 slice_pos_z += slice_thickness / 2;
@@ -142,7 +155,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h element, SensitiveDetector sens) 
 
                 
                 // Set region, limitset, and vis.
-                slice_vol.setAttributes(lcdd, x_slice.regionStr(), x_slice.limitsStr(), x_slice.visStr());
+                slice_vol.setAttributes(theDetector, x_slice.regionStr(), x_slice.limitsStr(), x_slice.visStr());
                 // slice PlacedVolume
                 PlacedVolume slice_phv = layer_vol.placeVolume(slice_vol, Position(0, 0, slice_pos_z));
                 slice_phv.addPhysVolID("slice", slice_number);
@@ -156,7 +169,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h element, SensitiveDetector sens) 
             
             
             // Set region, limitset, and vis.
-            layer_vol.setAttributes(lcdd, x_layer.regionStr(), x_layer.limitsStr(), x_layer.visStr());
+            layer_vol.setAttributes(theDetector, x_layer.regionStr(), x_layer.limitsStr(), x_layer.visStr());
            
             // Layer position in Z within the stave.
             layer_pos_z += layer_thickness / 2;

--- a/detector/CaloTB/TBecal4d.cpp
+++ b/detector/CaloTB/TBecal4d.cpp
@@ -16,9 +16,22 @@
 #include <vector>
 
 using namespace std;
-using namespace DD4hep;
-using namespace DD4hep::Geometry;
-using namespace lcgeo ;
+
+using dd4hep::BUILD_ENVELOPE;
+using dd4hep::Box;
+using dd4hep::DetElement;
+using dd4hep::Detector;
+using dd4hep::Layer;
+using dd4hep::Layering;
+using dd4hep::Material;
+using dd4hep::PlacedVolume;
+using dd4hep::Position;
+using dd4hep::Readout;
+using dd4hep::Ref_t;
+using dd4hep::Segmentation;
+using dd4hep::SensitiveDetector;
+using dd4hep::Volume;
+using dd4hep::_toString;
 
 // workaround for DD4hep v00-14 (and older) 
 #ifndef DD4HEP_VERSION_GE
@@ -26,7 +39,7 @@ using namespace lcgeo ;
 #endif
 
 
-static Ref_t create_detector(LCDD& lcdd, xml_h element, SensitiveDetector sens)  {
+static Ref_t create_detector(Detector& theDetector, xml_h element, SensitiveDetector sens)  {
 
   xml_det_t   x_det       = element;
   string      det_name    = x_det.nameStr();
@@ -36,15 +49,15 @@ static Ref_t create_detector(LCDD& lcdd, xml_h element, SensitiveDetector sens) 
 
   // --- create an envelope volume and position it into the world ---------------------
   
-  Volume envelope = XML::createPlacedEnvelope( lcdd,  element , sdet ) ;
+  Volume envelope = dd4hep::xml::createPlacedEnvelope( theDetector,  element , sdet ) ;
   
-  XML::setDetectorTypeFlag( element, sdet ) ;
+  dd4hep::xml::setDetectorTypeFlag( element, sdet ) ;
   
-  if( lcdd.buildType() == BUILD_ENVELOPE ) return sdet ;
+  if( theDetector.buildType() == BUILD_ENVELOPE ) return sdet ;
 
   //-----------------------------------------------------------------------------------
 
-  Material air = lcdd.air();
+  Material air = theDetector.air();
 
   sens.setType("calorimeter");
 
@@ -55,14 +68,14 @@ static Ref_t create_detector(LCDD& lcdd, xml_h element, SensitiveDetector sens) 
   //
   //====================================================================
 
-  //unused: double EBU_half_x = lcdd.constant<double>("EBU_dim_x")/2.0;
-  //unused: double EBU_half_y = lcdd.constant<double>("EBU_dim_y")/2.0;
+  //unused: double EBU_half_x = theDetector.constant<double>("EBU_dim_x")/2.0;
+  //unused: double EBU_half_y = theDetector.constant<double>("EBU_dim_y")/2.0;
 
-  int ECAL_ncell_x = lcdd.constant<int>("ECAL_ncell_x");
-  int ECAL_ncell_y = lcdd.constant<int>("ECAL_ncell_y");
+  int ECAL_ncell_x = theDetector.constant<int>("ECAL_ncell_x");
+  int ECAL_ncell_y = theDetector.constant<int>("ECAL_ncell_y");
 
-  int ECAL_nlayers = lcdd.constant<int>("ECAL_nlayers");
-  double Ecal_layer_thickness = lcdd.constant<double>("Ecal_layer_thickness");
+  int ECAL_nlayers = theDetector.constant<int>("ECAL_nlayers");
+  double Ecal_layer_thickness = theDetector.constant<double>("Ecal_layer_thickness");
 
   Readout  readout = sens.readout();
   Segmentation seg = readout.segmentation();
@@ -119,7 +132,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h element, SensitiveDetector sens) 
 	      xml_comp_t x_slice = k;
 	      string slice_name = _toString(slice_number, "slice%d");
 	      double slice_thickness = x_slice.thickness();
-	      Material slice_material = lcdd.material(x_slice.materialStr());
+	      Material slice_material = theDetector.material(x_slice.materialStr());
                 
 	      slice_pos_z += slice_thickness / 2;
 
@@ -130,7 +143,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h element, SensitiveDetector sens) 
 		  Volume slice_vol(slice_name, Box(cal_hx*4, cal_hy*8, slice_thickness / 2), slice_material);
 
 		  // Set region, limitset, and vis.
-		  slice_vol.setAttributes(lcdd, x_slice.regionStr(), x_slice.limitsStr(), x_slice.visStr());
+		  slice_vol.setAttributes(theDetector, x_slice.regionStr(), x_slice.limitsStr(), x_slice.visStr());
 		  // slice PlacedVolume
 		  layer_vol.placeVolume(slice_vol, Position(0, 0, slice_pos_z));
 		}
@@ -146,7 +159,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h element, SensitiveDetector sens) 
 		    } 
 
 		  // Set region, limitset, and vis.
-		  slice_vol.setAttributes(lcdd, x_slice.regionStr(), x_slice.limitsStr(), x_slice.visStr());
+		  slice_vol.setAttributes(theDetector, x_slice.regionStr(), x_slice.limitsStr(), x_slice.visStr());
 		  // slice PlacedVolume
 		  layer_vol.placeVolume(slice_vol, Position(0, 0, slice_pos_z));
                 }
@@ -158,7 +171,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h element, SensitiveDetector sens) 
 	    }
             
 	  // Set region, limitset, and vis.
-	  layer_vol.setAttributes(lcdd, x_layer.regionStr(), x_layer.limitsStr(), x_layer.visStr());
+	  layer_vol.setAttributes(theDetector, x_layer.regionStr(), x_layer.limitsStr(), x_layer.visStr());
            
 	  // Layer position in Z within the stave.
 	  layer_pos_z += layer_thickness / 2;

--- a/detector/calorimeter/ECalBarrel_o1_v02_geo.cpp
+++ b/detector/calorimeter/ECalBarrel_o1_v02_geo.cpp
@@ -23,10 +23,29 @@
 #include "DDSegmentation/Segmentation.h"
 
 using namespace std;
-using namespace DD4hep;
-using namespace DD4hep::Geometry;
 
-static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
+using dd4hep::BUILD_ENVELOPE;
+using dd4hep::Box;
+using dd4hep::DetElement;
+using dd4hep::Detector;
+using dd4hep::Layering;
+using dd4hep::Material;
+using dd4hep::PlacedVolume;
+using dd4hep::Position;
+using dd4hep::Readout;
+using dd4hep::Ref_t;
+using dd4hep::RotationZYX;
+using dd4hep::Segmentation;
+using dd4hep::SensitiveDetector;
+using dd4hep::Transform3D;
+using dd4hep::Translation3D;
+using dd4hep::Trapezoid;
+using dd4hep::Volume;
+using dd4hep::_toString;
+
+using dd4hep::rec::LayeredCalorimeterData;
+
+static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector sens)  {
     
     xml_det_t     x_det     = e;
     int           det_id    = x_det.id();
@@ -35,13 +54,13 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
     
     // --- create an envelope volume and position it into the world ---------------------
     
-    Volume envelope = XML::createPlacedEnvelope(lcdd, e, sdet);
+    Volume envelope = dd4hep::xml::createPlacedEnvelope(theDetector, e, sdet);
     
-    if(lcdd.buildType() == BUILD_ENVELOPE) return sdet;
+    if(theDetector.buildType() == BUILD_ENVELOPE) return sdet;
     
     //-----------------------------------------------------------------------------------
 
-    DD4hep::XML::Component xmlParameter = x_det.child(_Unicode(parameter));
+    dd4hep::xml::Component xmlParameter = x_det.child(_Unicode(parameter));
     const double tolerance = xmlParameter.attr<double>(_Unicode(ecal_barrel_tolerance));
     const int n_towers = (int) xmlParameter.attr<double>(_Unicode(num_towers));
     const int n_rails = (int) xmlParameter.attr<double>(_Unicode(num_rails));
@@ -49,8 +68,8 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
     const double towersAirGap = xmlParameter.attr<double>(_Unicode(TowersAirGap));
     const double faceThickness = xmlParameter.attr<double>(_Unicode(TowersFaceThickness));
     const double supportRailCS = xmlParameter.attr<double>(_Unicode(supportRailCrossSection));
-    Material Composite = lcdd.material(xmlParameter.attr<string>(_Unicode(AlveolusMaterial)));
-    Material Steel = lcdd.material(xmlParameter.attr<string>(_Unicode(supportRailMaterial)));
+    Material Composite = theDetector.material(xmlParameter.attr<string>(_Unicode(AlveolusMaterial)));
+    Material Steel = theDetector.material(xmlParameter.attr<string>(_Unicode(supportRailMaterial)));
 
     Readout readout = sens.readout();
     Segmentation seg = readout.segmentation();
@@ -61,7 +80,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
     double cell_sizeY      = cellSizeVector[1];
     
     Layering      layering (e);
-    Material      air       = lcdd.air();
+    Material      air       = theDetector.air();
     xml_comp_t    x_staves  = x_det.staves();
     xml_comp_t    x_dim     = x_det.dimensions();
     int           nsides    = x_dim.numsides();
@@ -76,8 +95,8 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
 
     // Create caloData object to extend driver with data required for reconstruction
     // See http://cern.ch/go/z8tp to learn how quantities are calculated
-    DDRec::LayeredCalorimeterData* caloData = new DDRec::LayeredCalorimeterData;
-    caloData->layoutType = DDRec::LayeredCalorimeterData::BarrelLayout;
+    LayeredCalorimeterData* caloData = new LayeredCalorimeterData;
+    caloData->layoutType = LayeredCalorimeterData::BarrelLayout;
     caloData->inner_symmetry = nsides;
     caloData->outer_symmetry = nsides; 
     
@@ -204,7 +223,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
 	    Volume     l_vol(l_name, l_box, air);
 	    DetElement layer(stack_det, l_name, det_id);
 
-	    DDRec::LayeredCalorimeterData::Layer caloLayer;
+	    LayeredCalorimeterData::Layer caloLayer;
 	    double nRadiationLengths   = 0.;
 	    double nInteractionLengths = 0.;
 	    double thickness_sum       = 0.;
@@ -222,7 +241,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
 	      std::cout << s_name << " thickness: " << s_thick << std::endl;
 #endif
 	      Box        s_box(l_dim_x - tolerance, l_dim_y - tolerance, s_thick/2.);
-	      Material   slice_material  = lcdd.material(x_slice.materialStr());
+	      Material   slice_material  = theDetector.material(x_slice.materialStr());
 	      Volume     s_vol(s_name, s_box, slice_material);
 	      DetElement slice(layer, s_name, det_id);
 
@@ -261,7 +280,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
 	      	absorberThickness += s_thick;
 	      }
 	      
-	      slice.setAttributes(lcdd, s_vol, x_slice.regionStr(), x_slice.limitsStr(), x_slice.visStr());
+	      slice.setAttributes(theDetector, s_vol, x_slice.regionStr(), x_slice.limitsStr(), x_slice.visStr());
 	      
 	      // Slice placement
 	      PlacedVolume slice_pv = l_vol.placeVolume(s_vol, Position(0., 0., s_pos_z + s_thick/2.));
@@ -274,7 +293,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
 	    }
 	    
 	    // Set region, limitset, and visibility of layer
-	    layer.setAttributes(lcdd, l_vol, x_layer.regionStr(), x_layer.limitsStr(), x_layer.visStr());
+	    layer.setAttributes(theDetector, l_vol, x_layer.regionStr(), x_layer.limitsStr(), x_layer.visStr());
 	    
 	    PlacedVolume layer_pv = stack_vol.placeVolume(l_vol, l_pos);
 	    layer_pv.addPhysVolID("layer", l_num);
@@ -300,15 +319,15 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
 	    ++l_num;
 	  }
 	}
-	//stack_det.setAttributes(lcdd, stack_vol, x_staves.regionStr(), x_staves.limitsStr(), x_staves.visStr());
-	stack_vol.setVisAttributes(lcdd.visAttributes(x_staves.visStr())); // Fix this!
+	//stack_det.setAttributes(theDetector, stack_vol, x_staves.regionStr(), x_staves.limitsStr(), x_staves.visStr());
+	stack_vol.setVisAttributes(theDetector.visAttributes(x_staves.visStr())); // Fix this!
 	
 	PlacedVolume stack_pv = tower_vol.placeVolume(stack_vol, Position(0., m_pos_y, 0.));
 	stack_pv.addPhysVolID("submodule", m); 
 	stack_det.setPlacement(stack_pv);
       }
-      //tower_det.setAttributes(lcdd, tower_vol, x_staves.regionStr(), x_staves.limitsStr(), x_staves.visStr());
-      tower_vol.setVisAttributes(lcdd.visAttributes(x_staves.visStr())); // Fix this!
+      //tower_det.setAttributes(theDetector, tower_vol, x_staves.regionStr(), x_staves.limitsStr(), x_staves.visStr());
+      tower_vol.setVisAttributes(theDetector.visAttributes(x_staves.visStr())); // Fix this!
       
       PlacedVolume tower_pv = stave_vol.placeVolume(tower_vol, Position(0., t_pos_y, -ry));
       tower_pv.addPhysVolID("module", t);  
@@ -324,13 +343,13 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
       double r_pos_y = (r - (n_rails - 1)/2)*rail_spacing;
       //PlacedVolume rail_pv = stave_vol.placeVolume(rail_vol, Position(r_pos_y, t_pos_y, trd_z));//3x5
       PlacedVolume rail_pv = stave_vol.placeVolume(rail_vol, Position(r_pos_y, 0., trd_z));//3
-      //rail_vol.setVisAttributes(lcdd.visAttributes(x_staves.visStr())); // fix!
+      //rail_vol.setVisAttributes(theDetector.visAttributes(x_staves.visStr())); // fix!
       rail_support.setPlacement(rail_pv);
     }
     
     // Set visualization
     if ( x_staves ) {
-        stave_vol.setVisAttributes(lcdd.visAttributes(x_staves.visStr()));
+        stave_vol.setVisAttributes(theDetector.visAttributes(x_staves.visStr()));
     }
     
     // Place the staves
@@ -349,9 +368,9 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
     }    
 
     // Set envelope volume attributes
-    envelope.setAttributes(lcdd,x_det.regionStr(),x_det.limitsStr(),x_det.visStr());
+    envelope.setAttributes(theDetector,x_det.regionStr(),x_det.limitsStr(),x_det.visStr());
     
-    sdet.addExtension< DDRec::LayeredCalorimeterData >( caloData ) ;
+    sdet.addExtension< LayeredCalorimeterData >( caloData ) ;
         
     return sdet;
 }

--- a/detector/calorimeter/ECalBarrel_o1_v03_geo.cpp
+++ b/detector/calorimeter/ECalBarrel_o1_v03_geo.cpp
@@ -24,10 +24,29 @@
 #include "DDSegmentation/Segmentation.h"
 
 using namespace std;
-using namespace DD4hep;
-using namespace DD4hep::Geometry;
 
-static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
+using dd4hep::BUILD_ENVELOPE;
+using dd4hep::Box;
+using dd4hep::DetElement;
+using dd4hep::Detector;
+using dd4hep::Layering;
+using dd4hep::Material;
+using dd4hep::PlacedVolume;
+using dd4hep::Position;
+using dd4hep::Readout;
+using dd4hep::Ref_t;
+using dd4hep::RotationZYX;
+using dd4hep::Segmentation;
+using dd4hep::SensitiveDetector;
+using dd4hep::Transform3D;
+using dd4hep::Translation3D;
+using dd4hep::Trapezoid;
+using dd4hep::Volume;
+using dd4hep::_toString;
+
+using dd4hep::rec::LayeredCalorimeterData;
+
+static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector sens)  {
     
     xml_det_t     x_det     = e;
     int           det_id    = x_det.id();
@@ -36,14 +55,14 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
     
     // --- create an envelope volume and position it into the world ---------------------
     
-    Volume envelope = XML::createPlacedEnvelope(lcdd, e, sdet);
-    XML::setDetectorTypeFlag( e, sdet ) ;
+    Volume envelope = dd4hep::xml::createPlacedEnvelope(theDetector, e, sdet);
+    dd4hep::xml::setDetectorTypeFlag( e, sdet ) ;
     
-    if(lcdd.buildType() == BUILD_ENVELOPE) return sdet;
+    if(theDetector.buildType() == BUILD_ENVELOPE) return sdet;
     
     //-----------------------------------------------------------------------------------
 
-    DD4hep::XML::Component xmlParameter = x_det.child(_Unicode(parameter));
+    dd4hep::xml::Component xmlParameter = x_det.child(_Unicode(parameter));
     const double tolerance = xmlParameter.attr<double>(_Unicode(ecal_barrel_tolerance));
     const int n_towers = (int) xmlParameter.attr<double>(_Unicode(num_towers));
     const int n_rails = (int) xmlParameter.attr<double>(_Unicode(num_rails));
@@ -51,8 +70,8 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
     const double towersAirGap = xmlParameter.attr<double>(_Unicode(TowersAirGap));
     const double faceThickness = xmlParameter.attr<double>(_Unicode(TowersFaceThickness));
     const double supportRailCS = xmlParameter.attr<double>(_Unicode(supportRailCrossSection));
-    Material Composite = lcdd.material(xmlParameter.attr<string>(_Unicode(AlveolusMaterial)));
-    Material Steel = lcdd.material(xmlParameter.attr<string>(_Unicode(supportRailMaterial)));
+    Material Composite = theDetector.material(xmlParameter.attr<string>(_Unicode(AlveolusMaterial)));
+    Material Steel = theDetector.material(xmlParameter.attr<string>(_Unicode(supportRailMaterial)));
 
     Readout readout = sens.readout();
     Segmentation seg = readout.segmentation();
@@ -63,7 +82,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
     double cell_sizeY      = cellSizeVector[1];
     
     Layering      layering (e);
-    Material      air       = lcdd.air();
+    Material      air       = theDetector.air();
     xml_comp_t    x_staves  = x_det.staves();
     xml_comp_t    x_dim     = x_det.dimensions();
     int           nsides    = x_dim.numsides();
@@ -79,8 +98,8 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
 
     // Create caloData object to extend driver with data required for reconstruction
     // See http://cern.ch/go/z8tp to learn how quantities are calculated
-    DDRec::LayeredCalorimeterData* caloData = new DDRec::LayeredCalorimeterData;
-    caloData->layoutType = DDRec::LayeredCalorimeterData::BarrelLayout;
+    LayeredCalorimeterData* caloData = new LayeredCalorimeterData;
+    caloData->layoutType = LayeredCalorimeterData::BarrelLayout;
     caloData->inner_symmetry = nsides;
     caloData->outer_symmetry = nsides; 
     
@@ -209,7 +228,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
 	    Volume     l_vol(l_name, l_box, air);
 	    DetElement layer(stack_det, l_name, det_id);
 
-	    DDRec::LayeredCalorimeterData::Layer caloLayer;
+	    LayeredCalorimeterData::Layer caloLayer;
 	    double nRadiationLengths   = 0.;
 	    double nInteractionLengths = 0.;
 	    double thickness_sum       = 0.;
@@ -227,7 +246,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
 	      std::cout << s_name << " thickness: " << s_thick << std::endl;
 #endif
 	      Box        s_box(l_dim_x - tolerance, l_dim_y - tolerance, s_thick/2.);
-	      Material   slice_material  = lcdd.material(x_slice.materialStr());
+	      Material   slice_material  = theDetector.material(x_slice.materialStr());
 	      Volume     s_vol(s_name, s_box, slice_material);
 	      DetElement slice(layer, s_name, det_id);
 
@@ -266,7 +285,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
 	      	absorberThickness += s_thick;
 	      }
 	      
-	      slice.setAttributes(lcdd, s_vol, x_slice.regionStr(), x_slice.limitsStr(), x_slice.visStr());
+	      slice.setAttributes(theDetector, s_vol, x_slice.regionStr(), x_slice.limitsStr(), x_slice.visStr());
 	      
 	      // Slice placement
 	      PlacedVolume slice_pv = l_vol.placeVolume(s_vol, Position(0., 0., s_pos_z + s_thick/2.));
@@ -279,7 +298,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
 	    }
 	    
 	    // Set region, limitset, and visibility of layer
-	    layer.setAttributes(lcdd, l_vol, x_layer.regionStr(), x_layer.limitsStr(), x_layer.visStr());
+	    layer.setAttributes(theDetector, l_vol, x_layer.regionStr(), x_layer.limitsStr(), x_layer.visStr());
 	    
 	    PlacedVolume layer_pv = stack_vol.placeVolume(l_vol, l_pos);
 	    layer_pv.addPhysVolID("layer", l_num);
@@ -306,15 +325,15 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
 	    ++l_num;
 	  }
 	}
-	//stack_det.setAttributes(lcdd, stack_vol, x_staves.regionStr(), x_staves.limitsStr(), x_staves.visStr());
-	stack_vol.setVisAttributes(lcdd.visAttributes(x_staves.visStr())); // Fix this!
+	//stack_det.setAttributes(theDetector, stack_vol, x_staves.regionStr(), x_staves.limitsStr(), x_staves.visStr());
+	stack_vol.setVisAttributes(theDetector.visAttributes(x_staves.visStr())); // Fix this!
 	
 	PlacedVolume stack_pv = tower_vol.placeVolume(stack_vol, Position(0., m_pos_y, 0.));
 	//as	stack_pv.addPhysVolID("submodule", m); 
 	stack_det.setPlacement(stack_pv);
       }
-      //tower_det.setAttributes(lcdd, tower_vol, x_staves.regionStr(), x_staves.limitsStr(), x_staves.visStr());
-      tower_vol.setVisAttributes(lcdd.visAttributes(x_staves.visStr())); // Fix this!
+      //tower_det.setAttributes(theDetector, tower_vol, x_staves.regionStr(), x_staves.limitsStr(), x_staves.visStr());
+      tower_vol.setVisAttributes(theDetector.visAttributes(x_staves.visStr())); // Fix this!
       
       PlacedVolume tower_pv = stave_vol.placeVolume(tower_vol, Position(0., t_pos_y, -ry));
       //as      tower_pv.addPhysVolID("module", t);  
@@ -330,13 +349,13 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
       double r_pos_y = (r - (n_rails - 1)/2)*rail_spacing;
       //PlacedVolume rail_pv = stave_vol.placeVolume(rail_vol, Position(r_pos_y, t_pos_y, trd_z));//3x5
       PlacedVolume rail_pv = stave_vol.placeVolume(rail_vol, Position(r_pos_y, 0., trd_z));//3
-      //rail_vol.setVisAttributes(lcdd.visAttributes(x_staves.visStr())); // fix!
+      //rail_vol.setVisAttributes(theDetector.visAttributes(x_staves.visStr())); // fix!
       rail_support.setPlacement(rail_pv);
     }
     
     // Set visualization
     if ( x_staves ) {
-        stave_vol.setVisAttributes(lcdd.visAttributes(x_staves.visStr()));
+        stave_vol.setVisAttributes(theDetector.visAttributes(x_staves.visStr()));
     }
     
     // Place the staves
@@ -356,9 +375,9 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
     }    
 
     // Set envelope volume attributes
-    envelope.setAttributes(lcdd,x_det.regionStr(),x_det.limitsStr(),x_det.visStr());
+    envelope.setAttributes(theDetector,x_det.regionStr(),x_det.limitsStr(),x_det.visStr());
     
-    sdet.addExtension< DDRec::LayeredCalorimeterData >( caloData ) ;
+    sdet.addExtension< LayeredCalorimeterData >( caloData ) ;
         
     return sdet;
 }

--- a/detector/calorimeter/ECalBarrel_o2_v01_geo.cpp
+++ b/detector/calorimeter/ECalBarrel_o2_v01_geo.cpp
@@ -13,8 +13,28 @@
 #include "DDSegmentation/Segmentation.h"
 
 using namespace std;
-using namespace DD4hep;
-using namespace DD4hep::Geometry;
+
+using dd4hep::BUILD_ENVELOPE;
+using dd4hep::Box;
+using dd4hep::DetElement;
+using dd4hep::Detector;
+using dd4hep::Layer;
+using dd4hep::Layering;
+using dd4hep::Material;
+using dd4hep::PlacedVolume;
+using dd4hep::Position;
+using dd4hep::Readout;
+using dd4hep::Ref_t;
+using dd4hep::RotationZYX;
+using dd4hep::Segmentation;
+using dd4hep::SensitiveDetector;
+using dd4hep::Transform3D;
+using dd4hep::Translation3D;
+using dd4hep::Trapezoid;
+using dd4hep::Volume;
+using dd4hep::_toString;
+
+using dd4hep::rec::LayeredCalorimeterData;
 
 static void placeStaves(DetElement& parent, DetElement& stave, double rmin, int numsides, double total_thickness,
                         Volume envelopeVolume, double innerAngle, Volume sectVolume)
@@ -41,15 +61,15 @@ static void placeStaves(DetElement& parent, DetElement& stave, double rmin, int 
   }
 }
 
-static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)
-{
+
+static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector sens) {
   xml_det_t x_det = e;
   Layering layering(x_det);
   xml_comp_t staves = x_det.staves();
   xml_dim_t dim = x_det.dimensions();
   string det_name = x_det.nameStr();
   string det_type = x_det.typeStr();
-  Material air = lcdd.air();
+  Material air = theDetector.air();
   double totalThickness = layering.totalThickness();
   int totalRepeat = 0;
   int totalSlices = 0;
@@ -60,7 +80,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)
   double rmin = dim.rmin();
   DetElement sdet(det_name, x_det.id());
   DetElement stave("stave1", x_det.id());
-  //  Volume motherVol = lcdd.pickMotherVolume(sdet);
+  //  Volume motherVol = theDetector.pickMotherVolume(sdet);
   Readout readout = sens.readout();
   Segmentation seg = readout.segmentation();
 
@@ -69,8 +89,8 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)
   double cell_sizeY      = cellSizeVector[1];
 
   //Create caloData object to extend driver with data required for reconstruction
-  DDRec::LayeredCalorimeterData* caloData = new DDRec::LayeredCalorimeterData ;
-  caloData->layoutType = DDRec::LayeredCalorimeterData::BarrelLayout ;
+  LayeredCalorimeterData* caloData = new LayeredCalorimeterData ;
+  caloData->layoutType = LayeredCalorimeterData::BarrelLayout ;
   caloData->inner_symmetry = nsides;
   caloData->outer_symmetry = nsides;
 
@@ -97,9 +117,9 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)
 
 // --- create an envelope volume and position it into the world ---------------------
 
-  Volume envelopeVol = XML::createPlacedEnvelope(lcdd,  e , sdet) ;
+  Volume envelopeVol = dd4hep::xml::createPlacedEnvelope(theDetector,  e , sdet) ;
 
-  if (lcdd.buildType() == BUILD_ENVELOPE) return sdet ;
+  if (theDetector.buildType() == BUILD_ENVELOPE) return sdet ;
 
   //-----------------------------------------------------------------------------------
 
@@ -148,7 +168,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)
       DetElement layer(stave, layer_name, layer_num);
       //### layeringExtension->setLayer(layer_num, layer, layerNormal);
 
-      DDRec::LayeredCalorimeterData::Layer caloLayer ;
+      LayeredCalorimeterData::Layer caloLayer ;
 
 
       // Layer position in Z within the stave.
@@ -167,7 +187,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)
         xml_comp_t x_slice = k;
         string slice_name = _toString(slice_number, "slice%d");
         double slice_thickness = x_slice.thickness();
-        Material slice_material = lcdd.material(x_slice.materialStr());
+        Material slice_material = theDetector.material(x_slice.materialStr());
         DetElement slice(layer, slice_name, slice_number);
 
         slice_pos_z += slice_thickness / 2;
@@ -196,7 +216,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)
 
 
         // Set region, limitset, and vis.
-        slice_vol.setAttributes(lcdd, x_slice.regionStr(), x_slice.limitsStr(), x_slice.visStr());
+        slice_vol.setAttributes(theDetector, x_slice.regionStr(), x_slice.limitsStr(), x_slice.visStr());
         // slice PlacedVolume
         PlacedVolume slice_phv = layer_vol.placeVolume(slice_vol, Position(0, 0, slice_pos_z));
 
@@ -207,7 +227,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)
         ++slice_number;
       }
       // Set region, limitset, and vis.
-      layer_vol.setAttributes(lcdd, x_layer.regionStr(), x_layer.limitsStr(), x_layer.visStr());
+      layer_vol.setAttributes(theDetector, x_layer.regionStr(), x_layer.limitsStr(), x_layer.visStr());
 
       // Layer physical volume.
       PlacedVolume layer_phv = staveInnerVol.placeVolume(layer_vol, Position(0, 0, layer_pos_z));
@@ -238,18 +258,18 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)
   staveOuterVol.placeVolume(staveInnerVol);
   if (staves)  {
     // Set the vis attributes of the outer stave section.
-    stave.setVisAttributes(lcdd, staves.visStr(), staveInnerVol);
-    stave.setVisAttributes(lcdd, staves.visStr(), staveOuterVol);
+    stave.setVisAttributes(theDetector, staves.visStr(), staveInnerVol);
+    stave.setVisAttributes(theDetector, staves.visStr(), staveOuterVol);
   }
   // Place the staves.
   placeStaves(sdet, stave, rmin, nsides, totalThickness, envelopeVol, innerAngle, staveOuterVol);
   // Set envelope volume attributes.
-  envelopeVol.setAttributes(lcdd, x_det.regionStr(), x_det.limitsStr(), x_det.visStr());
+  envelopeVol.setAttributes(theDetector, x_det.regionStr(), x_det.limitsStr(), x_det.visStr());
 
 
   //FOR NOW, USE A MORE "SIMPLE" VERSION OF EXTENSIONS, INCLUDING NECESSARY GEAR PARAMETERS
   //Copied from Frank's SECalSc04 Implementation
-  sdet.addExtension< DDRec::LayeredCalorimeterData >(caloData) ;
+  sdet.addExtension< LayeredCalorimeterData >(caloData) ;
 
   return sdet;
 }

--- a/detector/calorimeter/ECalEndcap_o2_v01_geo.cpp
+++ b/detector/calorimeter/ECalEndcap_o2_v01_geo.cpp
@@ -14,10 +14,29 @@
 #include "DDSegmentation/Segmentation.h"
 
 using namespace std;
-using namespace DD4hep;
-using namespace DD4hep::Geometry;
 
-static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
+using dd4hep::BUILD_ENVELOPE;
+using dd4hep::DetElement;
+using dd4hep::Detector;
+using dd4hep::Layer;
+using dd4hep::Layering;
+using dd4hep::Material;
+using dd4hep::PlacedVolume;
+using dd4hep::PolyhedraRegular;
+using dd4hep::Position;
+using dd4hep::Readout;
+using dd4hep::Ref_t;
+using dd4hep::RotationZYX;
+using dd4hep::Segmentation;
+using dd4hep::SensitiveDetector;
+using dd4hep::Transform3D;
+using dd4hep::Volume;
+using dd4hep::_toString;
+
+using dd4hep::rec::LayeredCalorimeterData;
+
+static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector sens) {
+
   xml_det_t   x_det     = e;
   int         det_id    = x_det.id();
   string      det_name  = x_det.nameStr();
@@ -25,9 +44,9 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
 
   // --- create an envelope volume and position it into the world ---------------------
   
-  Volume envelope = XML::createPlacedEnvelope( lcdd,  e , sdet ) ;
+  Volume envelope = dd4hep::xml::createPlacedEnvelope( theDetector,  e , sdet ) ;
   
-  if( lcdd.buildType() == BUILD_ENVELOPE ) return sdet ;
+  if( theDetector.buildType() == BUILD_ENVELOPE ) return sdet ;
   
   //-----------------------------------------------------------------------------------
   
@@ -36,7 +55,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
     
 //   std::cout<<"Building ECal EndCap inside envelope."<<std::endl;
   xml_dim_t   dim       = x_det.dimensions();
-  Material    air       = lcdd.air();
+  Material    air       = theDetector.air();
   int         nsides_inner = dim.nsides_inner();
   int         nsides_outer = dim.nsides_outer();
   double      rmin      = dim.rmin();
@@ -66,8 +85,8 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
   double layerZ   = -totalThickness/2;
   
   //Create caloData object to extend driver with data required for reconstruction
-  DDRec::LayeredCalorimeterData* caloData = new DDRec::LayeredCalorimeterData ;
-  caloData->layoutType = DDRec::LayeredCalorimeterData::EndcapLayout ;
+  LayeredCalorimeterData* caloData = new LayeredCalorimeterData ;
+  caloData->layoutType = LayeredCalorimeterData::EndcapLayout ;
   caloData->inner_symmetry = nsides_inner;
   caloData->outer_symmetry = nsides_outer; 
   
@@ -90,7 +109,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
   caloData->extent[2] = zmin ;
   caloData->extent[3] = zmin + totalThickness;
   
-  endcapVol.setAttributes(lcdd,x_det.regionStr(),x_det.limitsStr(),x_det.visStr());
+  endcapVol.setAttributes(theDetector,x_det.regionStr(),x_det.limitsStr(),x_det.visStr());
   
   for(xml_coll_t c(x_det,_U(layer)); c; ++c)  {
     xml_comp_t       x_layer  = c;
@@ -113,10 +132,10 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
       xml_comp_t x_slice = s;
       string     s_name  = _toString(s_num,"slice%d");
       double     s_thick = x_slice.thickness();
-      Material   s_mat   = lcdd.material(x_slice.materialStr());
+      Material   s_mat   = theDetector.material(x_slice.materialStr());
       Volume     s_vol(s_name,PolyhedraRegular(nsides_outer,rmin,rmax,s_thick),s_mat);
       
-      s_vol.setVisAttributes(lcdd.visAttributes(x_slice.visStr()));
+      s_vol.setVisAttributes(theDetector.visAttributes(x_slice.visStr()));
       sliceZ += s_thick/2;
       PlacedVolume s_phv = l_vol.placeVolume(s_vol,Position(0,0,sliceZ));
       if ( x_slice.isSensitive() )  {
@@ -139,7 +158,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
       sliceZ += s_thick/2;
       s_num++;
     }
-    l_vol.setVisAttributes(lcdd.visAttributes(x_layer.visStr()));
+    l_vol.setVisAttributes(theDetector.visAttributes(x_layer.visStr()));
     if ( l_repeat <= 0 ) throw std::runtime_error(x_det.nameStr()+"> Invalid repeat value");
     for(int j=0; j<l_repeat; ++j) {
       string phys_lay = _toString(l_num,"layer%d");
@@ -155,7 +174,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
       }
       
       ///FIXME: IS ORIENTATION RIGHT? WHICH SIDE DO WE NEED TO ADD TO STRUCTURE?
-      DDRec::LayeredCalorimeterData::Layer caloLayer ;
+      LayeredCalorimeterData::Layer caloLayer ;
       caloLayer.distance = zmin + totalThickness/2 + layerZ;
       caloLayer.inner_thickness = th_i ;
       caloLayer.outer_thickness = th_o ;
@@ -193,7 +212,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
 
   sdet.add(endcapB);
   
-  sdet.addExtension< DDRec::LayeredCalorimeterData >( caloData ) ;
+  sdet.addExtension< LayeredCalorimeterData >( caloData ) ;
   
   return sdet;
   

--- a/detector/calorimeter/ECalPlug_o1_v01_geo.cpp
+++ b/detector/calorimeter/ECalPlug_o1_v01_geo.cpp
@@ -18,10 +18,15 @@
 #include "XML/Utilities.h"
 
 using namespace std;
-using namespace DD4hep;
-using namespace DD4hep::Geometry;
 
-static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector )  {
+using dd4hep::BUILD_ENVELOPE;
+using dd4hep::DetElement;
+using dd4hep::Detector;
+using dd4hep::Ref_t;
+using dd4hep::SensitiveDetector;
+
+static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector ) {
+
     // static double tolerance = 0e0;
     
     xml_det_t     x_det     = e;
@@ -32,10 +37,10 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector )  {
     // --- create an envelope volume and position it into the world ---------------------
     
     // Volume envelope =
-    XML::createPlacedEnvelope( lcdd,  e , sdet ) ;
-    XML::setDetectorTypeFlag( e, sdet ) ;
+    dd4hep::xml::createPlacedEnvelope( theDetector,  e , sdet ) ;
+    dd4hep::xml::setDetectorTypeFlag( e, sdet ) ;
     
-    if( lcdd.buildType() == BUILD_ENVELOPE ) return sdet ;
+    if( theDetector.buildType() == BUILD_ENVELOPE ) return sdet ;
     
     //-----------------------------------------------------------------------------------
     

--- a/detector/calorimeter/GenericCalBarrel_o1_v01_geo.cpp
+++ b/detector/calorimeter/GenericCalBarrel_o1_v01_geo.cpp
@@ -13,8 +13,28 @@
 #include "DDSegmentation/Segmentation.h"
 
 using namespace std;
-using namespace DD4hep;
-using namespace DD4hep::Geometry;
+
+using dd4hep::BUILD_ENVELOPE;
+using dd4hep::Box;
+using dd4hep::DetElement;
+using dd4hep::Detector;
+using dd4hep::Layer;
+using dd4hep::Layering;
+using dd4hep::Material;
+using dd4hep::PlacedVolume;
+using dd4hep::Position;
+using dd4hep::Readout;
+using dd4hep::Ref_t;
+using dd4hep::RotationZYX;
+using dd4hep::Segmentation;
+using dd4hep::SensitiveDetector;
+using dd4hep::Transform3D;
+using dd4hep::Translation3D;
+using dd4hep::Trapezoid;
+using dd4hep::Volume;
+using dd4hep::_toString;
+
+using dd4hep::rec::LayeredCalorimeterData;
 
 // workaround for DD4hep v00-14 (and older) 
 #ifndef DD4HEP_VERSION_GE
@@ -45,14 +65,14 @@ static void placeStaves(DetElement& parent, DetElement& stave, double rmin, int 
     }
 }
 
-static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens) {
+static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector sens) {
     xml_det_t x_det = e;
     Layering layering(x_det);
     xml_comp_t staves = x_det.staves();
     xml_dim_t dim = x_det.dimensions();
     string det_name = x_det.nameStr();
     string det_type = x_det.typeStr();
-    Material air = lcdd.air();
+    Material air = theDetector.air();
     double totalThickness = layering.totalThickness();
     int totalRepeat = 0;
     int totalSlices = 0;
@@ -63,7 +83,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens) {
     double rmin = dim.rmin();
     DetElement sdet(det_name, x_det.id());
     DetElement stave("stave0", x_det.id());
-    //  Volume motherVol = lcdd.pickMotherVolume(sdet);
+    //  Volume motherVol = theDetector.pickMotherVolume(sdet);
     Readout readout = sens.readout();
     Segmentation seg = readout.segmentation();
     
@@ -72,8 +92,8 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens) {
     double cell_sizeY      = cellSizeVector[1];
     
     //Create caloData object to extend driver with data required for reconstruction
-    DDRec::LayeredCalorimeterData* caloData = new DDRec::LayeredCalorimeterData ;
-    caloData->layoutType = DDRec::LayeredCalorimeterData::BarrelLayout ;
+    LayeredCalorimeterData* caloData = new LayeredCalorimeterData ;
+    caloData->layoutType = LayeredCalorimeterData::BarrelLayout ;
     caloData->inner_symmetry = nsides;
     caloData->outer_symmetry = nsides; 
     
@@ -100,10 +120,10 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens) {
     
     // --- create an envelope volume and position it into the world ---------------------
     
-    Volume envelopeVol = XML::createPlacedEnvelope( lcdd,  e , sdet ) ;
-    XML::setDetectorTypeFlag( e, sdet ) ;
+    Volume envelopeVol = dd4hep::xml::createPlacedEnvelope( theDetector,  e , sdet ) ;
+    dd4hep::xml::setDetectorTypeFlag( e, sdet ) ;
     
-    if( lcdd.buildType() == BUILD_ENVELOPE ) return sdet ;
+    if( theDetector.buildType() == BUILD_ENVELOPE ) return sdet ;
     
     //-----------------------------------------------------------------------------------
     
@@ -142,7 +162,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens) {
         double layer_thickness = lay->thickness();
         string layer_type_name   = _toString(layerType,"layerType%d");
 
-        DDRec::LayeredCalorimeterData::Layer caloLayer ;
+        LayeredCalorimeterData::Layer caloLayer ;
         caloLayer.cellSize0 = cell_sizeX;
         caloLayer.cellSize1 = cell_sizeY;
 
@@ -166,7 +186,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens) {
                 xml_comp_t x_slice = k;
                 string slice_name = _toString(slice_number, "slice%d");
                 double slice_thickness = x_slice.thickness();
-                Material slice_material = lcdd.material(x_slice.materialStr());
+                Material slice_material = theDetector.material(x_slice.materialStr());
                 
                 slice_pos_z += slice_thickness / 2;
                 // Slice volume & box
@@ -199,7 +219,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens) {
                 thickness_sum += slice_thickness/2;
                 
                 // Set region, limitset, and vis.
-                slice_vol.setAttributes(lcdd, x_slice.regionStr(), x_slice.limitsStr(), x_slice.visStr());
+                slice_vol.setAttributes(theDetector, x_slice.regionStr(), x_slice.limitsStr(), x_slice.visStr());
                 // slice PlacedVolume
                 layer_vol.placeVolume(slice_vol, Position(0, 0, slice_pos_z));
                 
@@ -217,7 +237,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens) {
 #endif        
             
             // Set region, limitset, and vis.
-            layer_vol.setAttributes(lcdd, x_layer.regionStr(), x_layer.limitsStr(), x_layer.visStr());
+            layer_vol.setAttributes(theDetector, x_layer.regionStr(), x_layer.limitsStr(), x_layer.visStr());
 
 
             
@@ -254,18 +274,18 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens) {
     staveOuterVol.placeVolume(staveInnerVol);
     if ( staves )  {
         // Set the vis attributes of the outer stave section.
-        stave.setVisAttributes(lcdd, staves.visStr(), staveInnerVol);
-        stave.setVisAttributes(lcdd, staves.visStr(), staveOuterVol);
+        stave.setVisAttributes(theDetector, staves.visStr(), staveInnerVol);
+        stave.setVisAttributes(theDetector, staves.visStr(), staveOuterVol);
     }
     // Place the staves.
     placeStaves(sdet, stave, rmin, nsides, totalThickness, envelopeVol, innerAngle, staveOuterVol);
     // Set envelope volume attributes.
-    envelopeVol.setAttributes(lcdd, x_det.regionStr(), x_det.limitsStr(), x_det.visStr());
+    envelopeVol.setAttributes(theDetector, x_det.regionStr(), x_det.limitsStr(), x_det.visStr());
     
     
     //FOR NOW, USE A MORE "SIMPLE" VERSION OF EXTENSIONS, INCLUDING NECESSARY GEAR PARAMETERS
     //Copied from Frank's SHcalSc04 Implementation
-    sdet.addExtension< DDRec::LayeredCalorimeterData >( caloData ) ;
+    sdet.addExtension< LayeredCalorimeterData >( caloData ) ;
     
     return sdet;
 }

--- a/detector/calorimeter/HCalBarrel_o1_v01_geo.cpp
+++ b/detector/calorimeter/HCalBarrel_o1_v01_geo.cpp
@@ -13,8 +13,29 @@
 #include "DDSegmentation/Segmentation.h"
 
 using namespace std;
-using namespace DD4hep;
-using namespace DD4hep::Geometry;
+
+using dd4hep::BUILD_ENVELOPE;
+using dd4hep::Box;
+using dd4hep::DetElement;
+using dd4hep::Detector;
+using dd4hep::Layer;
+using dd4hep::Layering;
+using dd4hep::Material;
+using dd4hep::PlacedVolume;
+using dd4hep::PolyhedraRegular;
+using dd4hep::Position;
+using dd4hep::Readout;
+using dd4hep::Ref_t;
+using dd4hep::RotationZYX;
+using dd4hep::Segmentation;
+using dd4hep::SensitiveDetector;
+using dd4hep::Transform3D;
+using dd4hep::Translation3D;
+using dd4hep::Trapezoid;
+using dd4hep::Volume;
+using dd4hep::_toString;
+
+using dd4hep::rec::LayeredCalorimeterData;
 
 static void placeStaves(DetElement& parent, DetElement& stave, double rmin, int numsides, double total_thickness,
 			Volume envelopeVolume, double innerAngle, Volume sectVolume) {
@@ -40,14 +61,14 @@ static void placeStaves(DetElement& parent, DetElement& stave, double rmin, int 
   }
 }
 
-static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens) {
+static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector sens) {
   xml_det_t x_det = e;
   Layering layering(x_det);
   xml_comp_t staves = x_det.staves();
   xml_dim_t dim = x_det.dimensions();
   string det_name = x_det.nameStr();
   string det_type = x_det.typeStr();
-  Material air = lcdd.air();
+  Material air = theDetector.air();
   double totalThickness = layering.totalThickness();
   int totalRepeat = 0;
   int totalSlices = 0;
@@ -58,7 +79,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens) {
   double rmin = dim.rmin();
   DetElement sdet(det_name, x_det.id());
   DetElement stave("stave1", x_det.id());
-  //  Volume motherVol = lcdd.pickMotherVolume(sdet);
+  //  Volume motherVol = theDetector.pickMotherVolume(sdet);
   Readout readout = sens.readout();
   Segmentation seg = readout.segmentation();
   
@@ -67,8 +88,8 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens) {
   double cell_sizeY      = cellSizeVector[1];
   
   //Create caloData object to extend driver with data required for reconstruction
-  DDRec::LayeredCalorimeterData* caloData = new DDRec::LayeredCalorimeterData ;
-  caloData->layoutType = DDRec::LayeredCalorimeterData::BarrelLayout ;
+  LayeredCalorimeterData* caloData = new LayeredCalorimeterData ;
+  caloData->layoutType = LayeredCalorimeterData::BarrelLayout ;
   caloData->inner_symmetry = nsides;
   caloData->outer_symmetry = nsides; 
   
@@ -95,9 +116,9 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens) {
 
  // --- create an envelope volume and position it into the world ---------------------
 
-  Volume envelopeVol = XML::createPlacedEnvelope( lcdd,  e , sdet ) ;
+  Volume envelopeVol = dd4hep::xml::createPlacedEnvelope( theDetector,  e , sdet ) ;
 
-  if( lcdd.buildType() == BUILD_ENVELOPE ) return sdet ;
+  if( theDetector.buildType() == BUILD_ENVELOPE ) return sdet ;
 
   //-----------------------------------------------------------------------------------
 
@@ -147,7 +168,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens) {
       DetElement layer(stave, layer_name, layer_num);
       //### layeringExtension->setLayer(layer_num, layer, layerNormal);
       
-      DDRec::LayeredCalorimeterData::Layer caloLayer ;
+      LayeredCalorimeterData::Layer caloLayer ;
       
       
       // Layer position in Z within the stave.
@@ -167,7 +188,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens) {
         xml_comp_t x_slice = k;
         string slice_name = _toString(slice_number, "slice%d");
         double slice_thickness = x_slice.thickness();
-        Material slice_material = lcdd.material(x_slice.materialStr());
+        Material slice_material = theDetector.material(x_slice.materialStr());
         DetElement slice(layer, slice_name, slice_number);
         
         slice_pos_z += slice_thickness / 2;
@@ -193,7 +214,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens) {
 	  }
         } 
         // Set region, limitset, and vis.
-        slice_vol.setAttributes(lcdd, x_slice.regionStr(), x_slice.limitsStr(), x_slice.visStr());
+        slice_vol.setAttributes(theDetector, x_slice.regionStr(), x_slice.limitsStr(), x_slice.visStr());
         // slice PlacedVolume
         PlacedVolume slice_phv = layer_vol.placeVolume(slice_vol, Position(0, 0, slice_pos_z));
         
@@ -204,7 +225,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens) {
         ++slice_number;
       }
       // Set region, limitset, and vis.
-      layer_vol.setAttributes(lcdd, x_layer.regionStr(), x_layer.limitsStr(), x_layer.visStr());
+      layer_vol.setAttributes(theDetector, x_layer.regionStr(), x_layer.limitsStr(), x_layer.visStr());
 
       // Layer physical volume.
       PlacedVolume layer_phv = staveInnerVol.placeVolume(layer_vol, Position(0, 0, layer_pos_z));
@@ -238,18 +259,18 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens) {
   staveOuterVol.placeVolume(staveInnerVol);
   if ( staves )  {
     // Set the vis attributes of the outer stave section.
-    stave.setVisAttributes(lcdd, staves.visStr(), staveInnerVol);
-    stave.setVisAttributes(lcdd, staves.visStr(), staveOuterVol);
+    stave.setVisAttributes(theDetector, staves.visStr(), staveInnerVol);
+    stave.setVisAttributes(theDetector, staves.visStr(), staveOuterVol);
   }
   // Place the staves.
   placeStaves(sdet, stave, rmin, nsides, totalThickness, envelopeVol, innerAngle, staveOuterVol);
   // Set envelope volume attributes.
-  envelopeVol.setAttributes(lcdd, x_det.regionStr(), x_det.limitsStr(), x_det.visStr());
+  envelopeVol.setAttributes(theDetector, x_det.regionStr(), x_det.limitsStr(), x_det.visStr());
   
 
   //FOR NOW, USE A MORE "SIMPLE" VERSION OF EXTENSIONS, INCLUDING NECESSARY GEAR PARAMETERS
   //Copied from Frank's SHcalSc04 Implementation
-  sdet.addExtension< DDRec::LayeredCalorimeterData >( caloData ) ;
+  sdet.addExtension< LayeredCalorimeterData >( caloData ) ;
   
   return sdet;
 }

--- a/detector/calorimeter/HCalEndcap_o1_v01_geo.cpp
+++ b/detector/calorimeter/HCalEndcap_o1_v01_geo.cpp
@@ -15,10 +15,29 @@
 
 
 using namespace std;
-using namespace DD4hep;
-using namespace DD4hep::Geometry;
 
-static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
+using dd4hep::BUILD_ENVELOPE;
+using dd4hep::DetElement;
+using dd4hep::Detector;
+using dd4hep::Layer;
+using dd4hep::Layering;
+using dd4hep::Material;
+using dd4hep::PlacedVolume;
+using dd4hep::PolyhedraRegular;
+using dd4hep::Position;
+using dd4hep::Readout;
+using dd4hep::Ref_t;
+using dd4hep::RotationZYX;
+using dd4hep::Segmentation;
+using dd4hep::SensitiveDetector;
+using dd4hep::SubtractionSolid;
+using dd4hep::Transform3D;
+using dd4hep::Volume;
+using dd4hep::_toString;
+
+using dd4hep::rec::LayeredCalorimeterData;
+
+static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector sens) {
   xml_det_t   x_det     = e;
   int         det_id    = x_det.id();
   string      det_name  = x_det.nameStr();
@@ -26,9 +45,9 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
 
   // --- create an envelope volume and position it into the world ---------------------
   
-  Volume envelope = XML::createPlacedEnvelope( lcdd,  e , sdet ) ;
+  Volume envelope = dd4hep::xml::createPlacedEnvelope( theDetector,  e , sdet ) ;
   
-  if( lcdd.buildType() == BUILD_ENVELOPE ) return sdet ;
+  if( theDetector.buildType() == BUILD_ENVELOPE ) return sdet ;
   
   //-----------------------------------------------------------------------------------
   
@@ -37,7 +56,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
     
 //   std::cout<<"Building HCal EndCap inside envelope."<<std::endl;
   xml_dim_t   dim       = x_det.dimensions();
-  Material    air       = lcdd.air();
+  Material    air       = theDetector.air();
   int         nsides_inner = dim.nsides_inner();
   int         nsides_outer = dim.nsides_outer();
   double      rmin      = dim.rmin();
@@ -72,8 +91,8 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
   double layerZ   = -totalThickness/2;
   
   //Create caloData object to extend driver with data required for reconstruction
-  DDRec::LayeredCalorimeterData* caloData = new DDRec::LayeredCalorimeterData ;
-  caloData->layoutType = DDRec::LayeredCalorimeterData::EndcapLayout ;
+  LayeredCalorimeterData* caloData = new LayeredCalorimeterData ;
+  caloData->layoutType = LayeredCalorimeterData::EndcapLayout ;
   caloData->inner_symmetry = nsides_inner;
   caloData->outer_symmetry = nsides_outer; 
   
@@ -97,7 +116,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
   caloData->extent[2] = zmin ;
   caloData->extent[3] = zmin + totalThickness;
   
-  endcapVol.setAttributes(lcdd,x_det.regionStr(),x_det.limitsStr(),x_det.visStr());
+  endcapVol.setAttributes(theDetector,x_det.regionStr(),x_det.limitsStr(),x_det.visStr());
   
   for(xml_coll_t c(x_det,_U(layer)); c; ++c)  {
     xml_comp_t       x_layer  = c;
@@ -122,10 +141,10 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
       xml_comp_t x_slice = s;
       string     s_name  = _toString(s_num,"slice%d");
       double     s_thick = x_slice.thickness();
-      Material   s_mat   = lcdd.material(x_slice.materialStr());
+      Material   s_mat   = theDetector.material(x_slice.materialStr());
       Volume     s_vol(s_name,PolyhedraRegular(nsides_outer,rmin+l_rcutout,rmax,s_thick),s_mat);
       
-      s_vol.setVisAttributes(lcdd.visAttributes(x_slice.visStr()));
+      s_vol.setVisAttributes(theDetector.visAttributes(x_slice.visStr()));
       sliceZ += s_thick/2;
       PlacedVolume s_phv = l_vol.placeVolume(s_vol,Position(0,0,sliceZ));
       if ( x_slice.isSensitive() )  {
@@ -149,7 +168,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
       sliceZ += s_thick/2;
       s_num++;
     }
-    l_vol.setVisAttributes(lcdd.visAttributes(x_layer.visStr()));
+    l_vol.setVisAttributes(theDetector.visAttributes(x_layer.visStr()));
     if ( l_repeat <= 0 ) throw std::runtime_error(x_det.nameStr()+"> Invalid repeat value");
     
     for(int j=0; j<l_repeat; ++j) {
@@ -166,7 +185,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
       }
       
       ///FIXME: IS ORIENTATION RIGHT? WHICH SIDE DO WE NEED TO ADD TO STRUCTURE?
-      DDRec::LayeredCalorimeterData::Layer caloLayer ;
+      LayeredCalorimeterData::Layer caloLayer ;
       caloLayer.distance = zmin +  totalThickness/2 + layerZ+sens_pos ;
       caloLayer.inner_thickness = th_i ;
       caloLayer.outer_thickness = th_o ;
@@ -208,7 +227,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
 //   sdet.add(sdetA);
   sdet.add(endcapB);
   
-  sdet.addExtension< DDRec::LayeredCalorimeterData >( caloData ) ;
+  sdet.addExtension< LayeredCalorimeterData >( caloData ) ;
   
   return sdet;
   

--- a/detector/calorimeter/Hcal_BarrelSD_v00.cpp
+++ b/detector/calorimeter/Hcal_BarrelSD_v00.cpp
@@ -14,12 +14,15 @@
 #include "LcgeoExceptions.h"
 
 using namespace std;
-using namespace DD4hep;
-using namespace DD4hep::Geometry;
-using namespace lcgeo ;
 
+using dd4hep::BUILD_ENVELOPE;
+using dd4hep::DetElement;
+using dd4hep::Detector;
+using dd4hep::PlacedVolume;
+using dd4hep::Ref_t;
+using dd4hep::SensitiveDetector;
 
-static Ref_t create_detector(LCDD& lcdd, xml_h element, SensitiveDetector sens)  {
+static Ref_t create_detector(Detector& theDetector, xml_h element, SensitiveDetector sens) {
 
   // static double tolerance = 0e0;
 
@@ -40,9 +43,9 @@ static Ref_t create_detector(LCDD& lcdd, xml_h element, SensitiveDetector sens) 
   // --- create an envelope volume and position it into the world ---------------------
   
   // Volume envelope =
-  XML::createPlacedEnvelope( lcdd,  element , sdet ) ;
+  dd4hep::xml::createPlacedEnvelope( theDetector,  element , sdet ) ;
   
-  if( lcdd.buildType() == BUILD_ENVELOPE ) return sdet ;
+  if( theDetector.buildType() == BUILD_ENVELOPE ) return sdet ;
 
   //-----------------------------------------------------------------------------------
 

--- a/detector/calorimeter/Hcal_Barrel_SD_v01.cpp
+++ b/detector/calorimeter/Hcal_Barrel_SD_v01.cpp
@@ -11,9 +11,31 @@
 #include "LcgeoExceptions.h"
 
 using namespace std;
-using namespace DD4hep;
-using namespace DD4hep::Geometry;
-using namespace lcgeo ;
+
+using dd4hep::Assembly;
+using dd4hep::BUILD_ENVELOPE;
+using dd4hep::Box;
+using dd4hep::Cone;
+using dd4hep::DetElement;
+using dd4hep::Detector;
+using dd4hep::IntersectionSolid;
+using dd4hep::Material;
+using dd4hep::PlacedVolume;
+using dd4hep::PolyhedraRegular;
+using dd4hep::Position;
+using dd4hep::Readout;
+using dd4hep::Ref_t;
+using dd4hep::Rotation3D;
+using dd4hep::RotationZYX;
+using dd4hep::Segmentation;
+using dd4hep::SensitiveDetector;
+using dd4hep::Transform3D;
+using dd4hep::Tube;
+using dd4hep::Volume;
+using dd4hep::_toString;
+
+using dd4hep::rec::LayeredCalorimeterData;
+
 
 // workaround for DD4hep v00-14 (and older)
 #ifndef DD4HEP_VERSION_GE
@@ -21,7 +43,7 @@ using namespace lcgeo ;
 #endif
 //
 
-static Ref_t create_detector(LCDD& lcdd, xml_h element, SensitiveDetector sens)  {
+static Ref_t create_detector(Detector& theDetector, xml_h element, SensitiveDetector sens) {
   
   double boundarySafety = 0.0001;
 
@@ -32,17 +54,17 @@ static Ref_t create_detector(LCDD& lcdd, xml_h element, SensitiveDetector sens) 
   
   // --- create an envelope volume and position it into the world ---------------------
   
-  Volume envelope = XML::createPlacedEnvelope( lcdd,  element , sdet ) ;
+  Volume envelope = dd4hep::xml::createPlacedEnvelope( theDetector,  element , sdet ) ;
 
-  XML::setDetectorTypeFlag(element, sdet);
+  dd4hep::xml::setDetectorTypeFlag(element, sdet);
   
-  if( lcdd.buildType() == BUILD_ENVELOPE ) return sdet ;
+  if( theDetector.buildType() == BUILD_ENVELOPE ) return sdet ;
 
   //-----------------------------------------------------------------------------------
 
   xml_comp_t    x_staves          = x_det.staves();
-  Material      stavesMaterial    = lcdd.material(x_staves.materialStr());
-  Material      air               = lcdd.air();
+  Material      stavesMaterial    = theDetector.material(x_staves.materialStr());
+  Material      air               = theDetector.air();
 
   PlacedVolume pv;
 
@@ -70,28 +92,28 @@ static Ref_t create_detector(LCDD& lcdd, xml_h element, SensitiveDetector sens) 
   // Use them to build HcalBarrel
   //
   //====================================================================
-  double      Hcal_inner_radius   = lcdd.constant<double>("Hcal_inner_radius");
-  double      Hcal_outer_radius   = lcdd.constant<double>("Hcal_outer_radius");
-  double      Hcal_half_length    = lcdd.constant<double>("Hcal_half_length");
-  int         Hcal_inner_symmetry = lcdd.constant<int>("Hcal_inner_symmetry");
+  double      Hcal_inner_radius   = theDetector.constant<double>("Hcal_inner_radius");
+  double      Hcal_outer_radius   = theDetector.constant<double>("Hcal_outer_radius");
+  double      Hcal_half_length    = theDetector.constant<double>("Hcal_half_length");
+  int         Hcal_inner_symmetry = theDetector.constant<int>("Hcal_inner_symmetry");
   int         Hcal_outer_symmetry = 0; // Fixed shape for Tube, and not allow to modify from compact xml.
 
-  double      Hcal_radiator_thickness          = lcdd.constant<double>("HcalSD_radiator_thickness");
-  double      Hcal_module_wall_thickness        = lcdd.constant<double>("HcalSD_module_wall_thickness");
-  double      Hcal_modules_gap                 = lcdd.constant<double>("HcalSD_modules_gap"); 
-  double      Hcal_layer_air_gap               = lcdd.constant<double>("HcalSD_layer_air_gap");
-  double      Hcal_airgap_thickness             = lcdd.constant<double>("HcalSD_airgap_thickness");
-//  double      Hcal_cells_size                  = lcdd.constant<double>("HcalSD_cells_size");
-  double      Hcal_barrel_thickness            = lcdd.constant<double>("Hcal_barrel_thickness");
-  int         Hcal_MinNumCellsInTransvPlane    = lcdd.constant<int>("HcalSD_MinNumCellsInTransvPlane");
-  int         Hcal_barrel_number_modules       = lcdd.constant<int>("HcalBarrelSD_number_modules");
+  double      Hcal_radiator_thickness          = theDetector.constant<double>("HcalSD_radiator_thickness");
+  double      Hcal_module_wall_thickness        = theDetector.constant<double>("HcalSD_module_wall_thickness");
+  double      Hcal_modules_gap                 = theDetector.constant<double>("HcalSD_modules_gap"); 
+  double      Hcal_layer_air_gap               = theDetector.constant<double>("HcalSD_layer_air_gap");
+  double      Hcal_airgap_thickness             = theDetector.constant<double>("HcalSD_airgap_thickness");
+//  double      Hcal_cells_size                  = theDetector.constant<double>("HcalSD_cells_size");
+  double      Hcal_barrel_thickness            = theDetector.constant<double>("Hcal_barrel_thickness");
+  int         Hcal_MinNumCellsInTransvPlane    = theDetector.constant<int>("HcalSD_MinNumCellsInTransvPlane");
+  int         Hcal_barrel_number_modules       = theDetector.constant<int>("HcalBarrelSD_number_modules");
 
-  int         Hcal_nlayers                     = lcdd.constant<int>("HcalBarrelSD_nlayers");
+  int         Hcal_nlayers                     = theDetector.constant<int>("HcalBarrelSD_nlayers");
 
-  double      TPC_outer_radius               = lcdd.constant<double>("TPC_outer_radius");
+  double      TPC_outer_radius               = theDetector.constant<double>("TPC_outer_radius");
   std::cout << " ***********TPC_outer_radius " << TPC_outer_radius  << std::endl ;
 
-  double      Ecal_outer_radius               = lcdd.constant<double>("Ecal_outer_radius");
+  double      Ecal_outer_radius               = theDetector.constant<double>("Ecal_outer_radius");
   std::cout << " ***********Ecal_outer_radius " <<  Ecal_outer_radius << std::endl ;
   std::cout << " ***********Hcal_inner_radius " <<  Hcal_inner_radius << std::endl ;
   std::cout << " ***********Hcal_outer_radius " <<  Hcal_outer_radius << std::endl ;
@@ -99,8 +121,8 @@ static Ref_t create_detector(LCDD& lcdd, xml_h element, SensitiveDetector sens) 
 
 
   //========== fill data for reconstruction ============================
-  DDRec::LayeredCalorimeterData* caloData = new DDRec::LayeredCalorimeterData ;
-  caloData->layoutType = DDRec::LayeredCalorimeterData::BarrelLayout ;
+  LayeredCalorimeterData* caloData = new LayeredCalorimeterData ;
+  caloData->layoutType = LayeredCalorimeterData::BarrelLayout ;
   caloData->inner_symmetry = Hcal_inner_symmetry  ;
   caloData->outer_symmetry = Hcal_outer_symmetry  ;
   caloData->phi0 = 0 ; // fg: also hardcoded below 
@@ -154,7 +176,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h element, SensitiveDetector sens) 
  
   Assembly EnvLogHcalModuleBarrel(det_name+"_module");
 
-  EnvLogHcalModuleBarrel.setAttributes(lcdd,x_det.regionStr(),x_det.limitsStr(),x_det.visStr());
+  EnvLogHcalModuleBarrel.setAttributes(theDetector,x_det.regionStr(),x_det.limitsStr(),x_det.visStr());
 
 
 
@@ -173,7 +195,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h element, SensitiveDetector sens) 
 
   Volume  EnvLogHcalModuleBarrel_LP(det_name+"_Module_lateral_plate",Module_lateral_plate,stavesMaterial);
 
-  EnvLogHcalModuleBarrel_LP.setAttributes(lcdd,x_det.regionStr(),x_det.limitsStr(),x_det.visStr());
+  EnvLogHcalModuleBarrel_LP.setAttributes(theDetector,x_det.regionStr(),x_det.limitsStr(),x_det.visStr());
 
 
 
@@ -198,7 +220,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h element, SensitiveDetector sens) 
 
   double xShift = 0.;
 
-  DDRec::LayeredCalorimeterData::Layer caloLayer ;
+  LayeredCalorimeterData::Layer caloLayer ;
   caloLayer.cellSize0 = cell_sizeX;
   caloLayer.cellSize1 = cell_sizeZ;
 
@@ -265,7 +287,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h element, SensitiveDetector sens) 
 	xml_comp_t x_slice = k;
 	string   slice_name      = layer_name + _toString(slice_number,"_slice%d");
 	double   slice_thickness = x_slice.thickness();
-	Material slice_material  = lcdd.material(x_slice.materialStr());
+	Material slice_material  = theDetector.material(x_slice.materialStr());
         if(layer_id==1)
            cout<<"  Layer_slice:  "<<  slice_name<<" slice_thickness:  "<< slice_thickness<< endl;
 
@@ -302,7 +324,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h element, SensitiveDetector sens) 
 
 
 	// Set region, limitset, and vis.
-	slice_vol.setAttributes(lcdd,x_slice.regionStr(),x_slice.limitsStr(),x_slice.visStr());
+	slice_vol.setAttributes(theDetector,x_slice.regionStr(),x_slice.limitsStr(),x_slice.visStr());
 	// slice PlacedVolume
 	PlacedVolume slice_phv = ChamberLogical.placeVolume(slice_vol,Position(0.,0.,slice_pos_z));
 	if ( x_slice.isSensitive() ) {
@@ -416,7 +438,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h element, SensitiveDetector sens) 
     }  //-------- end loop over HCAL BARREL staves ----------------------------
 
 
-  sdet.addExtension< DDRec::LayeredCalorimeterData >( caloData ) ;
+  sdet.addExtension< LayeredCalorimeterData >( caloData ) ;
 
  
   return sdet;

--- a/detector/calorimeter/Hcal_EndcapRing_SD_v01.cpp
+++ b/detector/calorimeter/Hcal_EndcapRing_SD_v01.cpp
@@ -48,8 +48,29 @@
 #include "DDRec/DetectorData.h"
 
 using namespace std;
-using namespace DD4hep;
-using namespace DD4hep::Geometry;
+
+using dd4hep::BUILD_ENVELOPE;
+using dd4hep::Box;
+using dd4hep::DetElement;
+using dd4hep::Detector;
+using dd4hep::IntersectionSolid;
+using dd4hep::Layering;
+using dd4hep::Material;
+using dd4hep::PlacedVolume;
+using dd4hep::PolyhedraRegular;
+using dd4hep::Position;
+using dd4hep::Readout;
+using dd4hep::Ref_t;
+using dd4hep::Rotation3D;
+using dd4hep::RotationZ;
+using dd4hep::RotationZYX;
+using dd4hep::Segmentation;
+using dd4hep::SensitiveDetector;
+using dd4hep::Transform3D;
+using dd4hep::Volume;
+using dd4hep::_toString;
+
+using dd4hep::rec::LayeredCalorimeterData;
 
 //#define VERBOSE 1
 
@@ -58,15 +79,15 @@ using namespace DD4hep::Geometry;
 #define DD4HEP_VERSION_GE(a,b) 0 
 #endif
 
-static Ref_t create_detector(LCDD& lcdd, xml_h element, SensitiveDetector sens)  {
+static Ref_t create_detector(Detector& theDetector, xml_h element, SensitiveDetector sens)  {
   //unused:  static double tolerance = 0e0;
 
   xml_det_t   x_det     = element;
   string      det_name    = x_det.nameStr();
   Layering    layering(x_det);
 
-  Material    air         = lcdd.air();
-  Material    stavesMaterial    = lcdd.material(x_det.materialStr());
+  Material    air         = theDetector.air();
+  Material    stavesMaterial    = theDetector.material(x_det.materialStr());
 
   int           det_id    = x_det.id();
   xml_comp_t    x_staves  = x_det.staves();
@@ -75,11 +96,11 @@ static Ref_t create_detector(LCDD& lcdd, xml_h element, SensitiveDetector sens) 
 
   // --- create an envelope volume and position it into the world ---------------------
   
-  Volume envelope = XML::createPlacedEnvelope( lcdd,  element , sdet ) ;
+  Volume envelope = dd4hep::xml::createPlacedEnvelope( theDetector,  element , sdet ) ;
   
-  XML::setDetectorTypeFlag( element, sdet ) ;
+  dd4hep::xml::setDetectorTypeFlag( element, sdet ) ;
 
-  if( lcdd.buildType() == BUILD_ENVELOPE ) return sdet ;
+  if( theDetector.buildType() == BUILD_ENVELOPE ) return sdet ;
 
   //-----------------------------------------------------------------------------------
 
@@ -105,19 +126,19 @@ static Ref_t create_detector(LCDD& lcdd, xml_h element, SensitiveDetector sens) 
 // Use them to build HcalEndcapRing
 //
 //====================================================================
-  // The way to read constants from XML/LCDD file.
-//  double      Hcal_cells_size                  = lcdd.constant<double>("HcalSD_cells_size");
-  double      Hcal_radiator_thickness          = lcdd.constant<double>("HcalSD_radiator_thickness");
-  double      Hcal_back_plate_thickness        = lcdd.constant<double>("HcalSD_back_plate_thickness");
-  double      Hcal_lateral_plate_thickness     = lcdd.constant<double>("HcalSD_lateral_structure_thickness");
-  double      Hcal_stave_gaps                  = lcdd.constant<double>("HcalSD_stave_gaps");
-  int         HcalEndcapRing_nlayers           = lcdd.constant<int>("HcalEndcapRingSD_nlayers");
-  int         HcalEndcapRing_inner_symmetry    = lcdd.constant<int>("HcalEndcapRingSD_inner_symmetry");
-//  int         HcalEndcapRing_outer_symmetry    = lcdd.constant<int>("HcalEndcapRingSD_outer_symmetry");
-  double      HcalEndcapRing_inner_radius      = lcdd.constant<double>("HcalEndcapRing_inner_radius");
-  double      HcalEndcapRing_outer_radius      = lcdd.constant<double>("HcalEndcapRing_outer_radius");
-  double      HcalEndcapRing_min_z             = lcdd.constant<double>("HcalEndcapRing_min_z");
-  double      HcalEndcapRing_max_z             = lcdd.constant<double>("HcalEndcapRing_max_z");
+  // The way to read constants from XML/Detector file.
+//  double      Hcal_cells_size                  = theDetector.constant<double>("HcalSD_cells_size");
+  double      Hcal_radiator_thickness          = theDetector.constant<double>("HcalSD_radiator_thickness");
+  double      Hcal_back_plate_thickness        = theDetector.constant<double>("HcalSD_back_plate_thickness");
+  double      Hcal_lateral_plate_thickness     = theDetector.constant<double>("HcalSD_lateral_structure_thickness");
+  double      Hcal_stave_gaps                  = theDetector.constant<double>("HcalSD_stave_gaps");
+  int         HcalEndcapRing_nlayers           = theDetector.constant<int>("HcalEndcapRingSD_nlayers");
+  int         HcalEndcapRing_inner_symmetry    = theDetector.constant<int>("HcalEndcapRingSD_inner_symmetry");
+//  int         HcalEndcapRing_outer_symmetry    = theDetector.constant<int>("HcalEndcapRingSD_outer_symmetry");
+  double      HcalEndcapRing_inner_radius      = theDetector.constant<double>("HcalEndcapRing_inner_radius");
+  double      HcalEndcapRing_outer_radius      = theDetector.constant<double>("HcalEndcapRing_outer_radius");
+  double      HcalEndcapRing_min_z             = theDetector.constant<double>("HcalEndcapRing_min_z");
+  double      HcalEndcapRing_max_z             = theDetector.constant<double>("HcalEndcapRing_max_z");
 //====================================================================
 //
 // general calculated parameters
@@ -185,8 +206,8 @@ static Ref_t create_detector(LCDD& lcdd, xml_h element, SensitiveDetector sens) 
 
 
   //========== fill data for reconstruction ============================
-  DDRec::LayeredCalorimeterData* caloData = new DDRec::LayeredCalorimeterData ;
-  caloData->layoutType = DDRec::LayeredCalorimeterData::EndcapLayout ;
+  LayeredCalorimeterData* caloData = new LayeredCalorimeterData ;
+  caloData->layoutType = LayeredCalorimeterData::EndcapLayout ;
   caloData->inner_symmetry = numSide  ;
   caloData->outer_symmetry = numSide  ;
   caloData->phi0 = 0 ; // hardcoded 
@@ -268,7 +289,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h element, SensitiveDetector sens) 
 	  
 	  Volume HcalEndCapRingStaveLogical("HcalEndCapRingStaveLogical",HcalEndCapRingStaveSolid, air);
 
-	  DDRec::LayeredCalorimeterData::Layer caloLayer ;
+	  LayeredCalorimeterData::Layer caloLayer ;
 	  caloLayer.cellSize0 = cell_sizeX;
 	  caloLayer.cellSize1 = cell_sizeY;
 
@@ -287,7 +308,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h element, SensitiveDetector sens) 
 	    xml_comp_t x_slice = k;
 	    string   slice_name      = layer_name + _toString(slice_number,"_slice%d");
 	    double   slice_thickness = x_slice.thickness();
-	    Material slice_material  = lcdd.material(x_slice.materialStr());
+	    Material slice_material  = theDetector.material(x_slice.materialStr());
 	    DetElement slice(layer_name,_toString(slice_number,"slice%d"),x_det.id());
 	    
 	    slice_pos_z += slice_thickness/2.;
@@ -340,7 +361,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h element, SensitiveDetector sens) 
 	    thickness_sum += slice_thickness/2;
 
 	    // Set region, limitset, and vis.
-	    slice_vol.setAttributes(lcdd,x_slice.regionStr(),x_slice.limitsStr(),x_slice.visStr());
+	    slice_vol.setAttributes(theDetector,x_slice.regionStr(),x_slice.limitsStr(),x_slice.visStr());
 	    // slice PlacedVolume
 	    PlacedVolume slice_phv = HcalEndCapRingStaveLogical.placeVolume(slice_vol,Position(0.,0.,slice_pos_z));
 	    if ( x_slice.isSensitive() ) {
@@ -398,7 +419,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h element, SensitiveDetector sens) 
 
   // Set stave visualization.
   if (x_staves)   {
-    HcalEndCapRingLogical.setVisAttributes(lcdd.visAttributes(x_staves.visStr()));
+    HcalEndCapRingLogical.setVisAttributes(theDetector.visAttributes(x_staves.visStr()));
    }
 
   //====================================================================
@@ -425,7 +446,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h element, SensitiveDetector sens) 
 
   }
   
-  sdet.addExtension< DDRec::LayeredCalorimeterData >( caloData ) ;
+  sdet.addExtension< LayeredCalorimeterData >( caloData ) ;
 
   return sdet;
   

--- a/detector/calorimeter/Hcal_Endcaps_SD_v01.cpp
+++ b/detector/calorimeter/Hcal_Endcaps_SD_v01.cpp
@@ -49,8 +49,29 @@
 #include "DDRec/DetectorData.h"
 
 using namespace std;
-using namespace DD4hep;
-using namespace DD4hep::Geometry;
+
+using dd4hep::BUILD_ENVELOPE;
+using dd4hep::Box;
+using dd4hep::DetElement;
+using dd4hep::Detector;
+using dd4hep::IntersectionSolid;
+using dd4hep::Layering;
+using dd4hep::Material;
+using dd4hep::PlacedVolume;
+using dd4hep::PolyhedraRegular;
+using dd4hep::Position;
+using dd4hep::Readout;
+using dd4hep::Ref_t;
+using dd4hep::Rotation3D;
+using dd4hep::RotationZ;
+using dd4hep::RotationZYX;
+using dd4hep::Segmentation;
+using dd4hep::SensitiveDetector;
+using dd4hep::Transform3D;
+using dd4hep::Volume;
+using dd4hep::_toString;
+
+using dd4hep::rec::LayeredCalorimeterData;
 
 //#define VERBOSE 1
 
@@ -59,7 +80,7 @@ using namespace DD4hep::Geometry;
 #define DD4HEP_VERSION_GE(a,b) 0 
 #endif
 
-static Ref_t create_detector(LCDD& lcdd, xml_h element, SensitiveDetector sens)  {
+static Ref_t create_detector(Detector& theDetector, xml_h element, SensitiveDetector sens)  {
   //unused:  static double tolerance = 0e0;
 
   xml_det_t   x_det     = element;
@@ -67,8 +88,8 @@ static Ref_t create_detector(LCDD& lcdd, xml_h element, SensitiveDetector sens) 
   string      det_type    = x_det.typeStr();
   Layering    layering(x_det);
 
-  Material    air         = lcdd.air();
-  Material    stavesMaterial    = lcdd.material(x_det.materialStr());
+  Material    air         = theDetector.air();
+  Material    stavesMaterial    = theDetector.material(x_det.materialStr());
 
   int           det_id    = x_det.id();
   xml_comp_t    x_staves  = x_det.staves();
@@ -77,11 +98,11 @@ static Ref_t create_detector(LCDD& lcdd, xml_h element, SensitiveDetector sens) 
 
   // --- create an envelope volume and position it into the world ---------------------
   
-  Volume envelope = XML::createPlacedEnvelope( lcdd,  element , sdet ) ;
+  Volume envelope = dd4hep::xml::createPlacedEnvelope( theDetector,  element , sdet ) ;
   
-  XML::setDetectorTypeFlag( element, sdet ) ;
+  dd4hep::xml::setDetectorTypeFlag( element, sdet ) ;
 
-  if( lcdd.buildType() == BUILD_ENVELOPE ) return sdet ;
+  if( theDetector.buildType() == BUILD_ENVELOPE ) return sdet ;
 
   //-----------------------------------------------------------------------------------
 
@@ -104,19 +125,19 @@ static Ref_t create_detector(LCDD& lcdd, xml_h element, SensitiveDetector sens) 
 // Use them to build HcalEndcaps
 //
 //====================================================================
-  // The way to read constant from XML/LCDD file.
-  double      Hcal_radiator_thickness          = lcdd.constant<double>("HcalSD_radiator_thickness");
-  double      HcalEndcap_nlayers               = lcdd.constant<double>("HcalEndcapSD_nlayers");
+  // The way to read constant from XML/THEDETECTOR file.
+  double      Hcal_radiator_thickness          = theDetector.constant<double>("HcalSD_radiator_thickness");
+  double      HcalEndcap_nlayers               = theDetector.constant<double>("HcalEndcapSD_nlayers");
 
-  double      HcalEndcap_inner_radius          = lcdd.constant<double>("HcalEndcap_inner_radius");
-  double      HcalEndcap_outer_radius          = lcdd.constant<double>("HcalEndcap_outer_radius");
-  double      HcalEndcap_min_z                 = lcdd.constant<double>("HcalEndcap_min_z");
-  double      HcalEndcap_max_z                 = lcdd.constant<double>("HcalEndcap_max_z");
+  double      HcalEndcap_inner_radius          = theDetector.constant<double>("HcalEndcap_inner_radius");
+  double      HcalEndcap_outer_radius          = theDetector.constant<double>("HcalEndcap_outer_radius");
+  double      HcalEndcap_min_z                 = theDetector.constant<double>("HcalEndcap_min_z");
+  double      HcalEndcap_max_z                 = theDetector.constant<double>("HcalEndcap_max_z");
 
-  double      Hcal_stave_gaps                  = lcdd.constant<double>("HcalSD_stave_gaps");
-  double      Hcal_lateral_plate_thickness     = lcdd.constant<double>("HcalSD_endcap_lateral_structure_thickness");
-  double      Hcal_back_plate_thickness        = lcdd.constant<double>("HcalSD_back_plate_thickness");
-  int         HcalEndcap_symmetry              = lcdd.constant<int>("HcalEndcap_symmetry");
+  double      Hcal_stave_gaps                  = theDetector.constant<double>("HcalSD_stave_gaps");
+  double      Hcal_lateral_plate_thickness     = theDetector.constant<double>("HcalSD_endcap_lateral_structure_thickness");
+  double      Hcal_back_plate_thickness        = theDetector.constant<double>("HcalSD_back_plate_thickness");
+  int         HcalEndcap_symmetry              = theDetector.constant<int>("HcalEndcap_symmetry");
 
 // Some verbose output
   cout << " \n\n\n CREATE DETECTOR: Hcal_Endcaps_SD_v01" << endl;
@@ -180,8 +201,8 @@ static Ref_t create_detector(LCDD& lcdd, xml_h element, SensitiveDetector sens) 
 
 
   //========== fill data for reconstruction ============================
-  DDRec::LayeredCalorimeterData* caloData = new DDRec::LayeredCalorimeterData ;
-  caloData->layoutType = DDRec::LayeredCalorimeterData::EndcapLayout ;
+  LayeredCalorimeterData* caloData = new LayeredCalorimeterData ;
+  caloData->layoutType = LayeredCalorimeterData::EndcapLayout ;
   caloData->inner_symmetry = 4  ;
   caloData->outer_symmetry = 0  ;
 //  caloData->outer_symmetry = numSide  ;
@@ -258,7 +279,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h element, SensitiveDetector sens) 
           string layer_name      = det_name+_toString(layer_id,"_layer%d");
 	  Volume HcalEndCapStaveLogical("HcalEndCapStaveLogical",HcalEndCapStaveSolid, air);
 
-	  DDRec::LayeredCalorimeterData::Layer caloLayer ;
+	  LayeredCalorimeterData::Layer caloLayer ;
 	  caloLayer.cellSize0 = cell_sizeX;
 	  caloLayer.cellSize1 = cell_sizeY;
 
@@ -277,7 +298,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h element, SensitiveDetector sens) 
 	    xml_comp_t x_slice = k;
 	    string   slice_name      = layer_name + _toString(slice_number,"_slice%d");
 	    double   slice_thickness = x_slice.thickness();
-	    Material slice_material  = lcdd.material(x_slice.materialStr());
+	    Material slice_material  = theDetector.material(x_slice.materialStr());
             if(stave_id==1 && layer_id==1)
 	      cout<<"  Layer_slice:  "<<  slice_name<<" slice_thickness:  "<< slice_thickness<< endl;
 	    DetElement slice(layer_name,_toString(slice_number,"slice%d"),x_det.id());
@@ -327,7 +348,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h element, SensitiveDetector sens) 
 	    thickness_sum += slice_thickness/2;
 
 	    // Set region, limitset, and vis.
-	    slice_vol.setAttributes(lcdd,x_slice.regionStr(),x_slice.limitsStr(),x_slice.visStr());
+	    slice_vol.setAttributes(theDetector,x_slice.regionStr(),x_slice.limitsStr(),x_slice.visStr());
 	    // slice PlacedVolume
 	    PlacedVolume slice_phv = HcalEndCapStaveLogical.placeVolume(slice_vol,Position(0.,0.,slice_pos_z));
 	    if ( x_slice.isSensitive() ) {
@@ -385,7 +406,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h element, SensitiveDetector sens) 
 
   // Set stave visualization.
   if (x_staves)   {
-    HcalEndCapLogical.setVisAttributes(lcdd.visAttributes(x_staves.visStr()));
+    HcalEndCapLogical.setVisAttributes(theDetector.visAttributes(x_staves.visStr()));
    }
 
   //====================================================================
@@ -414,7 +435,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h element, SensitiveDetector sens) 
 
   }
   
-  sdet.addExtension< DDRec::LayeredCalorimeterData >( caloData ) ;
+  sdet.addExtension< LayeredCalorimeterData >( caloData ) ;
 
   return sdet;
   

--- a/detector/calorimeter/SECalEndcap_o1_v01_geo.cpp
+++ b/detector/calorimeter/SECalEndcap_o1_v01_geo.cpp
@@ -19,10 +19,28 @@
 #include "DDRec/DetectorData.h"
 
 using namespace std;
-using namespace DD4hep;
-using namespace DD4hep::Geometry;
 
-static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
+using dd4hep::BUILD_ENVELOPE;
+using dd4hep::DetElement;
+using dd4hep::DetType;
+using dd4hep::Detector;
+using dd4hep::Layering;
+using dd4hep::Material;
+using dd4hep::PlacedVolume;
+using dd4hep::Position;
+using dd4hep::Ref_t;
+using dd4hep::RotationZYX;
+using dd4hep::SensitiveDetector;
+using dd4hep::Transform3D;
+using dd4hep::Translation3D;
+using dd4hep::Trap;
+using dd4hep::Volume;
+using dd4hep::_toString;
+
+using dd4hep::rec::LayeredCalorimeterData;
+
+
+static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector sens)  {
     
     xml_det_t     x_det     = e;
     int           det_id    = x_det.id();
@@ -31,20 +49,20 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
     
     // --- create an envelope volume and position it into the world ---------------------
     
-    Volume envelope = XML::createPlacedEnvelope(lcdd, e, sdet);
+    Volume envelope = dd4hep::xml::createPlacedEnvelope(theDetector, e, sdet);
     
     sdet.setTypeFlag( DetType::CALORIMETER |  DetType::ENDCAP  | DetType::ELECTROMAGNETIC ) ;
 
-    if( lcdd.buildType() == BUILD_ENVELOPE ) return sdet ;
+    if( theDetector.buildType() == BUILD_ENVELOPE ) return sdet ;
     
     //-----------------------------------------------------------------------------------
-    DD4hep::XML::Component xmlParameter = x_det.child(_Unicode(parameter));
+    dd4hep::xml::Component xmlParameter = x_det.child(_Unicode(parameter));
     const double tolerance = xmlParameter.attr<double>(_Unicode(ecal_endcap_tolerance));
     const int insides = xmlParameter.attr<double>(_Unicode(InSides));
-    Material Composite = lcdd.material(xmlParameter.attr<string>(_Unicode(CarbonFiber)));
+    Material Composite = theDetector.material(xmlParameter.attr<string>(_Unicode(CarbonFiber)));
 
     Layering      layering (e);
-    Material      air       = lcdd.air();
+    Material      air       = theDetector.air();
     xml_comp_t    x_panels  = x_det.staves();
     xml_comp_t    x_dim     = x_det.dimensions();
     int           outsides  = x_dim.numsides();
@@ -55,13 +73,13 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
     double        z_min     = x_dim.zmin();
     double        z_max     = x_dim.zmax();
     double        mod_z     = layering.totalThickness() + 2*tolerance;
-    double eCal_cell_size = lcdd.constant<double>("ECal_cell_size"); //Should try to obtain from segmentation
+    double eCal_cell_size = theDetector.constant<double>("ECal_cell_size"); //Should try to obtain from segmentation
     
     
     
     //Create caloData object to extend driver with data required for reconstruction
-    DDRec::LayeredCalorimeterData* caloData = new DDRec::LayeredCalorimeterData ;
-    caloData->layoutType = DDRec::LayeredCalorimeterData::EndcapLayout ;
+    LayeredCalorimeterData* caloData = new LayeredCalorimeterData ;
+    caloData->layoutType = LayeredCalorimeterData::EndcapLayout ;
     caloData->inner_symmetry = insides;
     caloData->outer_symmetry = outsides; 
     /** NOTE: phi0=0 means lower face flat parallel to experimental floor
@@ -183,7 +201,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
 
 	// Loop over number of repeats for this layer.
 	for (int k=0; k<repeat; k++)  {
-    DDRec::LayeredCalorimeterData::Layer caloLayer ;
+    LayeredCalorimeterData::Layer caloLayer ;
     
 	  string l_name = _toString(100*m + l_num, "layer%d");
 	  double l_thickness = layering.layer(l_num-1)->thickness();  // this layer's thickness	  
@@ -208,7 +226,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
 	    double     xtol = tolerance + 0.00001;
 	    Trap       s_box(s_thick/2., theta, phi, y1 - xtol, x1 - xtol, x2 - xtol, alpha1, 
                                                      y1 - xtol, x1 - xtol, x2 - xtol, alpha1);
-	    Volume     s_vol(s_name, s_box, lcdd.material(x_slice.materialStr()));
+	    Volume     s_vol(s_name, s_box, theDetector.material(x_slice.materialStr()));
 	    DetElement slice(layer, s_name, det_id);
 	    
 	    if ( x_slice.isSensitive() ) {
@@ -222,7 +240,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
 		th_o += s_thick;
 	      }
 	    }
-	    slice.setAttributes(lcdd, s_vol, x_slice.regionStr(), x_slice.limitsStr(), x_slice.visStr());
+	    slice.setAttributes(theDetector, s_vol, x_slice.regionStr(), x_slice.limitsStr(), x_slice.visStr());
 	    
       char val = x_slice.hasAttr(_U(radiator)) ? x_slice.attr < string > (_U(radiator))[0] : 'f';
       val = std::toupper(val);
@@ -252,7 +270,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
 	  }
 	  
 	  // Set region, limitset, and visibility of layer
-	  layer.setAttributes(lcdd, l_vol, x_layer.regionStr(), x_layer.limitsStr(), x_layer.visStr());
+	  layer.setAttributes(theDetector, l_vol, x_layer.regionStr(), x_layer.limitsStr(), x_layer.visStr());
 
 	  // std::cout << "Layer " << 100*m + l_num << std::endl;
 	  PlacedVolume layer_phv = panel_vol.placeVolume(l_vol, l_pos);
@@ -278,7 +296,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
      
       // Set visualization
       if ( x_panels ) {
-      	panel_vol.setVisAttributes(lcdd.visAttributes(x_panels.visStr()));
+      	panel_vol.setVisAttributes(theDetector.visAttributes(x_panels.visStr()));
       }
 
       // Placement
@@ -316,9 +334,9 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
     }
 
     // Set envelope volume attributes
-    envelope.setAttributes(lcdd,x_det.regionStr(),x_det.limitsStr(),x_det.visStr());
+    envelope.setAttributes(theDetector,x_det.regionStr(),x_det.limitsStr(),x_det.visStr());
     
-    sdet.addExtension< DDRec::LayeredCalorimeterData >( caloData ) ;
+    sdet.addExtension< LayeredCalorimeterData >( caloData ) ;
     
     return sdet;
 }

--- a/detector/calorimeter/SEcal04_Barrel.cpp
+++ b/detector/calorimeter/SEcal04_Barrel.cpp
@@ -18,8 +18,29 @@
 #include "DDSegmentation/WaferGridXY.h"
 
 using namespace std;
-using namespace DD4hep;
-using namespace DD4hep::Geometry;
+
+using dd4hep::BUILD_ENVELOPE;
+using dd4hep::Box;
+using dd4hep::DetElement;
+using dd4hep::Detector;
+using dd4hep::Layering;
+using dd4hep::Material;
+using dd4hep::PlacedVolume;
+using dd4hep::Position;
+using dd4hep::Readout;
+using dd4hep::Ref_t;
+using dd4hep::RotationZYX;
+using dd4hep::Segmentation;
+using dd4hep::SensitiveDetector;
+using dd4hep::Transform3D;
+using dd4hep::Translation3D;
+using dd4hep::Trapezoid;
+using dd4hep::Volume;
+using dd4hep::_toString;
+
+using dd4hep::rec::LayeredCalorimeterData;
+
+using dd4hep::DDSegmentation::WaferGridXY;
 
 //#define VERBOSE 1
 
@@ -44,15 +65,15 @@ using namespace DD4hep::Geometry;
  *            create the envelope volume with create_placed_envelope() using the xml 
  */
 
-static Ref_t create_detector(LCDD& lcdd, xml_h element, SensitiveDetector sens)  {
+static Ref_t create_detector(Detector& theDetector, xml_h element, SensitiveDetector sens)  {
   static double tolerance = 0e0;
 
   xml_det_t     x_det     = element;
   string        det_name  = x_det.nameStr();
   Layering      layering (element);
 
-  Material      air       = lcdd.air();
-  //unused: Material      vacuum    = lcdd.vacuum();
+  Material      air       = theDetector.air();
+  //unused: Material      vacuum    = theDetector.vacuum();
 
   int           det_id    = x_det.id();
   xml_comp_t    x_staves  = x_det.staves();
@@ -66,18 +87,18 @@ static Ref_t create_detector(LCDD& lcdd, xml_h element, SensitiveDetector sens) 
 
  // --- create an envelope volume and position it into the world ---------------------
 
-  Volume envelope = XML::createPlacedEnvelope( lcdd,  element , sdet ) ;
+  Volume envelope = dd4hep::xml::createPlacedEnvelope( theDetector,  element , sdet ) ;
 
-  XML::setDetectorTypeFlag( element, sdet ) ;
+  dd4hep::xml::setDetectorTypeFlag( element, sdet ) ;
  
-  if( lcdd.buildType() == BUILD_ENVELOPE ) return sdet ;
+  if( theDetector.buildType() == BUILD_ENVELOPE ) return sdet ;
 
   //-----------------------------------------------------------------------------------
 
 
   sens.setType("calorimeter");
 
-  Material stave_material  = lcdd.material(x_staves.materialStr());
+  Material stave_material  = theDetector.material(x_staves.materialStr());
 
   DetElement    stave_det("module0stave0",det_id);
 
@@ -85,8 +106,8 @@ static Ref_t create_detector(LCDD& lcdd, xml_h element, SensitiveDetector sens) 
   Segmentation seg = readout.segmentation();
   
   // check if we have a WaferGridXY segmentation :
-  DD4hep::DDSegmentation::WaferGridXY* waferSeg = 
-    dynamic_cast< DD4hep::DDSegmentation::WaferGridXY*>( seg.segmentation() ) ;
+  WaferGridXY* waferSeg = 
+    dynamic_cast< WaferGridXY*>( seg.segmentation() ) ;
 
   std::vector<double> cellSizeVector = seg.segmentation()->cellDimensions(0); //Assume uniform cell sizes, provide dummy cellID
   double cell_sizeX      = cellSizeVector[0];
@@ -103,37 +124,37 @@ static Ref_t create_detector(LCDD& lcdd, xml_h element, SensitiveDetector sens) 
   int N_FIBERS_ALVOULUS = 3;
 
   //  read parametere from compact.xml file
-  double Ecal_Alveolus_Air_Gap              = lcdd.constant<double>("Ecal_Alveolus_Air_Gap");
-  double Ecal_Slab_shielding                = lcdd.constant<double>("Ecal_Slab_shielding");
-  double Ecal_Slab_copper_thickness         = lcdd.constant<double>("Ecal_Slab_copper_thickness");
-  double Ecal_Slab_PCB_thickness            = lcdd.constant<double>("Ecal_Slab_PCB_thickness");
-  double Ecal_Slab_glue_gap                 = lcdd.constant<double>("Ecal_Slab_glue_gap");
-  double Ecal_Slab_ground_thickness         = lcdd.constant<double>("Ecal_Slab_ground_thickness");
-  double Ecal_fiber_thickness               = lcdd.constant<double>("Ecal_fiber_thickness");
-  double Ecal_Si_thickness                  = lcdd.constant<double>("Ecal_Si_thickness");
+  double Ecal_Alveolus_Air_Gap              = theDetector.constant<double>("Ecal_Alveolus_Air_Gap");
+  double Ecal_Slab_shielding                = theDetector.constant<double>("Ecal_Slab_shielding");
+  double Ecal_Slab_copper_thickness         = theDetector.constant<double>("Ecal_Slab_copper_thickness");
+  double Ecal_Slab_PCB_thickness            = theDetector.constant<double>("Ecal_Slab_PCB_thickness");
+  double Ecal_Slab_glue_gap                 = theDetector.constant<double>("Ecal_Slab_glue_gap");
+  double Ecal_Slab_ground_thickness         = theDetector.constant<double>("Ecal_Slab_ground_thickness");
+  double Ecal_fiber_thickness               = theDetector.constant<double>("Ecal_fiber_thickness");
+  double Ecal_Si_thickness                  = theDetector.constant<double>("Ecal_Si_thickness");
   
-  double Ecal_inner_radius                  = lcdd.constant<double>("TPC_outer_radius") +lcdd.constant<double>("Ecal_Tpc_gap");
-  double Ecal_radiator_thickness1           = lcdd.constant<double>("Ecal_radiator_layers_set1_thickness");
-  double Ecal_radiator_thickness2           = lcdd.constant<double>("Ecal_radiator_layers_set2_thickness");
-  double Ecal_radiator_thickness3           = lcdd.constant<double>("Ecal_radiator_layers_set3_thickness");
-  double Ecal_Barrel_halfZ                  = lcdd.constant<double>("Ecal_Barrel_halfZ");
+  double Ecal_inner_radius                  = theDetector.constant<double>("TPC_outer_radius") +theDetector.constant<double>("Ecal_Tpc_gap");
+  double Ecal_radiator_thickness1           = theDetector.constant<double>("Ecal_radiator_layers_set1_thickness");
+  double Ecal_radiator_thickness2           = theDetector.constant<double>("Ecal_radiator_layers_set2_thickness");
+  double Ecal_radiator_thickness3           = theDetector.constant<double>("Ecal_radiator_layers_set3_thickness");
+  double Ecal_Barrel_halfZ                  = theDetector.constant<double>("Ecal_Barrel_halfZ");
   
-  double Ecal_support_thickness             = lcdd.constant<double>("Ecal_support_thickness");
-  double Ecal_front_face_thickness          = lcdd.constant<double>("Ecal_front_face_thickness");
-  double Ecal_lateral_face_thickness        = lcdd.constant<double>("Ecal_lateral_face_thickness");
-  double Ecal_Slab_H_fiber_thickness        = lcdd.constant<double>("Ecal_Slab_H_fiber_thickness");
+  double Ecal_support_thickness             = theDetector.constant<double>("Ecal_support_thickness");
+  double Ecal_front_face_thickness          = theDetector.constant<double>("Ecal_front_face_thickness");
+  double Ecal_lateral_face_thickness        = theDetector.constant<double>("Ecal_lateral_face_thickness");
+  double Ecal_Slab_H_fiber_thickness        = theDetector.constant<double>("Ecal_Slab_H_fiber_thickness");
 
-  double Ecal_Slab_Sc_PCB_thickness         = lcdd.constant<double>("Ecal_Slab_Sc_PCB_thickness");
-  double Ecal_Sc_thickness                  = lcdd.constant<double>("Ecal_Sc_thickness");
-  double Ecal_Sc_reflector_thickness        = lcdd.constant<double>("Ecal_Sc_reflector_thickness");
+  double Ecal_Slab_Sc_PCB_thickness         = theDetector.constant<double>("Ecal_Slab_Sc_PCB_thickness");
+  double Ecal_Sc_thickness                  = theDetector.constant<double>("Ecal_Sc_thickness");
+  double Ecal_Sc_reflector_thickness        = theDetector.constant<double>("Ecal_Sc_reflector_thickness");
 
-  int    Ecal_nlayers1                      = lcdd.constant<int>("Ecal_nlayers1");
-  int    Ecal_nlayers2                      = lcdd.constant<int>("Ecal_nlayers2");
-  int    Ecal_nlayers3                      = lcdd.constant<int>("Ecal_nlayers3");
-  int    Ecal_barrel_number_of_towers       = lcdd.constant<int>("Ecal_barrel_number_of_towers");
+  int    Ecal_nlayers1                      = theDetector.constant<int>("Ecal_nlayers1");
+  int    Ecal_nlayers2                      = theDetector.constant<int>("Ecal_nlayers2");
+  int    Ecal_nlayers3                      = theDetector.constant<int>("Ecal_nlayers3");
+  int    Ecal_barrel_number_of_towers       = theDetector.constant<int>("Ecal_barrel_number_of_towers");
   
-  //double      Ecal_cells_size                  = lcdd.constant<double>("Ecal_cells_size");
-  double Ecal_guard_ring_size               = lcdd.constant<double>("Ecal_guard_ring_size");
+  //double      Ecal_cells_size                  = theDetector.constant<double>("Ecal_cells_size");
+  double Ecal_guard_ring_size               = theDetector.constant<double>("Ecal_guard_ring_size");
   
 //====================================================================
 //
@@ -230,7 +251,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h element, SensitiveDetector sens) 
 
   //------------------------------------------------------------------------------------
 
-  DDRec::LayeredCalorimeterData::Layer caloLayer ;
+  LayeredCalorimeterData::Layer caloLayer ;
   caloLayer.cellSize0 = cell_sizeX;
   caloLayer.cellSize1 = cell_sizeY;
 
@@ -274,8 +295,8 @@ static Ref_t create_detector(LCDD& lcdd, xml_h element, SensitiveDetector sens) 
 		Ecal_Barrel_module_dim_z / 2,
 		module_thickness/2);
 
-  //  Volume mod_vol(det_name+"_module",trd,lcdd.material("g10"));
-  Volume mod_vol(det_name+"_module",trd,lcdd.material("CarbonFiber")); // DJeans 5-sep-2016
+  //  Volume mod_vol(det_name+"_module",trd,theDetector.material("g10"));
+  Volume mod_vol(det_name+"_module",trd,theDetector.material("CarbonFiber")); // DJeans 5-sep-2016
 
   // We count the layers starting from IP and from 1,
   // so odd layers should be inside slabs and
@@ -316,8 +337,8 @@ static Ref_t create_detector(LCDD& lcdd, xml_h element, SensitiveDetector sens) 
     // ------------- create extension objects for reconstruction -----------------
     
     //========== fill data for reconstruction ============================
-    DDRec::LayeredCalorimeterData* caloData = new DDRec::LayeredCalorimeterData ;
-    caloData->layoutType = DDRec::LayeredCalorimeterData::BarrelLayout ;
+    LayeredCalorimeterData* caloData = new LayeredCalorimeterData ;
+    caloData->layoutType = LayeredCalorimeterData::BarrelLayout ;
     caloData->inner_symmetry = nsides  ;
     //added by Thorben Quast
     caloData->outer_symmetry = nsides  ;
@@ -368,7 +389,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h element, SensitiveDetector sens) 
 	Box        l_box(l_dim_x-tolerance,stave_z-tolerance,l_thickness/2.0-tolerance);
 	Volume     l_vol(det_name+"_"+l_name,l_box,air);
 
-	l_vol.setVisAttributes(lcdd.visAttributes(x_layer.visStr()));
+	l_vol.setVisAttributes(theDetector.visAttributes(x_layer.visStr()));
 
 	//fg: need vector of DetElements for towers ! 
 	//    DetElement layer(stave_det, l_name, det_id);
@@ -414,7 +435,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h element, SensitiveDetector sens) 
 	  xml_comp_t x_slice = si;
 	  string     s_name  =  _toString(s_num,"slice%d");
 	  double     s_thick = x_slice.thickness();
-	  Material slice_material  = lcdd.material(x_slice.materialStr());
+	  Material slice_material  = theDetector.material(x_slice.materialStr());
 #ifdef VERBOSE
 	  std::cout<<"Ecal_barrel_number_of_towers: "<< Ecal_barrel_number_of_towers <<std::endl;
 #endif
@@ -426,7 +447,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h element, SensitiveDetector sens) 
 	  Volume     s_vol(det_name+"_"+l_name+"_"+s_name,s_box,slice_material);
 	  //fg: not needed          DetElement slice(layer,s_name,det_id);
 
-	  s_vol.setVisAttributes(lcdd.visAttributes(x_slice.visStr()));
+	  s_vol.setVisAttributes(theDetector.visAttributes(x_slice.visStr()));
 #ifdef VERBOSE
 	  std::cout<<"x_slice.materialStr(): "<< x_slice.materialStr() <<std::endl;
 #endif
@@ -508,7 +529,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h element, SensitiveDetector sens) 
 		    string Wafer_name  =  _toString(wafer_num,"wafer%d");
 		    Volume WaferSiLog(det_name+"_"+l_name+"_"+s_name+"_"+Wafer_name,WaferSiSolid,slice_material);
 		    WaferSiLog.setSensitiveDetector(sens);
-		    //WaferSiLog.setVisAttributes(lcdd.visAttributes(x_slice.visStr()));
+		    //WaferSiLog.setVisAttributes(theDetector.visAttributes(x_slice.visStr()));
 		    PlacedVolume wafer_phv = s_vol.placeVolume(WaferSiLog,Position(wafer_pos_x,
 							  wafer_pos_z,
 							  0));
@@ -577,7 +598,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h element, SensitiveDetector sens) 
 		    string MagicWafer_name  =  _toString(wafer_num,"MagicWafer%d");
 		    Volume MagicWaferSiLog(det_name+"_"+l_name+"_"+s_name+"_"+MagicWafer_name,MagicWaferSiSolid,slice_material);
 		    MagicWaferSiLog.setSensitiveDetector(sens);
-		    //MagicWaferSiLog.setVisAttributes(lcdd.visAttributes(x_slice.visStr()));
+		    //MagicWaferSiLog.setVisAttributes(theDetector.visAttributes(x_slice.visStr()));
 		    PlacedVolume wafer_phv = s_vol.placeVolume(MagicWaferSiLog,Position(wafer_pos_x,
 							       wafer_pos_z,
 							       0));
@@ -709,7 +730,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h element, SensitiveDetector sens) 
 	Box        barrelStructureLayer_box(radiator_dim_x/2.,radiator_dim_z/2.,radiator_dim_y/2.);
 	Volume     barrelStructureLayer_vol(det_name+"_"+l_name+"_"+bs_name,barrelStructureLayer_box,stave_material);
 
-	barrelStructureLayer_vol.setVisAttributes(lcdd.visAttributes(x_layer.visStr()));	
+	barrelStructureLayer_vol.setVisAttributes(theDetector.visAttributes(x_layer.visStr()));	
 
 
         // Increment to next layer Z position.
@@ -739,7 +760,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h element, SensitiveDetector sens) 
 
     // Set stave visualization.
     if (x_staves)   {
-      mod_vol.setVisAttributes(lcdd.visAttributes(x_staves.visStr()));
+      mod_vol.setVisAttributes(theDetector.visAttributes(x_staves.visStr()));
     }
     
     
@@ -772,9 +793,9 @@ static Ref_t create_detector(LCDD& lcdd, xml_h element, SensitiveDetector sens) 
 	}
     
     // Set envelope volume attributes.
-    envelope.setAttributes(lcdd,x_det.regionStr(),x_det.limitsStr(),x_det.visStr());
+    envelope.setAttributes(theDetector,x_det.regionStr(),x_det.limitsStr(),x_det.visStr());
     
-    sdet.addExtension< DDRec::LayeredCalorimeterData >( caloData ) ; 
+    sdet.addExtension< LayeredCalorimeterData >( caloData ) ; 
 
 
     return sdet;

--- a/detector/calorimeter/SEcal04_ECRing.cpp
+++ b/detector/calorimeter/SEcal04_ECRing.cpp
@@ -43,8 +43,28 @@
 #include "DDRec/DetectorData.h"
 
 using namespace std;
-using namespace DD4hep;
-using namespace DD4hep::Geometry;
+
+using dd4hep::BUILD_ENVELOPE;
+using dd4hep::Box;
+using dd4hep::DetElement;
+using dd4hep::Detector;
+using dd4hep::Layering;
+using dd4hep::Material;
+using dd4hep::PlacedVolume;
+using dd4hep::Position;
+using dd4hep::Readout;
+using dd4hep::Ref_t;
+using dd4hep::Rotation3D;
+using dd4hep::RotationZYX;
+using dd4hep::Segmentation;
+using dd4hep::SensitiveDetector;
+using dd4hep::SubtractionSolid;
+using dd4hep::Transform3D;
+using dd4hep::Tube;
+using dd4hep::Volume;
+using dd4hep::_toString;
+
+using dd4hep::rec::LayeredCalorimeterData;
 
 //#define VERBOSE 1
 
@@ -53,15 +73,15 @@ using namespace DD4hep::Geometry;
 #define DD4HEP_VERSION_GE(a,b) 0 
 #endif
 
-static Ref_t create_detector(LCDD& lcdd, xml_h element, SensitiveDetector sens)  {
+static Ref_t create_detector(Detector& theDetector, xml_h element, SensitiveDetector sens)  {
   static double tolerance = 0e0;
 
   xml_det_t     x_det     = element;
   string        det_name  = x_det.nameStr();
   Layering      layering (element);
 
-  Material      air       = lcdd.air();
-  //unused: Material      vacuum    = lcdd.vacuum();
+  Material      air       = theDetector.air();
+  //unused: Material      vacuum    = theDetector.vacuum();
 
   int           det_id    = x_det.id();
   xml_comp_t    x_staves  = x_det.staves();
@@ -69,17 +89,17 @@ static Ref_t create_detector(LCDD& lcdd, xml_h element, SensitiveDetector sens) 
 
   // --- create an envelope volume and position it into the world ---------------------
   
-  Volume envelope = XML::createPlacedEnvelope( lcdd,  element , sdet ) ;
+  Volume envelope = dd4hep::xml::createPlacedEnvelope( theDetector,  element , sdet ) ;
   
-  XML::setDetectorTypeFlag( element, sdet ) ;
+  dd4hep::xml::setDetectorTypeFlag( element, sdet ) ;
 
-  if( lcdd.buildType() == BUILD_ENVELOPE ) return sdet ;
+  if( theDetector.buildType() == BUILD_ENVELOPE ) return sdet ;
 
   //-----------------------------------------------------------------------------------
 
   sens.setType("calorimeter");
 
-  Material stave_material  = lcdd.material(x_staves.materialStr());
+  Material stave_material  = theDetector.material(x_staves.materialStr());
 
   DetElement    module_det("module0",det_id);
 
@@ -101,49 +121,49 @@ static Ref_t create_detector(LCDD& lcdd, xml_h element, SensitiveDetector sens) 
   int N_FIBERS_ALVOULUS = 3;
 
   //  read parametere from compact.xml file
-  double Ecal_Alveolus_Air_Gap              = lcdd.constant<double>("Ecal_Alveolus_Air_Gap");
-  double Ecal_Slab_shielding                = lcdd.constant<double>("Ecal_Slab_shielding");
-  double Ecal_Slab_copper_thickness         = lcdd.constant<double>("Ecal_Slab_copper_thickness");
-  double Ecal_Slab_PCB_thickness            = lcdd.constant<double>("Ecal_Slab_PCB_thickness");
-  double Ecal_Slab_glue_gap                 = lcdd.constant<double>("Ecal_Slab_glue_gap");
-  double Ecal_Slab_ground_thickness         = lcdd.constant<double>("Ecal_Slab_ground_thickness");
-  double Ecal_fiber_thickness               = lcdd.constant<double>("Ecal_fiber_thickness");
-  double Ecal_Si_thickness                  = lcdd.constant<double>("Ecal_Si_thickness");
+  double Ecal_Alveolus_Air_Gap              = theDetector.constant<double>("Ecal_Alveolus_Air_Gap");
+  double Ecal_Slab_shielding                = theDetector.constant<double>("Ecal_Slab_shielding");
+  double Ecal_Slab_copper_thickness         = theDetector.constant<double>("Ecal_Slab_copper_thickness");
+  double Ecal_Slab_PCB_thickness            = theDetector.constant<double>("Ecal_Slab_PCB_thickness");
+  double Ecal_Slab_glue_gap                 = theDetector.constant<double>("Ecal_Slab_glue_gap");
+  double Ecal_Slab_ground_thickness         = theDetector.constant<double>("Ecal_Slab_ground_thickness");
+  double Ecal_fiber_thickness               = theDetector.constant<double>("Ecal_fiber_thickness");
+  double Ecal_Si_thickness                  = theDetector.constant<double>("Ecal_Si_thickness");
   
-  double Ecal_radiator_thickness1           = lcdd.constant<double>("Ecal_radiator_layers_set1_thickness");
-  double Ecal_radiator_thickness2           = lcdd.constant<double>("Ecal_radiator_layers_set2_thickness");
-  double Ecal_radiator_thickness3           = lcdd.constant<double>("Ecal_radiator_layers_set3_thickness");
-  double Ecal_Barrel_halfZ                  = lcdd.constant<double>("Ecal_Barrel_halfZ");
+  double Ecal_radiator_thickness1           = theDetector.constant<double>("Ecal_radiator_layers_set1_thickness");
+  double Ecal_radiator_thickness2           = theDetector.constant<double>("Ecal_radiator_layers_set2_thickness");
+  double Ecal_radiator_thickness3           = theDetector.constant<double>("Ecal_radiator_layers_set3_thickness");
+  double Ecal_Barrel_halfZ                  = theDetector.constant<double>("Ecal_Barrel_halfZ");
   
-  double Ecal_support_thickness             = lcdd.constant<double>("Ecal_support_thickness");
-  double Ecal_front_face_thickness          = lcdd.constant<double>("Ecal_front_face_thickness");
-  double Ecal_lateral_face_thickness        = lcdd.constant<double>("Ecal_lateral_face_thickness");
+  double Ecal_support_thickness             = theDetector.constant<double>("Ecal_support_thickness");
+  double Ecal_front_face_thickness          = theDetector.constant<double>("Ecal_front_face_thickness");
+  double Ecal_lateral_face_thickness        = theDetector.constant<double>("Ecal_lateral_face_thickness");
  
-  double Ecal_Slab_Sc_PCB_thickness         = lcdd.constant<double>("Ecal_Slab_Sc_PCB_thickness");
-  double Ecal_Sc_thickness                  = lcdd.constant<double>("Ecal_Sc_thickness");
-  double Ecal_Sc_reflector_thickness        = lcdd.constant<double>("Ecal_Sc_reflector_thickness");
+  double Ecal_Slab_Sc_PCB_thickness         = theDetector.constant<double>("Ecal_Slab_Sc_PCB_thickness");
+  double Ecal_Sc_thickness                  = theDetector.constant<double>("Ecal_Sc_thickness");
+  double Ecal_Sc_reflector_thickness        = theDetector.constant<double>("Ecal_Sc_reflector_thickness");
 
-  double Ecal_EC_Ring_gap                   = lcdd.constant<double>("Ecal_EC_Ring_gap");
+  double Ecal_EC_Ring_gap                   = theDetector.constant<double>("Ecal_EC_Ring_gap");
 
-  double Ecal_cables_gap                    = lcdd.constant<double>("Ecal_cables_gap");
-  double Lcal_outer_radius                  = lcdd.constant<double>("Lcal_outer_radius");
-  double Ecal_Lcal_ring_gap                 = lcdd.constant<double>("Ecal_Lcal_ring_gap");
-  double Ecal_endcap_center_box_size        = lcdd.constant<double>("Ecal_endcap_center_box_size");
+  double Ecal_cables_gap                    = theDetector.constant<double>("Ecal_cables_gap");
+  double Lcal_outer_radius                  = theDetector.constant<double>("Lcal_outer_radius");
+  double Ecal_Lcal_ring_gap                 = theDetector.constant<double>("Ecal_Lcal_ring_gap");
+  double Ecal_endcap_center_box_size        = theDetector.constant<double>("Ecal_endcap_center_box_size");
 
-  int    Ecal_nlayers1                      = lcdd.constant<int>("Ecal_nlayers1");
-  int    Ecal_nlayers2                      = lcdd.constant<int>("Ecal_nlayers2");
-  int    Ecal_nlayers3                      = lcdd.constant<int>("Ecal_nlayers3");
+  int    Ecal_nlayers1                      = theDetector.constant<int>("Ecal_nlayers1");
+  int    Ecal_nlayers2                      = theDetector.constant<int>("Ecal_nlayers2");
+  int    Ecal_nlayers3                      = theDetector.constant<int>("Ecal_nlayers3");
   
 
-  //double      Ecal_cells_size               = lcdd.constant<double>("Ecal_cells_size");
-  double      EcalEndcapRing_inner_radius   = lcdd.constant<double>("EcalEndcapRing_inner_radius");
-  double      EcalEndcapRing_outer_radius   = lcdd.constant<double>("EcalEndcapRing_outer_radius");
-  double      EcalEndcapRing_min_z          = lcdd.constant<double>("EcalEndcapRing_min_z");
-  double      EcalEndcapRing_max_z          = lcdd.constant<double>("EcalEndcapRing_max_z");
+  //double      Ecal_cells_size               = theDetector.constant<double>("Ecal_cells_size");
+  double      EcalEndcapRing_inner_radius   = theDetector.constant<double>("EcalEndcapRing_inner_radius");
+  double      EcalEndcapRing_outer_radius   = theDetector.constant<double>("EcalEndcapRing_outer_radius");
+  double      EcalEndcapRing_min_z          = theDetector.constant<double>("EcalEndcapRing_min_z");
+  double      EcalEndcapRing_max_z          = theDetector.constant<double>("EcalEndcapRing_max_z");
 
   //========== fill data for reconstruction ============================
-  DDRec::LayeredCalorimeterData* caloData = new DDRec::LayeredCalorimeterData ;
-  caloData->layoutType = DDRec::LayeredCalorimeterData::EndcapLayout ;
+  LayeredCalorimeterData* caloData = new LayeredCalorimeterData ;
+  caloData->layoutType = LayeredCalorimeterData::EndcapLayout ;
   caloData->inner_symmetry = 0  ; // hard code cernter pipe hole
   caloData->outer_symmetry = 4  ; // outer box
   caloData->phi0 = 0 ;
@@ -254,8 +274,8 @@ static Ref_t create_detector(LCDD& lcdd, xml_h element, SensitiveDetector sens) 
 
   SubtractionSolid ECRingSolid( CenterECBox, CenterECTub);
 
-  //  Volume EnvLogECRing("ECRing",ECRingSolid,lcdd.material("g10"));
-  Volume EnvLogECRing("ECRing",ECRingSolid,lcdd.material("CarbonFiber")); // DJeans 5-sep-2016
+  //  Volume EnvLogECRing("ECRing",ECRingSolid,theDetector.material("g10"));
+  Volume EnvLogECRing("ECRing",ECRingSolid,theDetector.material("CarbonFiber")); // DJeans 5-sep-2016
 
   //==============================================================
   // build the layer and place into the ECRing
@@ -277,7 +297,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h element, SensitiveDetector sens) 
 
   double l_pos_z = z_floor;
  
-  DDRec::LayeredCalorimeterData::Layer caloLayer ;
+  LayeredCalorimeterData::Layer caloLayer ;
   caloLayer.cellSize0 = cell_sizeX;
   caloLayer.cellSize1 = cell_sizeY;
 
@@ -346,7 +366,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h element, SensitiveDetector sens) 
       Volume     l_vol(det_name+"_"+l_name+"_"+tower_name,ECRingSiSolid,air);
       DetElement layer(module_det, l_name+tower_name, det_id);
 	  
-      l_vol.setVisAttributes(lcdd.visAttributes(x_layer.visStr()));
+      l_vol.setVisAttributes(theDetector.visAttributes(x_layer.visStr()));
       
       
       
@@ -362,7 +382,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h element, SensitiveDetector sens) 
 	xml_comp_t x_slice = si;
 	string     s_name  =  _toString(s_num,"slice%d");
 	double     s_thick = x_slice.thickness();
-	Material slice_material  = lcdd.material(x_slice.materialStr());
+	Material slice_material  = theDetector.material(x_slice.materialStr());
 	  
 	double slab_dim_x = ECRingSiplateSize/2.-tolerance;
 	double slab_dim_y = s_thick/2.-tolerance;
@@ -375,7 +395,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h element, SensitiveDetector sens) 
 	Volume     s_vol(det_name+"_"+l_name+"_"+s_name,ECRingSiSliceSolid,slice_material);
 	DetElement slice(layer,s_name,det_id);
 	
-	s_vol.setVisAttributes(lcdd.visAttributes(x_slice.visStr()));
+	s_vol.setVisAttributes(theDetector.visAttributes(x_slice.visStr()));
 
 #ifdef VERBOSE	    
 	std::cout<<"x_slice.materialStr(): "<< x_slice.materialStr() <<std::endl;
@@ -453,7 +473,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h element, SensitiveDetector sens) 
 	nInteractionLengths += s_thick/(2.*slice_material.intLength());
 	thickness_sum       += s_thick/2;
 
-	slice.setAttributes(lcdd,s_vol,x_slice.regionStr(),x_slice.limitsStr(),x_slice.visStr());
+	slice.setAttributes(theDetector,s_vol,x_slice.regionStr(),x_slice.limitsStr(),x_slice.visStr());
 	
 	// Slice placement.
 	PlacedVolume slice_phv = l_vol.placeVolume(s_vol,Position(0,0,s_pos_z+s_thick/2));
@@ -523,9 +543,9 @@ static Ref_t create_detector(LCDD& lcdd, xml_h element, SensitiveDetector sens) 
       Box        EndcapStructureLayer_box(ECRingSiplateSize/ 2. - tolerance, ECRingSiplateSize/ 2. - tolerance, radiator_dim_y/2.);
       SubtractionSolid  EndcapStructureLayerSolid( EndcapStructureLayer_box, CenterECTubForSi);
       
-      Volume     EndcapStructureLayer_vol(det_name+"_"+l_name+"_"+bs_name,EndcapStructureLayerSolid,lcdd.material(x_staves.materialStr()));
+      Volume     EndcapStructureLayer_vol(det_name+"_"+l_name+"_"+bs_name,EndcapStructureLayerSolid,theDetector.material(x_staves.materialStr()));
       
-      EndcapStructureLayer_vol.setVisAttributes(lcdd.visAttributes(x_layer.visStr()));	
+      EndcapStructureLayer_vol.setVisAttributes(theDetector.visAttributes(x_layer.visStr()));	
       
   
       int i_stave = 1;
@@ -566,7 +586,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h element, SensitiveDetector sens) 
   
   // Set stave visualization.
   if (x_staves)   {
-    EnvLogECRing.setVisAttributes(lcdd.visAttributes(x_staves.visStr()));
+    EnvLogECRing.setVisAttributes(theDetector.visAttributes(x_staves.visStr()));
   }
   
 
@@ -596,7 +616,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h element, SensitiveDetector sens) 
 
   }
   
-  sdet.addExtension< DDRec::LayeredCalorimeterData >( caloData ) ; 
+  sdet.addExtension< LayeredCalorimeterData >( caloData ) ; 
 
   return sdet;
   

--- a/detector/calorimeter/SEcal04_Endcaps.cpp
+++ b/detector/calorimeter/SEcal04_Endcaps.cpp
@@ -43,8 +43,32 @@
 #include "DDSegmentation/WaferGridXY.h"
 
 using namespace std;
-using namespace DD4hep;
-using namespace DD4hep::Geometry;
+
+using dd4hep::BUILD_ENVELOPE;
+using dd4hep::Box;
+using dd4hep::DetElement;
+using dd4hep::Detector;
+using dd4hep::Layering;
+using dd4hep::Material;
+using dd4hep::PlacedVolume;
+using dd4hep::PolyhedraRegular;
+using dd4hep::Position;
+using dd4hep::Readout;
+using dd4hep::Ref_t;
+using dd4hep::Rotation3D;
+using dd4hep::RotationZ;
+using dd4hep::RotationZYX;
+using dd4hep::Segmentation;
+using dd4hep::SensitiveDetector;
+using dd4hep::SubtractionSolid;
+using dd4hep::Transform3D;
+using dd4hep::Tube;
+using dd4hep::Volume;
+using dd4hep::_toString;
+
+using dd4hep::DDSegmentation::WaferGridXY;
+
+using dd4hep::rec::LayeredCalorimeterData;
 
 //#define VERBOSE 1
 
@@ -53,15 +77,15 @@ using namespace DD4hep::Geometry;
 #define DD4HEP_VERSION_GE(a,b) 0 
 #endif
 
-static Ref_t create_detector(LCDD& lcdd, xml_h element, SensitiveDetector sens)  {
+static Ref_t create_detector(Detector& theDetector, xml_h element, SensitiveDetector sens)  {
   static double tolerance = 0e0;
 
   xml_det_t     x_det     = element;
   string        det_name  = x_det.nameStr();
   Layering      layering (element);
 
-  Material      air       = lcdd.air();
-  //unused:  Material      vacuum    = lcdd.vacuum();
+  Material      air       = theDetector.air();
+  //unused:  Material      vacuum    = theDetector.vacuum();
 
   int           det_id    = x_det.id();
   xml_comp_t    x_staves  = x_det.staves();
@@ -69,16 +93,16 @@ static Ref_t create_detector(LCDD& lcdd, xml_h element, SensitiveDetector sens) 
 
   // --- create an envelope volume and position it into the world ---------------------
 
-  Volume envelope = XML::createPlacedEnvelope( lcdd,  element , sdet ) ;
+  Volume envelope = dd4hep::xml::createPlacedEnvelope( theDetector,  element , sdet ) ;
 
-  XML::setDetectorTypeFlag( element, sdet ) ;
+  dd4hep::xml::setDetectorTypeFlag( element, sdet ) ;
 
-  if( lcdd.buildType() == BUILD_ENVELOPE ) return sdet ;
+  if( theDetector.buildType() == BUILD_ENVELOPE ) return sdet ;
   //-----------------------------------------------------------------------------------
 
   sens.setType("calorimeter");
 
-  Material stave_material  = lcdd.material(x_staves.materialStr());
+  Material stave_material  = theDetector.material(x_staves.materialStr());
 
   DetElement    module_det("module0",det_id);
 
@@ -86,8 +110,8 @@ static Ref_t create_detector(LCDD& lcdd, xml_h element, SensitiveDetector sens) 
   Segmentation seg = readout.segmentation();
 
   // check if we have a WaferGridXY segmentation :
-  DD4hep::DDSegmentation::WaferGridXY* waferSeg = 
-    dynamic_cast< DD4hep::DDSegmentation::WaferGridXY*>( seg.segmentation() ) ;
+  WaferGridXY* waferSeg = 
+    dynamic_cast< WaferGridXY*>( seg.segmentation() ) ;
   
   std::vector<double> cellSizeVector = seg.segmentation()->cellDimensions(0); //Assume uniform cell sizes, provide dummy cellID
   double cell_sizeX      = cellSizeVector[0];
@@ -104,48 +128,48 @@ static Ref_t create_detector(LCDD& lcdd, xml_h element, SensitiveDetector sens) 
   int N_FIBERS_ALVOULUS = 3;
 
   //  read parametere from compact.xml file
-  double Ecal_Alveolus_Air_Gap              = lcdd.constant<double>("Ecal_Alveolus_Air_Gap");
-  double Ecal_Slab_shielding                = lcdd.constant<double>("Ecal_Slab_shielding");
-  double Ecal_Slab_copper_thickness         = lcdd.constant<double>("Ecal_Slab_copper_thickness");
-  double Ecal_Slab_PCB_thickness            = lcdd.constant<double>("Ecal_Slab_PCB_thickness");
-  double Ecal_Slab_glue_gap                 = lcdd.constant<double>("Ecal_Slab_glue_gap");
-  double Ecal_Slab_ground_thickness         = lcdd.constant<double>("Ecal_Slab_ground_thickness");
-  double Ecal_fiber_thickness               = lcdd.constant<double>("Ecal_fiber_thickness");
-  double Ecal_Si_thickness                  = lcdd.constant<double>("Ecal_Si_thickness");
+  double Ecal_Alveolus_Air_Gap              = theDetector.constant<double>("Ecal_Alveolus_Air_Gap");
+  double Ecal_Slab_shielding                = theDetector.constant<double>("Ecal_Slab_shielding");
+  double Ecal_Slab_copper_thickness         = theDetector.constant<double>("Ecal_Slab_copper_thickness");
+  double Ecal_Slab_PCB_thickness            = theDetector.constant<double>("Ecal_Slab_PCB_thickness");
+  double Ecal_Slab_glue_gap                 = theDetector.constant<double>("Ecal_Slab_glue_gap");
+  double Ecal_Slab_ground_thickness         = theDetector.constant<double>("Ecal_Slab_ground_thickness");
+  double Ecal_fiber_thickness               = theDetector.constant<double>("Ecal_fiber_thickness");
+  double Ecal_Si_thickness                  = theDetector.constant<double>("Ecal_Si_thickness");
   
-  double Ecal_inner_radius                  = lcdd.constant<double>("TPC_outer_radius") +lcdd.constant<double>("Ecal_Tpc_gap");
-  double Ecal_radiator_thickness1           = lcdd.constant<double>("Ecal_radiator_layers_set1_thickness");
-  double Ecal_radiator_thickness2           = lcdd.constant<double>("Ecal_radiator_layers_set2_thickness");
-  double Ecal_radiator_thickness3           = lcdd.constant<double>("Ecal_radiator_layers_set3_thickness");
-  double Ecal_Barrel_halfZ                  = lcdd.constant<double>("Ecal_Barrel_halfZ");
+  double Ecal_inner_radius                  = theDetector.constant<double>("TPC_outer_radius") +theDetector.constant<double>("Ecal_Tpc_gap");
+  double Ecal_radiator_thickness1           = theDetector.constant<double>("Ecal_radiator_layers_set1_thickness");
+  double Ecal_radiator_thickness2           = theDetector.constant<double>("Ecal_radiator_layers_set2_thickness");
+  double Ecal_radiator_thickness3           = theDetector.constant<double>("Ecal_radiator_layers_set3_thickness");
+  double Ecal_Barrel_halfZ                  = theDetector.constant<double>("Ecal_Barrel_halfZ");
   
-  double Ecal_support_thickness             = lcdd.constant<double>("Ecal_support_thickness");
-  double Ecal_front_face_thickness          = lcdd.constant<double>("Ecal_front_face_thickness");
-  double Ecal_lateral_face_thickness        = lcdd.constant<double>("Ecal_lateral_face_thickness");
-  double Ecal_Slab_H_fiber_thickness        = lcdd.constant<double>("Ecal_Slab_H_fiber_thickness");
+  double Ecal_support_thickness             = theDetector.constant<double>("Ecal_support_thickness");
+  double Ecal_front_face_thickness          = theDetector.constant<double>("Ecal_front_face_thickness");
+  double Ecal_lateral_face_thickness        = theDetector.constant<double>("Ecal_lateral_face_thickness");
+  double Ecal_Slab_H_fiber_thickness        = theDetector.constant<double>("Ecal_Slab_H_fiber_thickness");
 
-  double Ecal_Slab_Sc_PCB_thickness         = lcdd.constant<double>("Ecal_Slab_Sc_PCB_thickness");
-  double Ecal_Sc_thickness                  = lcdd.constant<double>("Ecal_Sc_thickness");
-  double Ecal_Sc_reflector_thickness        = lcdd.constant<double>("Ecal_Sc_reflector_thickness");
+  double Ecal_Slab_Sc_PCB_thickness         = theDetector.constant<double>("Ecal_Slab_Sc_PCB_thickness");
+  double Ecal_Sc_thickness                  = theDetector.constant<double>("Ecal_Sc_thickness");
+  double Ecal_Sc_reflector_thickness        = theDetector.constant<double>("Ecal_Sc_reflector_thickness");
 
-  double Ecal_endcap_extra_size             = lcdd.constant<double>("Ecal_endcap_extra_size");
-  double Ecal_cables_gap                    = lcdd.constant<double>("Ecal_cables_gap");
-  //unused:  double Lcal_outer_radius                  = lcdd.constant<double>("Lcal_outer_radius");
-  //unused:  double Ecal_Lcal_ring_gap                 = lcdd.constant<double>("Ecal_Lcal_ring_gap");
-  double Ecal_endcap_center_box_size        = lcdd.constant<double>("Ecal_endcap_center_box_size");
+  double Ecal_endcap_extra_size             = theDetector.constant<double>("Ecal_endcap_extra_size");
+  double Ecal_cables_gap                    = theDetector.constant<double>("Ecal_cables_gap");
+  //unused:  double Lcal_outer_radius                  = theDetector.constant<double>("Lcal_outer_radius");
+  //unused:  double Ecal_Lcal_ring_gap                 = theDetector.constant<double>("Ecal_Lcal_ring_gap");
+  double Ecal_endcap_center_box_size        = theDetector.constant<double>("Ecal_endcap_center_box_size");
 
-  int    Ecal_nlayers1                      = lcdd.constant<int>("Ecal_nlayers1");
-  int    Ecal_nlayers2                      = lcdd.constant<int>("Ecal_nlayers2");
-  int    Ecal_nlayers3                      = lcdd.constant<int>("Ecal_nlayers3");
-  int    Ecal_barrel_number_of_towers       = lcdd.constant<int>("Ecal_barrel_number_of_towers");
+  int    Ecal_nlayers1                      = theDetector.constant<int>("Ecal_nlayers1");
+  int    Ecal_nlayers2                      = theDetector.constant<int>("Ecal_nlayers2");
+  int    Ecal_nlayers3                      = theDetector.constant<int>("Ecal_nlayers3");
+  int    Ecal_barrel_number_of_towers       = theDetector.constant<int>("Ecal_barrel_number_of_towers");
   
-  double Ecal_guard_ring_size               = lcdd.constant<double>("Ecal_guard_ring_size");
+  double Ecal_guard_ring_size               = theDetector.constant<double>("Ecal_guard_ring_size");
 
-  //double      Ecal_cells_size                  = lcdd.constant<double>("Ecal_cells_size");
-  double      EcalEndcap_inner_radius          = lcdd.constant<double>("EcalEndcap_inner_radius");
-  double      EcalEndcap_outer_radius          = lcdd.constant<double>("EcalEndcap_outer_radius");
-  double      EcalEndcap_min_z                 = lcdd.constant<double>("EcalEndcap_min_z");
-  double      EcalEndcap_max_z                 = lcdd.constant<double>("EcalEndcap_max_z");
+  //double      Ecal_cells_size                  = theDetector.constant<double>("Ecal_cells_size");
+  double      EcalEndcap_inner_radius          = theDetector.constant<double>("EcalEndcap_inner_radius");
+  double      EcalEndcap_outer_radius          = theDetector.constant<double>("EcalEndcap_outer_radius");
+  double      EcalEndcap_min_z                 = theDetector.constant<double>("EcalEndcap_min_z");
+  double      EcalEndcap_max_z                 = theDetector.constant<double>("EcalEndcap_max_z");
 
 //====================================================================
 //
@@ -234,7 +258,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h element, SensitiveDetector sens) 
 
   //------------------------------------------------------------------------------------
 
-  DDRec::LayeredCalorimeterData::Layer caloLayer ;
+  LayeredCalorimeterData::Layer caloLayer ;
   caloLayer.cellSize0 = cell_sizeX;
   caloLayer.cellSize1 = cell_sizeY;
 
@@ -287,8 +311,8 @@ static Ref_t create_detector(LCDD& lcdd, xml_h element, SensitiveDetector sens) 
   Box  CenterECBox(Ecal_endcap_center_box_size/2.,Ecal_endcap_center_box_size/2.,module_thickness+0.0001);
   SubtractionSolid EndCapSolid( ECPolyHedra, CenterECBox);
 
-  //  Volume EnvLogEndCap("endcap",EndCapSolid,lcdd.material("g10"));
-  Volume EnvLogEndCap("endcap",EndCapSolid,lcdd.material("CarbonFiber")); // DJeans 5-sep-2016
+  //  Volume EnvLogEndCap("endcap",EndCapSolid,theDetector.material("g10"));
+  Volume EnvLogEndCap("endcap",EndCapSolid,theDetector.material("CarbonFiber")); // DJeans 5-sep-2016
  
 
 
@@ -340,8 +364,8 @@ static Ref_t create_detector(LCDD& lcdd, xml_h element, SensitiveDetector sens) 
   double l_pos_z = z_floor;
 
   //========== fill data for reconstruction ============================
-  DDRec::LayeredCalorimeterData* caloData = new DDRec::LayeredCalorimeterData ;
-  caloData->layoutType = DDRec::LayeredCalorimeterData::EndcapLayout ;
+  LayeredCalorimeterData* caloData = new LayeredCalorimeterData ;
+  caloData->layoutType = LayeredCalorimeterData::EndcapLayout ;
   caloData->inner_symmetry = 4  ; // hard code cernter box hole
   caloData->outer_symmetry = 8  ; // outer Octagun
   caloData->phi0 = 0 ;
@@ -423,7 +447,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h element, SensitiveDetector sens) 
 	  Volume     l_vol(det_name+"_"+l_name+"_"+tower_name,l_box,air);
 	  DetElement layer(module_det, l_name+tower_name, det_id);
 	  
-	  l_vol.setVisAttributes(lcdd.visAttributes(x_layer.visStr()));
+	  l_vol.setVisAttributes(theDetector.visAttributes(x_layer.visStr()));
 	  
 	  
 	  // Loop over the sublayers or slices for this layer.
@@ -439,7 +463,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h element, SensitiveDetector sens) 
 	    xml_comp_t x_slice = si;
 	    string     s_name  =  _toString(s_num,"slice%d");
 	    double     s_thick = x_slice.thickness();
-	    Material slice_material  = lcdd.material(x_slice.materialStr());
+	    Material slice_material  = theDetector.material(x_slice.materialStr());
  
 	    double slab_dim_x = alveolus_dim_z/2.-tolerance;
 	    double slab_dim_y = s_thick/2.-tolerance;
@@ -449,7 +473,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h element, SensitiveDetector sens) 
 	    Volume     s_vol(det_name+"_"+l_name+"_"+s_name,s_box,slice_material);
 	    DetElement slice(layer,s_name,det_id);
 	    
-	    s_vol.setVisAttributes(lcdd.visAttributes(x_slice.visStr()));
+	    s_vol.setVisAttributes(theDetector.visAttributes(x_slice.visStr()));
 
 #ifdef VERBOSE	    
 	    std::cout<<"x_slice.materialStr(): "<< x_slice.materialStr() <<std::endl;
@@ -534,7 +558,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h element, SensitiveDetector sens) 
 		    string Wafer_name  =  _toString(wafer_num,"wafer%d");
 		    Volume WaferSiLog(det_name+"_"+l_name+"_"+s_name+"_"+Wafer_name,WaferSiSolid,slice_material);
 		    WaferSiLog.setSensitiveDetector(sens);
-		    WaferSiLog.setVisAttributes(lcdd.visAttributes(x_slice.visStr()));
+		    WaferSiLog.setVisAttributes(theDetector.visAttributes(x_slice.visStr()));
 		    PlacedVolume wafer_phv = s_vol.placeVolume(WaferSiLog,Position(wafer_pos_z,
 										   wafer_pos_x,
 										   0));
@@ -600,7 +624,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h element, SensitiveDetector sens) 
 		    string MagicWafer_name  =  _toString(wafer_num,"MagicWafer%d");
 		    Volume MagicWaferSiLog(det_name+"_"+l_name+"_"+s_name+"_"+MagicWafer_name,MagicWaferSiSolid,slice_material);
 		    MagicWaferSiLog.setSensitiveDetector(sens);
-		    MagicWaferSiLog.setVisAttributes(lcdd.visAttributes(x_slice.visStr()));
+		    MagicWaferSiLog.setVisAttributes(theDetector.visAttributes(x_slice.visStr()));
 		    PlacedVolume wafer_phv = s_vol.placeVolume(MagicWaferSiLog,Position(wafer_pos_z,
 											wafer_pos_x,
 											0));
@@ -657,7 +681,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h element, SensitiveDetector sens) 
 	      thickness_sum       += s_thick/2.;
 	    }
 	    
-	    slice.setAttributes(lcdd,s_vol,x_slice.regionStr(),x_slice.limitsStr(),x_slice.visStr());
+	    slice.setAttributes(theDetector,s_vol,x_slice.regionStr(),x_slice.limitsStr(),x_slice.visStr());
 	    
 	    // Slice placement.
 	    PlacedVolume slice_phv = l_vol.placeVolume(s_vol,Position(0,0,s_pos_z+s_thick/2));
@@ -702,9 +726,9 @@ static Ref_t create_detector(LCDD& lcdd, xml_h element, SensitiveDetector sens) 
 	  string bs_name="bs";
 	  
 	  Box        EndcapStructureLayer_box(radiator_dim_x/2.,radiator_dim_z/2.,radiator_dim_y/2.);
-	  Volume     EndcapStructureLayer_vol(det_name+"_"+l_name+"_"+bs_name,EndcapStructureLayer_box,lcdd.material(x_staves.materialStr()));
+	  Volume     EndcapStructureLayer_vol(det_name+"_"+l_name+"_"+bs_name,EndcapStructureLayer_box,theDetector.material(x_staves.materialStr()));
 	  
-	  EndcapStructureLayer_vol.setVisAttributes(lcdd.visAttributes(x_layer.visStr()));	
+	  EndcapStructureLayer_vol.setVisAttributes(theDetector.visAttributes(x_layer.visStr()));	
 	  
 	  
 	  int limit_staves;
@@ -802,7 +826,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h element, SensitiveDetector sens) 
   
     // Set stave visualization.
     if (x_staves)   {
-      EnvLogEndCap.setVisAttributes(lcdd.visAttributes(x_staves.visStr()));
+      EnvLogEndCap.setVisAttributes(theDetector.visAttributes(x_staves.visStr()));
     }
  
 
@@ -838,7 +862,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h element, SensitiveDetector sens) 
 
   }
   
-  sdet.addExtension< DDRec::LayeredCalorimeterData >( caloData ) ; 
+  sdet.addExtension< LayeredCalorimeterData >( caloData ) ; 
 
   return sdet;
   

--- a/detector/calorimeter/SEcal05_ECRing.cpp
+++ b/detector/calorimeter/SEcal05_ECRing.cpp
@@ -61,8 +61,28 @@
 #include "DDRec/DetectorData.h"
 
 using namespace std;
-using namespace DD4hep;
-using namespace DD4hep::Geometry;
+
+using dd4hep::BUILD_ENVELOPE;
+using dd4hep::Box;
+using dd4hep::DetElement;
+using dd4hep::Detector;
+using dd4hep::Layering;
+using dd4hep::Material;
+using dd4hep::PlacedVolume;
+using dd4hep::Position;
+using dd4hep::Readout;
+using dd4hep::Ref_t;
+using dd4hep::Rotation3D;
+using dd4hep::RotationZYX;
+using dd4hep::Segmentation;
+using dd4hep::SensitiveDetector;
+using dd4hep::SubtractionSolid;
+using dd4hep::Transform3D;
+using dd4hep::Tube;
+using dd4hep::Volume;
+using dd4hep::_toString;
+
+using dd4hep::rec::LayeredCalorimeterData;
 
 //#define VERBOSE 1
 
@@ -71,15 +91,15 @@ using namespace DD4hep::Geometry;
 #define DD4HEP_VERSION_GE(a,b) 0 
 #endif
 
-static Ref_t create_detector(LCDD& lcdd, xml_h element, SensitiveDetector sens)  {
+static Ref_t create_detector(Detector& theDetector, xml_h element, SensitiveDetector sens)  {
   static double tolerance = 0e0;
 
   xml_det_t     x_det     = element;
   string        det_name  = x_det.nameStr();
   Layering      layering (element);
 
-  Material      air       = lcdd.air();
-  //unused: Material      vacuum    = lcdd.vacuum();
+  Material      air       = theDetector.air();
+  //unused: Material      vacuum    = theDetector.vacuum();
 
   int           det_id    = x_det.id();
   xml_comp_t    x_staves  = x_det.staves();
@@ -87,17 +107,17 @@ static Ref_t create_detector(LCDD& lcdd, xml_h element, SensitiveDetector sens) 
 
   // --- create an envelope volume and position it into the world ---------------------
   
-  Volume envelope = XML::createPlacedEnvelope( lcdd,  element , sdet ) ;
+  Volume envelope = dd4hep::xml::createPlacedEnvelope( theDetector,  element , sdet ) ;
   
-  XML::setDetectorTypeFlag( element, sdet ) ;
+  dd4hep::xml::setDetectorTypeFlag( element, sdet ) ;
 
-  if( lcdd.buildType() == BUILD_ENVELOPE ) return sdet ;
+  if( theDetector.buildType() == BUILD_ENVELOPE ) return sdet ;
 
   //-----------------------------------------------------------------------------------
 
   sens.setType("calorimeter");
 
-  Material stave_material  = lcdd.material(x_staves.materialStr());
+  Material stave_material  = theDetector.material(x_staves.materialStr());
 
   //  DetElement    module_det("module0",det_id); // need 2 separate modules, move to a little later
 
@@ -119,57 +139,57 @@ static Ref_t create_detector(LCDD& lcdd, xml_h element, SensitiveDetector sens) 
 //  int N_FIBERS_ALVOULUS = 3;
 
   //  read parametere from compact.xml file
-  double Ecal_Alveolus_Air_Gap              = lcdd.constant<double>("Ecal_Alveolus_Air_Gap");
-  double Ecal_Slab_shielding                = lcdd.constant<double>("Ecal_Slab_shielding");
-  double Ecal_Slab_copper_thickness         = lcdd.constant<double>("Ecal_Slab_copper_thickness");
-  double Ecal_Slab_PCB_thickness            = lcdd.constant<double>("Ecal_Slab_PCB_thickness");
-  double Ecal_Slab_glue_gap                 = lcdd.constant<double>("Ecal_Slab_glue_gap");
-  double Ecal_Slab_ground_thickness         = lcdd.constant<double>("Ecal_Slab_ground_thickness");
-  double Ecal_fiber_thickness_alveolus      = lcdd.constant<double>("Ecal_fiber_thickness_alveolus");
-  double Ecal_fiber_thickness_structure     = lcdd.constant<double>("Ecal_fiber_thickness_structure");
-  double Ecal_fiber_thickness_slabAbs       = lcdd.constant<double>("Ecal_fiber_thickness_slabAbs");
-  double Ecal_Si_thickness                  = lcdd.constant<double>("Ecal_Si_thickness");
+  double Ecal_Alveolus_Air_Gap              = theDetector.constant<double>("Ecal_Alveolus_Air_Gap");
+  double Ecal_Slab_shielding                = theDetector.constant<double>("Ecal_Slab_shielding");
+  double Ecal_Slab_copper_thickness         = theDetector.constant<double>("Ecal_Slab_copper_thickness");
+  double Ecal_Slab_PCB_thickness            = theDetector.constant<double>("Ecal_Slab_PCB_thickness");
+  double Ecal_Slab_glue_gap                 = theDetector.constant<double>("Ecal_Slab_glue_gap");
+  double Ecal_Slab_ground_thickness         = theDetector.constant<double>("Ecal_Slab_ground_thickness");
+  double Ecal_fiber_thickness_alveolus      = theDetector.constant<double>("Ecal_fiber_thickness_alveolus");
+  double Ecal_fiber_thickness_structure     = theDetector.constant<double>("Ecal_fiber_thickness_structure");
+  double Ecal_fiber_thickness_slabAbs       = theDetector.constant<double>("Ecal_fiber_thickness_slabAbs");
+  double Ecal_Si_thickness                  = theDetector.constant<double>("Ecal_Si_thickness");
   
-  double Ecal_radiator_thickness1           = lcdd.constant<double>("Ecal_radiator_layers_set1_thickness");
-  double Ecal_radiator_thickness2           = lcdd.constant<double>("Ecal_radiator_layers_set2_thickness");
-  double Ecal_radiator_thickness3           = lcdd.constant<double>("Ecal_radiator_layers_set3_thickness");
-  double Ecal_Barrel_halfZ                  = lcdd.constant<double>("Ecal_Barrel_halfZ");
+  double Ecal_radiator_thickness1           = theDetector.constant<double>("Ecal_radiator_layers_set1_thickness");
+  double Ecal_radiator_thickness2           = theDetector.constant<double>("Ecal_radiator_layers_set2_thickness");
+  double Ecal_radiator_thickness3           = theDetector.constant<double>("Ecal_radiator_layers_set3_thickness");
+  double Ecal_Barrel_halfZ                  = theDetector.constant<double>("Ecal_Barrel_halfZ");
   
-  double Ecal_support_thickness             = lcdd.constant<double>("Ecal_support_thickness");
-  double Ecal_front_face_thickness          = lcdd.constant<double>("Ecal_front_face_thickness");
-  double Ecal_lateral_face_thickness        = lcdd.constant<double>("Ecal_lateral_face_thickness");
+  double Ecal_support_thickness             = theDetector.constant<double>("Ecal_support_thickness");
+  double Ecal_front_face_thickness          = theDetector.constant<double>("Ecal_front_face_thickness");
+  double Ecal_lateral_face_thickness        = theDetector.constant<double>("Ecal_lateral_face_thickness");
  
-  double Ecal_Slab_Sc_PCB_thickness         = lcdd.constant<double>("Ecal_Slab_Sc_PCB_thickness");
-  double Ecal_Sc_thickness                  = lcdd.constant<double>("Ecal_Sc_thickness");
-  double Ecal_Sc_reflector_thickness        = lcdd.constant<double>("Ecal_Sc_reflector_thickness");
+  double Ecal_Slab_Sc_PCB_thickness         = theDetector.constant<double>("Ecal_Slab_Sc_PCB_thickness");
+  double Ecal_Sc_thickness                  = theDetector.constant<double>("Ecal_Sc_thickness");
+  double Ecal_Sc_reflector_thickness        = theDetector.constant<double>("Ecal_Sc_reflector_thickness");
 
-  double Ecal_EC_Ring_gap                   = lcdd.constant<double>("Ecal_EC_Ring_gap");
+  double Ecal_EC_Ring_gap                   = theDetector.constant<double>("Ecal_EC_Ring_gap");
 
-  double Ecal_cables_gap                    = lcdd.constant<double>("Ecal_cables_gap");
-  double Lcal_outer_radius                  = lcdd.constant<double>("Lcal_outer_radius");
-  double Ecal_Lcal_ring_gap                 = lcdd.constant<double>("Ecal_Lcal_ring_gap");
-  double Ecal_endcap_center_box_size        = lcdd.constant<double>("Ecal_endcap_center_box_size");
+  double Ecal_cables_gap                    = theDetector.constant<double>("Ecal_cables_gap");
+  double Lcal_outer_radius                  = theDetector.constant<double>("Lcal_outer_radius");
+  double Ecal_Lcal_ring_gap                 = theDetector.constant<double>("Ecal_Lcal_ring_gap");
+  double Ecal_endcap_center_box_size        = theDetector.constant<double>("Ecal_endcap_center_box_size");
 
-  int    Ecal_nlayers1                      = lcdd.constant<int>("Ecal_nlayers1");
-  int    Ecal_nlayers2                      = lcdd.constant<int>("Ecal_nlayers2");
-  int    Ecal_nlayers3                      = lcdd.constant<int>("Ecal_nlayers3");
+  int    Ecal_nlayers1                      = theDetector.constant<int>("Ecal_nlayers1");
+  int    Ecal_nlayers2                      = theDetector.constant<int>("Ecal_nlayers2");
+  int    Ecal_nlayers3                      = theDetector.constant<int>("Ecal_nlayers3");
   
 
-  //double      Ecal_cells_size               = lcdd.constant<double>("Ecal_cells_size");
-  double      EcalEndcapRing_inner_radius   = lcdd.constant<double>("EcalEndcapRing_inner_radius");
-  double      EcalEndcapRing_outer_radius   = lcdd.constant<double>("EcalEndcapRing_outer_radius");
-  double      EcalEndcapRing_min_z          = lcdd.constant<double>("EcalEndcapRing_min_z");
-  double      EcalEndcapRing_max_z          = lcdd.constant<double>("EcalEndcapRing_max_z");
+  //double      Ecal_cells_size               = theDetector.constant<double>("Ecal_cells_size");
+  double      EcalEndcapRing_inner_radius   = theDetector.constant<double>("EcalEndcapRing_inner_radius");
+  double      EcalEndcapRing_outer_radius   = theDetector.constant<double>("EcalEndcapRing_outer_radius");
+  double      EcalEndcapRing_min_z          = theDetector.constant<double>("EcalEndcapRing_min_z");
+  double      EcalEndcapRing_max_z          = theDetector.constant<double>("EcalEndcapRing_max_z");
 
 
-  double      crossing_angle = lcdd.constant<double>("ILC_Main_Crossing_Angle");
-  bool        Ecal_Barrel_PreshowerLayer         = lcdd.constant<int>("Ecal_Barrel_Preshower") > 0;
+  double      crossing_angle = theDetector.constant<double>("ILC_Main_Crossing_Angle");
+  bool        Ecal_Barrel_PreshowerLayer         = theDetector.constant<int>("Ecal_Barrel_Preshower") > 0;
 
 
 
   //========== fill data for reconstruction ============================
-  DDRec::LayeredCalorimeterData* caloData = new DDRec::LayeredCalorimeterData ;
-  caloData->layoutType = DDRec::LayeredCalorimeterData::EndcapLayout ;
+  dd4hep::rec::LayeredCalorimeterData* caloData = new dd4hep::rec::LayeredCalorimeterData ;
+  caloData->layoutType = dd4hep::rec::LayeredCalorimeterData::EndcapLayout ;
   caloData->inner_symmetry = 0  ; // hard code cernter pipe hole
   caloData->outer_symmetry = 4  ; // outer box
   caloData->phi0 = 0 ;
@@ -294,8 +314,8 @@ static Ref_t create_detector(LCDD& lcdd, xml_h element, SensitiveDetector sens) 
 
   SubtractionSolid ECRingSolid( CenterECBox, CenterECTub, hole_position);
 
-  //  Volume EnvLogECRing("ECRing",ECRingSolid,lcdd.material("g10"));
-  Volume EnvLogECRing("ECRing",ECRingSolid,lcdd.material("CarbonFiber")); // DJeans 5-sep-2016
+  //  Volume EnvLogECRing("ECRing",ECRingSolid,theDetector.material("g10"));
+  Volume EnvLogECRing("ECRing",ECRingSolid,theDetector.material("CarbonFiber")); // DJeans 5-sep-2016
 
   //==============================================================
   // build the layer and place into the ECRing
@@ -319,7 +339,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h element, SensitiveDetector sens) 
 
   double l_pos_z = z_floor;
  
-  DDRec::LayeredCalorimeterData::Layer caloLayer ;
+  dd4hep::rec::LayeredCalorimeterData::Layer caloLayer ;
   caloLayer.cellSize0 = cell_sizeX;
   caloLayer.cellSize1 = cell_sizeY;
 
@@ -426,8 +446,8 @@ static Ref_t create_detector(LCDD& lcdd, xml_h element, SensitiveDetector sens) 
       //Box        EndcapStructureLayer_box(radiator_dim_x/2.,radiator_dim_z/2.,radiator_dim_y/2.);
       Box        EndcapStructureLayer_box(ECRingSiplateSize/ 2. - tolerance, ECRingSiplateSize/ 2. - tolerance, radiator_dim_y/2.);
       SubtractionSolid  EndcapStructureLayerSolid( EndcapStructureLayer_box, CenterECTubForSi, hole_position);
-      Volume     EndcapStructureLayer_vol(det_name+"_"+l_name+"_"+bs_name,EndcapStructureLayerSolid,lcdd.material(x_staves.materialStr()));
-      EndcapStructureLayer_vol.setVisAttributes(lcdd.visAttributes( x_staves.visStr()));	
+      Volume     EndcapStructureLayer_vol(det_name+"_"+l_name+"_"+bs_name,EndcapStructureLayerSolid,theDetector.material(x_staves.materialStr()));
+      EndcapStructureLayer_vol.setVisAttributes(theDetector.visAttributes( x_staves.visStr()));	
       
   
       // Without last W StructureLayer, the last part is Si SD even layer.
@@ -503,7 +523,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h element, SensitiveDetector sens) 
       Volume     l_vol(det_name+"_"+l_name+"_"+tower_name,ECRingSiSolid,air);
       DetElement layer(module_det, l_name+tower_name, det_id);
 	  
-      l_vol.setVisAttributes(lcdd.visAttributes( x_layer.visStr() ));
+      l_vol.setVisAttributes(theDetector.visAttributes( x_layer.visStr() ));
       
       
       
@@ -519,7 +539,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h element, SensitiveDetector sens) 
 	xml_comp_t x_slice = si;
 	string     s_name  =  _toString(s_num,"slice%d");
 	double     s_thick = x_slice.thickness();
-	Material slice_material  = lcdd.material(x_slice.materialStr());
+	Material slice_material  = theDetector.material(x_slice.materialStr());
 	  
 	double slab_dim_x = ECRingSiplateSize/2.-tolerance;
 	double slab_dim_y = s_thick/2.-tolerance;
@@ -532,7 +552,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h element, SensitiveDetector sens) 
 	Volume     s_vol(det_name+"_"+l_name+"_"+s_name,ECRingSiSliceSolid,slice_material);
 	DetElement slice(layer,s_name,det_id);
 	
-	s_vol.setVisAttributes(lcdd.visAttributes(x_slice.visStr()));
+	s_vol.setVisAttributes(theDetector.visAttributes(x_slice.visStr()));
 
 #ifdef VERBOSE	    
 	std::cout<<"x_slice.materialStr(): "<< x_slice.materialStr() <<std::endl;
@@ -613,7 +633,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h element, SensitiveDetector sens) 
 	nInteractionLengths += s_thick/(2.*slice_material.intLength());
 	thickness_sum       += s_thick/2;
 
-	slice.setAttributes(lcdd,s_vol,x_slice.regionStr(),x_slice.limitsStr(),x_slice.visStr());
+	slice.setAttributes(theDetector,s_vol,x_slice.regionStr(),x_slice.limitsStr(),x_slice.visStr());
 	
 	// Slice placement.
 	PlacedVolume slice_phv = l_vol.placeVolume(s_vol,Position(0,0,s_pos_z+s_thick/2));
@@ -698,8 +718,8 @@ static Ref_t create_detector(LCDD& lcdd, xml_h element, SensitiveDetector sens) 
 //      //Box        EndcapStructureLayer_box(radiator_dim_x/2.,radiator_dim_z/2.,radiator_dim_y/2.);
 //      Box        EndcapStructureLayer_box(ECRingSiplateSize/ 2. - tolerance, ECRingSiplateSize/ 2. - tolerance, radiator_dim_y/2.);
 //      SubtractionSolid  EndcapStructureLayerSolid( EndcapStructureLayer_box, CenterECTubForSi, hole_position);
-//      Volume     EndcapStructureLayer_vol(det_name+"_"+l_name+"_"+bs_name,EndcapStructureLayerSolid,lcdd.material(x_staves.materialStr()));
-//      EndcapStructureLayer_vol.setVisAttributes(lcdd.visAttributes(x_layer.visStr()));	
+//      Volume     EndcapStructureLayer_vol(det_name+"_"+l_name+"_"+bs_name,EndcapStructureLayerSolid,theDetector.material(x_staves.materialStr()));
+//      EndcapStructureLayer_vol.setVisAttributes(theDetector.visAttributes(x_layer.visStr()));	
 //      
 //  
 //      // Without last W StructureLayer, the last part is Si SD even layer.
@@ -729,7 +749,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h element, SensitiveDetector sens) 
   
   // Set stave visualization.
   if (x_staves)   {
-    EnvLogECRing.setVisAttributes(lcdd.visAttributes(x_staves.visStr()));
+    EnvLogECRing.setVisAttributes(theDetector.visAttributes(x_staves.visStr()));
   }
   
 
@@ -759,7 +779,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h element, SensitiveDetector sens) 
 
   }
   
-  sdet.addExtension< DDRec::LayeredCalorimeterData >( caloData ) ; 
+  sdet.addExtension< dd4hep::rec::LayeredCalorimeterData >( caloData ) ; 
 
   return sdet;
   

--- a/detector/calorimeter/SEcal05_Endcaps.cpp
+++ b/detector/calorimeter/SEcal05_Endcaps.cpp
@@ -44,8 +44,28 @@
 #include <sstream>
 
 using namespace std;
-using namespace DD4hep;
-using namespace DD4hep::Geometry;
+
+using dd4hep::BUILD_ENVELOPE;
+using dd4hep::Box;
+using dd4hep::DetElement;
+using dd4hep::Detector;
+using dd4hep::IntersectionSolid;
+using dd4hep::Layering;
+using dd4hep::Material;
+using dd4hep::PlacedVolume;
+using dd4hep::PolyhedraRegular;
+using dd4hep::Position;
+using dd4hep::Readout;
+using dd4hep::Ref_t;
+using dd4hep::Rotation3D;
+using dd4hep::RotationZYX;
+using dd4hep::Segmentation;
+using dd4hep::SensitiveDetector;
+using dd4hep::Transform3D;
+using dd4hep::Volume;
+using dd4hep::_toString;
+
+using dd4hep::rec::LayeredCalorimeterData;
 
 #include "SEcal05_Helpers.h"
 
@@ -60,7 +80,7 @@ using namespace DD4hep::Geometry;
 #define DD4HEP_VERSION_GE(a,b) 0 
 #endif
 
-static Ref_t create_detector(LCDD& lcdd, xml_h element, SensitiveDetector sens)  {
+static Ref_t create_detector(Detector& theDetector, xml_h element, SensitiveDetector sens)  {
 
   cout << "------------------------" << endl;
   cout << "creating SEcal05_Endcaps" << endl;
@@ -73,15 +93,15 @@ static Ref_t create_detector(LCDD& lcdd, xml_h element, SensitiveDetector sens) 
   int           det_id    = x_det.id();
   //  xml_comp_t    x_staves  = x_det.staves();
   DetElement    sdet      (det_name,det_id);
-  //  Volume        motherVol = lcdd.pickMotherVolume(sdet);
+  //  Volume        motherVol = theDetector.pickMotherVolume(sdet);
 
   // --- create an envelope volume and position it into the world ---------------------
 
-  Volume envelope = XML::createPlacedEnvelope( lcdd,  element , sdet ) ;
+  Volume envelope = dd4hep::xml::createPlacedEnvelope( theDetector,  element , sdet ) ;
 
-  XML::setDetectorTypeFlag( element, sdet ) ;
+  dd4hep::xml::setDetectorTypeFlag( element, sdet ) ;
 
-  if( lcdd.buildType() == BUILD_ENVELOPE ) return sdet ;
+  if( theDetector.buildType() == BUILD_ENVELOPE ) return sdet ;
   //-----------------------------------------------------------------------------------
 
   sens.setType("calorimeter");
@@ -97,56 +117,56 @@ static Ref_t create_detector(LCDD& lcdd, xml_h element, SensitiveDetector sens) 
   //====================================================================
   
   //  read parameters from compact.xml file
-  double Ecal_Slab_shielding                = lcdd.constant<double>("Ecal_Slab_shielding");
-  double Ecal_fiber_thickness_structure = lcdd.constant<double>("Ecal_fiber_thickness_structure"); // absorber wrapping thickness
-  double Ecal_fiber_thickness_alveolus  = lcdd.constant<double>("Ecal_fiber_thickness_alveolus"); // alveolar wall thickness
+  double Ecal_Slab_shielding                = theDetector.constant<double>("Ecal_Slab_shielding");
+  double Ecal_fiber_thickness_structure = theDetector.constant<double>("Ecal_fiber_thickness_structure"); // absorber wrapping thickness
+  double Ecal_fiber_thickness_alveolus  = theDetector.constant<double>("Ecal_fiber_thickness_alveolus"); // alveolar wall thickness
   
-  double EcalBarrel_inner_radius                  = lcdd.constant<double>("TPC_outer_radius") +lcdd.constant<double>("Ecal_Tpc_gap");
-  int    Ecal_barrel_z_modules              = lcdd.constant<int>("Ecal_barrel_z_modules");
+  double EcalBarrel_inner_radius                  = theDetector.constant<double>("TPC_outer_radius") +theDetector.constant<double>("Ecal_Tpc_gap");
+  int    Ecal_barrel_z_modules              = theDetector.constant<int>("Ecal_barrel_z_modules");
 
-  double Ecal_radiator_thickness1           = lcdd.constant<double>("Ecal_radiator_layers_set1_thickness");
-  double Ecal_radiator_thickness2           = lcdd.constant<double>("Ecal_radiator_layers_set2_thickness");
-  double Ecal_radiator_thickness3           = lcdd.constant<double>("Ecal_radiator_layers_set3_thickness");
-  double Ecal_Barrel_halfZ                  = lcdd.constant<double>("Ecal_Barrel_halfZ");
+  double Ecal_radiator_thickness1           = theDetector.constant<double>("Ecal_radiator_layers_set1_thickness");
+  double Ecal_radiator_thickness2           = theDetector.constant<double>("Ecal_radiator_layers_set2_thickness");
+  double Ecal_radiator_thickness3           = theDetector.constant<double>("Ecal_radiator_layers_set3_thickness");
+  double Ecal_Barrel_halfZ                  = theDetector.constant<double>("Ecal_Barrel_halfZ");
 
-  int    Ecal_barrel_number_of_towers       = lcdd.constant<int>("Ecal_barrel_number_of_towers");
+  int    Ecal_barrel_number_of_towers       = theDetector.constant<int>("Ecal_barrel_number_of_towers");
   
-  double Ecal_support_thickness             = lcdd.constant<double>("Ecal_support_thickness");
-  double Ecal_front_face_thickness          = lcdd.constant<double>("Ecal_front_face_thickness");
-  double Ecal_lateral_face_thickness        = lcdd.constant<double>("Ecal_lateral_face_thickness");
-  double Ecal_Slab_H_fiber_thickness        = lcdd.constant<double>("Ecal_Slab_H_fiber_thickness");
+  double Ecal_support_thickness             = theDetector.constant<double>("Ecal_support_thickness");
+  double Ecal_front_face_thickness          = theDetector.constant<double>("Ecal_front_face_thickness");
+  double Ecal_lateral_face_thickness        = theDetector.constant<double>("Ecal_lateral_face_thickness");
+  double Ecal_Slab_H_fiber_thickness        = theDetector.constant<double>("Ecal_Slab_H_fiber_thickness");
 
-  double Ecal_endcap_extra_size             = lcdd.constant<double>("Ecal_endcap_extra_size");
-  double Ecal_cables_gap                    = lcdd.constant<double>("Ecal_cables_gap");
+  double Ecal_endcap_extra_size             = theDetector.constant<double>("Ecal_endcap_extra_size");
+  double Ecal_cables_gap                    = theDetector.constant<double>("Ecal_cables_gap");
 
-  int    Ecal_nlayers1                      = lcdd.constant<int>("Ecal_nlayers1");
-  int    Ecal_nlayers2                      = lcdd.constant<int>("Ecal_nlayers2");
-  int    Ecal_nlayers3                      = lcdd.constant<int>("Ecal_nlayers3");
+  int    Ecal_nlayers1                      = theDetector.constant<int>("Ecal_nlayers1");
+  int    Ecal_nlayers2                      = theDetector.constant<int>("Ecal_nlayers2");
+  int    Ecal_nlayers3                      = theDetector.constant<int>("Ecal_nlayers3");
 
   // first layer is preshower?
-  bool   Ecal_Endcap_PreshowerLayer         = lcdd.constant<int>("Ecal_Endcap_Preshower") > 0;
+  bool   Ecal_Endcap_PreshowerLayer         = theDetector.constant<int>("Ecal_Endcap_Preshower") > 0;
 
-  std::string Ecal_endcap_number_of_towers       = lcdd.constant<string>("Ecal_endcap_number_of_towers");
+  std::string Ecal_endcap_number_of_towers       = theDetector.constant<string>("Ecal_endcap_number_of_towers");
 
-  int Ecal_end_of_slab_strategy             = lcdd.constant<int>("Ecal_end_of_slab_strategy");
+  int Ecal_end_of_slab_strategy             = theDetector.constant<int>("Ecal_end_of_slab_strategy");
 
 
-  int    Ecal_n_wafers_per_tower            = lcdd.constant<int>("Ecal_n_wafers_per_tower");
+  int    Ecal_n_wafers_per_tower            = theDetector.constant<int>("Ecal_n_wafers_per_tower");
   
-  double Ecal_guard_ring_size               = lcdd.constant<double>("Ecal_guard_ring_size");
+  double Ecal_guard_ring_size               = theDetector.constant<double>("Ecal_guard_ring_size");
 
-  double      EcalEndcap_inner_radius          = lcdd.constant<double>("EcalEndcap_inner_radius");
-  double      EcalEndcap_outer_radius          = lcdd.constant<double>("EcalEndcap_outer_radius");
-  double      EcalEndcap_min_z                 = lcdd.constant<double>("EcalEndcap_min_z");
-  double      EcalEndcap_max_z                 = lcdd.constant<double>("EcalEndcap_max_z");
+  double      EcalEndcap_inner_radius          = theDetector.constant<double>("EcalEndcap_inner_radius");
+  double      EcalEndcap_outer_radius          = theDetector.constant<double>("EcalEndcap_outer_radius");
+  double      EcalEndcap_min_z                 = theDetector.constant<double>("EcalEndcap_min_z");
+  double      EcalEndcap_max_z                 = theDetector.constant<double>("EcalEndcap_max_z");
 
-  std::string Ecal_layerConfig              = lcdd.constant<string>("Ecal_layer_pattern");
+  std::string Ecal_layerConfig              = theDetector.constant<string>("Ecal_layer_pattern");
 
-  int Ecal_cells_across_megatile = lcdd.constant <int> ("Ecal_cells_across_megatile" );
-  int Ecal_strips_across_megatile= lcdd.constant <int> ("Ecal_strips_across_megatile");
-  int Ecal_strips_along_megatile = lcdd.constant <int> ("Ecal_strips_along_megatile" );
+  int Ecal_cells_across_megatile = theDetector.constant <int> ("Ecal_cells_across_megatile" );
+  int Ecal_strips_across_megatile= theDetector.constant <int> ("Ecal_strips_across_megatile");
+  int Ecal_strips_along_megatile = theDetector.constant <int> ("Ecal_strips_along_megatile" );
 
-  double Ecal_barrel_thickness              = lcdd.constant<double>("Ecal_barrel_thickness"); // what's assumed in the compact description
+  double Ecal_barrel_thickness              = theDetector.constant<double>("Ecal_barrel_thickness"); // what's assumed in the compact description
  
 
   //====================================================================
@@ -278,7 +298,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h element, SensitiveDetector sens) 
 				 Position( quadr - EcalEndcap_inner_radius, 
 					   quadr + EcalEndcap_inner_radius, 0 ) );
 
-  Volume EnvLogEndCap("EcalEndcapQuadrant",EndCapSolid,lcdd.material("CarbonFiber"));
+  Volume EnvLogEndCap("EcalEndcapQuadrant",EndCapSolid,theDetector.material("CarbonFiber"));
 
   // kink position wrt bottom of quadrant (inside the lateral support)
   // Y==0 is defined as outer edge of lateral face of inner module of quadrant
@@ -290,19 +310,19 @@ static Ref_t create_detector(LCDD& lcdd, xml_h element, SensitiveDetector sens) 
 			     kink_y
 			     );
   
-  helper.setTranslation ( DD4hep::Geometry::Position ( -EcalEndcap_inner_radius , EcalEndcap_inner_radius, -module_thickness/2. ) );
+  helper.setTranslation ( Position ( -EcalEndcap_inner_radius , EcalEndcap_inner_radius, -module_thickness/2. ) );
 
   // make the module
 
-  DDRec::LayeredCalorimeterData* caloData = new DDRec::LayeredCalorimeterData ;
-  caloData->layoutType = DDRec::LayeredCalorimeterData::EndcapLayout ;
+  LayeredCalorimeterData* caloData = new LayeredCalorimeterData ;
+  caloData->layoutType = LayeredCalorimeterData::EndcapLayout ;
 
   DetElement mod_det ("quad0",det_id);
 
   helper.makeModule( EnvLogEndCap, 
 		     mod_det,
 		     *caloData,
-		     lcdd, 
+		     theDetector, 
 		     sens );
 
   for (size_t i=0; i<caloData->layers.size(); i++) {
@@ -314,7 +334,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h element, SensitiveDetector sens) 
     cout << "sensitive layer " << i << " : x,y = " << caloData->layers[i].cellSize0 << " " << caloData->layers[i].cellSize1 << endl;
   }
 
-  caloData->layoutType = DDRec::LayeredCalorimeterData::EndcapLayout ;
+  caloData->layoutType = LayeredCalorimeterData::EndcapLayout ;
   caloData->inner_symmetry = 4  ; // hard code cernter box hole
   caloData->outer_symmetry = 8  ; // outer Octagun
   caloData->phi0 = 0 ;
@@ -359,7 +379,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h element, SensitiveDetector sens) 
     }
   }
   
-  sdet.addExtension< DDRec::LayeredCalorimeterData >( caloData ) ; 
+  sdet.addExtension< LayeredCalorimeterData >( caloData ) ; 
 
   //  cout << "finished SEcal05_Endcaps" << endl;
 

--- a/detector/calorimeter/SEcal05_Helpers.h
+++ b/detector/calorimeter/SEcal05_Helpers.h
@@ -21,8 +21,6 @@
 #undef NDEBUG
 #include <assert.h>
 
-using namespace DD4hep;
-
 using std::cout;
 using std::endl;
 
@@ -95,7 +93,7 @@ class SEcal05_Helpers {
 
   void setDet( xml_det_t* x_det ) {
     _x_det = x_det;
-    _layering = new Layering(*x_det);
+    _layering = new dd4hep::Layering(*x_det);
     _det_name  = x_det->nameStr();
   }
 
@@ -105,11 +103,11 @@ class SEcal05_Helpers {
     _layerConfig=layerConfig;
   }
 
-  void setSegmentation(  DD4hep::Geometry::Segmentation & seg ) {
+  void setSegmentation(  dd4hep::Segmentation & seg ) {
     _geomseg = &seg;
   }
 
-  void setSegmentation(  DD4hep::Geometry::Segmentation * seg ) {
+  void setSegmentation(  dd4hep::Segmentation * seg ) {
     _geomseg = seg;
   }
 
@@ -175,14 +173,14 @@ class SEcal05_Helpers {
 
   float getTotalThickness();
 
-  void setTranslation( DD4hep::Geometry::Position trans ) {_trans = trans;}
+  void setTranslation( dd4hep::Position trans ) {_trans = trans;}
 
   // ---- this is the main workhorse
-  void makeModule( DD4hep::Geometry::Volume & mod_vol,  // the volume we'll fill
-		   DD4hep::Geometry::DetElement & stave_det, // the detector element
-		   DDRec::LayeredCalorimeterData & caloData, // the reco data we'll fill
-		   DD4hep::Geometry::LCDD & lcdd,
-		   DD4hep::Geometry::SensitiveDetector & sens
+  void makeModule( dd4hep::Volume & mod_vol,  // the volume we'll fill
+		   dd4hep::DetElement & stave_det, // the detector element
+		   dd4hep::rec::LayeredCalorimeterData & caloData, // the reco data we'll fill
+		   dd4hep::Detector & theDetector,
+		   dd4hep::SensitiveDetector & sens
 		   );
 
   void setPlugLength( float ll ) { _plugLength = ll; }
@@ -190,7 +188,7 @@ class SEcal05_Helpers {
 
  private:
 
-  void printSEcal05LayerInfo( DDRec::LayeredCalorimeterData::Layer & caloLayer);
+  void printSEcal05LayerInfo( dd4hep::rec::LayeredCalorimeterData::Layer & caloLayer);
 
   double getAbsThickness( unsigned int iAbsLay );
 
@@ -220,7 +218,7 @@ class SEcal05_Helpers {
   };
 
   xml_det_t* _x_det;
-  Layering* _layering=NULL;
+  dd4hep::Layering* _layering=NULL;
   std::string _det_name;
 
   std::vector <dimposXYStruct> getAbsPlateXYDimensions( double ztop=-999 );
@@ -228,15 +226,15 @@ class SEcal05_Helpers {
   std::vector <dimposXYStruct> getSlabXYDimensions( double ztop=-999 );
 
 
-  DD4hep::Geometry::Position  getTranslatedPosition(double x, double y, double z) {
-    return DD4hep::Geometry::Position ( x, y, z ) + _trans;
+  dd4hep::Position  getTranslatedPosition(double x, double y, double z) {
+    return dd4hep::Position ( x, y, z ) + _trans;
   }
 
   dxinfo getNormalMagicUnitsInX( double dx_total, double dx_unit, double dx_cell, double dx_dead ,
 				 int magicStrategy );
 
   void updateCaloLayers(double thickness,
-			DD4hep::Geometry::Material mat,
+			dd4hep::Material mat,
 			bool isAbsorber,
 			bool isSensitive,
 			double cell_size_x=0, double cell_size_y=0,
@@ -244,11 +242,11 @@ class SEcal05_Helpers {
 			);
 
 
-  DD4hep::Geometry::Segmentation* _geomseg;
+  dd4hep::Segmentation* _geomseg;
 
-  DD4hep::Geometry::Material _air_material;
-  DD4hep::Geometry::Material _carbon_fibre_material;
-  DD4hep::Geometry::Material _radiator_material;
+  dd4hep::Material _air_material;
+  dd4hep::Material _carbon_fibre_material;
+  dd4hep::Material _radiator_material;
 
   unsigned int _cells_across_megatile;
   unsigned int _strips_across_megatile;
@@ -286,8 +284,8 @@ class SEcal05_Helpers {
   int    _unitsPerTower;
   double _unitDeadEdge;
 
-  DDRec::LayeredCalorimeterData* _caloData;
-  DDRec::LayeredCalorimeterData::Layer _caloLayer ; // this is the output info which is passed to reconstruction
+  dd4hep::rec::LayeredCalorimeterData* _caloData;
+  dd4hep::rec::LayeredCalorimeterData::Layer _caloLayer ; // this is the output info which is passed to reconstruction
 
   double _layer_thickness;
   double _layer_nRadiationLengths;
@@ -300,7 +298,7 @@ class SEcal05_Helpers {
 
   int _magicMegatileStrategy;
 
-  DD4hep::Geometry::Position _trans;
+  dd4hep::Position _trans;
 
   std::vector <dimposXYStruct> _constantSlabXYDimensions;
 

--- a/detector/calorimeter/SHcalSc04_EndcapRing.cpp
+++ b/detector/calorimeter/SHcalSc04_EndcapRing.cpp
@@ -42,8 +42,29 @@
 #include "DDRec/DetectorData.h"
 
 using namespace std;
-using namespace DD4hep;
-using namespace DD4hep::Geometry;
+
+using dd4hep::BUILD_ENVELOPE;
+using dd4hep::Box;
+using dd4hep::DetElement;
+using dd4hep::Detector;
+using dd4hep::IntersectionSolid;
+using dd4hep::Layering;
+using dd4hep::Material;
+using dd4hep::PlacedVolume;
+using dd4hep::PolyhedraRegular;
+using dd4hep::Position;
+using dd4hep::Readout;
+using dd4hep::Ref_t;
+using dd4hep::Rotation3D;
+using dd4hep::RotationZ;
+using dd4hep::RotationZYX;
+using dd4hep::Segmentation;
+using dd4hep::SensitiveDetector;
+using dd4hep::Transform3D;
+using dd4hep::Volume;
+using dd4hep::_toString;
+
+using dd4hep::rec::LayeredCalorimeterData;
 
 //#define VERBOSE 1
 
@@ -52,15 +73,15 @@ using namespace DD4hep::Geometry;
 #define DD4HEP_VERSION_GE(a,b) 0 
 #endif
 
-static Ref_t create_detector(LCDD& lcdd, xml_h element, SensitiveDetector sens)  {
+static Ref_t create_detector(Detector& theDetector, xml_h element, SensitiveDetector sens)  {
   //unused:  static double tolerance = 0e0;
 
   xml_det_t   x_det     = element;
   string      det_name    = x_det.nameStr();
   Layering    layering(x_det);
 
-  Material    air         = lcdd.air();
-  Material    stavesMaterial    = lcdd.material(x_det.materialStr());
+  Material    air         = theDetector.air();
+  Material    stavesMaterial    = theDetector.material(x_det.materialStr());
 
   int           det_id    = x_det.id();
   xml_comp_t    x_staves  = x_det.staves();
@@ -69,11 +90,11 @@ static Ref_t create_detector(LCDD& lcdd, xml_h element, SensitiveDetector sens) 
 
   // --- create an envelope volume and position it into the world ---------------------
   
-  Volume envelope = XML::createPlacedEnvelope( lcdd,  element , sdet ) ;
+  Volume envelope = dd4hep::xml::createPlacedEnvelope( theDetector,  element , sdet ) ;
   
-  XML::setDetectorTypeFlag( element, sdet ) ;
+  dd4hep::xml::setDetectorTypeFlag( element, sdet ) ;
 
-  if( lcdd.buildType() == BUILD_ENVELOPE ) return sdet ;
+  if( theDetector.buildType() == BUILD_ENVELOPE ) return sdet ;
 
   //-----------------------------------------------------------------------------------
 
@@ -100,21 +121,21 @@ static Ref_t create_detector(LCDD& lcdd, xml_h element, SensitiveDetector sens) 
 // Use them to build HcalEndcapRing
 //
 //====================================================================
-  // The way to read constant from XML/LCDD file.
-  double      Hcal_radiator_thickness          = lcdd.constant<double>("Hcal_radiator_thickness");
-  double      Hcal_chamber_thickness           = lcdd.constant<double>("Hcal_chamber_thickness");
-  double      Hcal_back_plate_thickness        = lcdd.constant<double>("Hcal_back_plate_thickness");
-  double      Hcal_lateral_plate_thickness     = lcdd.constant<double>("Hcal_lateral_structure_thickness");
-  double      Hcal_stave_gaps                  = lcdd.constant<double>("Hcal_stave_gaps");
+  // The way to read constant from XML/Detector file.
+  double      Hcal_radiator_thickness          = theDetector.constant<double>("Hcal_radiator_thickness");
+  double      Hcal_chamber_thickness           = theDetector.constant<double>("Hcal_chamber_thickness");
+  double      Hcal_back_plate_thickness        = theDetector.constant<double>("Hcal_back_plate_thickness");
+  double      Hcal_lateral_plate_thickness     = theDetector.constant<double>("Hcal_lateral_structure_thickness");
+  double      Hcal_stave_gaps                  = theDetector.constant<double>("Hcal_stave_gaps");
 
-  int         Hcal_nlayers                     = lcdd.constant<int>("Hcal_nlayers");
-  int         Hcal_endcap_nlayers              = lcdd.constant<int>("Hcal_endcap_nlayers");
+  int         Hcal_nlayers                     = theDetector.constant<int>("Hcal_nlayers");
+  int         Hcal_endcap_nlayers              = theDetector.constant<int>("Hcal_endcap_nlayers");
 
-  double      HcalEndcapRing_inner_radius      = lcdd.constant<double>("HcalEndcapRing_inner_radius");
-  double      HcalEndcapRing_outer_radius      = lcdd.constant<double>("HcalEndcapRing_outer_radius");
-  double      HcalEndcapRing_min_z             = lcdd.constant<double>("HcalEndcapRing_min_z");
-  double      HcalEndcapRing_max_z             = lcdd.constant<double>("HcalEndcapRing_max_z");
-  int         HcalEndcapRing_symmetry          = lcdd.constant<int>("HcalEndcapRing_symmetry");
+  double      HcalEndcapRing_inner_radius      = theDetector.constant<double>("HcalEndcapRing_inner_radius");
+  double      HcalEndcapRing_outer_radius      = theDetector.constant<double>("HcalEndcapRing_outer_radius");
+  double      HcalEndcapRing_min_z             = theDetector.constant<double>("HcalEndcapRing_min_z");
+  double      HcalEndcapRing_max_z             = theDetector.constant<double>("HcalEndcapRing_max_z");
+  int         HcalEndcapRing_symmetry          = theDetector.constant<int>("HcalEndcapRing_symmetry");
 //====================================================================
 //
 // general calculated parameters
@@ -174,8 +195,8 @@ static Ref_t create_detector(LCDD& lcdd, xml_h element, SensitiveDetector sens) 
 
 
   //========== fill data for reconstruction ============================
-  DDRec::LayeredCalorimeterData* caloData = new DDRec::LayeredCalorimeterData ;
-  caloData->layoutType = DDRec::LayeredCalorimeterData::EndcapLayout ;
+  LayeredCalorimeterData* caloData = new LayeredCalorimeterData ;
+  caloData->layoutType = LayeredCalorimeterData::EndcapLayout ;
   caloData->inner_symmetry = numSide  ;
   caloData->outer_symmetry = numSide  ;
   caloData->phi0 = 0 ; // hardcoded 
@@ -258,7 +279,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h element, SensitiveDetector sens) 
 	  
 	  Volume HcalEndCapRingStaveLogical("HcalEndCapRingStaveLogical",HcalEndCapRingStaveSolid, air);
 
-	  DDRec::LayeredCalorimeterData::Layer caloLayer ;
+	  LayeredCalorimeterData::Layer caloLayer ;
 	  caloLayer.cellSize0 = cell_sizeX;
 	  caloLayer.cellSize1 = cell_sizeY;
 
@@ -278,7 +299,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h element, SensitiveDetector sens) 
 	    xml_comp_t x_slice = k;
 	    string   slice_name      = layer_name + _toString(slice_number,"_slice%d");
 	    double   slice_thickness = x_slice.thickness();
-	    Material slice_material  = lcdd.material(x_slice.materialStr());
+	    Material slice_material  = theDetector.material(x_slice.materialStr());
 	    DetElement slice(layer_name,_toString(slice_number,"slice%d"),x_det.id());
 	    
 	    slice_pos_z -= slice_thickness/2.;
@@ -329,7 +350,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h element, SensitiveDetector sens) 
 	    thickness_sum += slice_thickness/2;
 
 	    // Set region, limitset, and vis.
-	    slice_vol.setAttributes(lcdd,x_slice.regionStr(),x_slice.limitsStr(),x_slice.visStr());
+	    slice_vol.setAttributes(theDetector,x_slice.regionStr(),x_slice.limitsStr(),x_slice.visStr());
 	    // slice PlacedVolume
 	    PlacedVolume slice_phv = HcalEndCapRingStaveLogical.placeVolume(slice_vol,Position(0.,0.,slice_pos_z));
 	    if ( x_slice.isSensitive() ) {
@@ -393,7 +414,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h element, SensitiveDetector sens) 
 
   // Set stave visualization.
   if (x_staves)   {
-    HcalEndCapRingLogical.setVisAttributes(lcdd.visAttributes(x_staves.visStr()));
+    HcalEndCapRingLogical.setVisAttributes(theDetector.visAttributes(x_staves.visStr()));
    }
   
 
@@ -422,7 +443,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h element, SensitiveDetector sens) 
 
   }
   
-  sdet.addExtension< DDRec::LayeredCalorimeterData >( caloData ) ;
+  sdet.addExtension< LayeredCalorimeterData >( caloData ) ;
 
   return sdet;
   

--- a/detector/fcal/DDLHCal.cpp
+++ b/detector/fcal/DDLHCal.cpp
@@ -5,43 +5,74 @@
 #include "DDRec/DetectorData.h"
 
 #include <string>
-using namespace DD4hep;
-using namespace DD4hep::Geometry;
 
+using dd4hep::Assembly;
+using dd4hep::BitField64;
+using dd4hep::BUILD_ENVELOPE;
+using dd4hep::Box;
+using dd4hep::Cone;
+using dd4hep::DetElement;
+using dd4hep::Detector;
+using dd4hep::DetType;
+using dd4hep::IntersectionSolid;
+using dd4hep::Layering;
+using dd4hep::Layer;
+using dd4hep::Material;
+using dd4hep::PlacedVolume;
+using dd4hep::PolyhedraRegular;
+using dd4hep::Position;
+using dd4hep::Readout;
+using dd4hep::Ref_t;
+using dd4hep::Rotation3D;
+using dd4hep::RotationY;
+using dd4hep::RotationZYX;
+using dd4hep::SensitiveDetector;
+using dd4hep::SubtractionSolid;
+using dd4hep::Transform3D;
+using dd4hep::Translation3D;
+using dd4hep::Trapezoid;
+using dd4hep::Tube;
+using dd4hep::Volume;
+using dd4hep::_toString;
+using dd4hep::UnionSolid;
+using dd4hep::IntersectionSolid;
+using dd4hep::Segmentation;
 
-static DD4hep::Geometry::Ref_t create_detector(DD4hep::Geometry::LCDD& lcdd,
-					       xml_h element,
-					       DD4hep::Geometry::SensitiveDetector sens) {
+using dd4hep::rec::LayeredCalorimeterData;
+
+static Ref_t create_detector(Detector& theDetector,
+                             xml_h element,
+                             SensitiveDetector sens) {
 
   std::cout << __PRETTY_FUNCTION__  << std::endl;
   std::cout << "Here is my LHCal"  << std::endl;
   std::cout << " and this is the sensitive detector: " << &sens  << std::endl;
   sens.setType("calorimeter");
   //Materials
-  DD4hep::Geometry::Material air = lcdd.air();
+  Material air = theDetector.air();
 
   //Access to the XML File
-  // DD4hep::XML::DetElement xmlLHCal = xmlHandle;
+  // dd4hep::xml::DetElement xmlLHCal = xmlHandle;
   // const std::string detName = xmlLHCal.nameStr();
 
   xml_det_t     xmlLHCal     = element;
   std::string   detName  = xmlLHCal.nameStr();
 
 
-  DD4hep::Geometry::DetElement sdet ( detName,  xmlLHCal.id() );
+  DetElement sdet ( detName,  xmlLHCal.id() );
 
 
   // --- create an envelope volume and position it into the world ---------------------
   
-  DD4hep::Geometry::Volume envelope = DD4hep::XML::createPlacedEnvelope( lcdd,  element , sdet ) ;
+  Volume envelope = dd4hep::xml::createPlacedEnvelope( theDetector,  element , sdet ) ;
   
   sdet.setTypeFlag( DetType::CALORIMETER |  DetType::ENDCAP  | DetType::HADRONIC |  DetType::FORWARD ) ;
 
-  if( lcdd.buildType() == DD4hep::BUILD_ENVELOPE ) return sdet ;
+  if( theDetector.buildType() == BUILD_ENVELOPE ) return sdet ;
   
   //-----------------------------------------------------------------------------------
 
-  DD4hep::XML::Dimension dimensions =  xmlLHCal.dimensions();
+  dd4hep::xml::Dimension dimensions =  xmlLHCal.dimensions();
 
   //LHCal Dimensions
   const double lhcalInnerR = dimensions.inner_r();
@@ -49,14 +80,14 @@ static DD4hep::Geometry::Ref_t create_detector(DD4hep::Geometry::LCDD& lcdd,
   const double lhcalheight = dimensions.height();
   const double lhcalInnerZ = dimensions.inner_z();
   const double lhcaloffset = dimensions.offset();
-  const double lhcalThickness = DD4hep::Layering(xmlLHCal).totalThickness();
+  const double lhcalThickness = Layering(xmlLHCal).totalThickness();
   const double lhcalCentreZ = lhcalInnerZ+lhcalThickness*0.5;
 
-  double LHcal_cell_size      = lcdd.constant<double>("LHcal_cell_size");
-  double LHCal_outer_radius   = lcdd.constant<double>("LHCal_outer_radius");
+  double LHcal_cell_size      = theDetector.constant<double>("LHcal_cell_size");
+  double LHCal_outer_radius   = theDetector.constant<double>("LHCal_outer_radius");
   //========== fill data for reconstruction ============================
-  DD4hep::DDRec::LayeredCalorimeterData* caloData = new DD4hep::DDRec::LayeredCalorimeterData ;
-  caloData->layoutType = DD4hep::DDRec::LayeredCalorimeterData::EndcapLayout ;
+  LayeredCalorimeterData* caloData = new LayeredCalorimeterData ;
+  caloData->layoutType = LayeredCalorimeterData::EndcapLayout ;
   caloData->inner_symmetry = 0  ; // hard code cernter pipe hole
   caloData->outer_symmetry = 4  ; // outer box
   caloData->phi0 = 0 ;
@@ -71,24 +102,24 @@ static DD4hep::Geometry::Ref_t create_detector(DD4hep::Geometry::LCDD& lcdd,
   int thisLayerId = 1;
 
   //Parameters we have to know about
-  DD4hep::XML::Component xmlParameter = xmlLHCal.child(_Unicode(parameter));
+  dd4hep::xml::Component xmlParameter = xmlLHCal.child(_Unicode(parameter));
   const double mradFullCrossingAngle  = xmlParameter.attr< double >(_Unicode(crossingangle));
   std::cout << " The crossing angle is: " << mradFullCrossingAngle << " radian"  << std::endl;
 
   // this needs the full crossing angle, because the beamCal is centred on the
   // outgoing beampipe, and the incoming beampipe is a full crossing agle away
-  const DD4hep::Geometry::Position    incomingBeamPipePosition( -1.0*lhcaloffset, 0.0, 0.0);
+  const Position    incomingBeamPipePosition( -1.0*lhcaloffset, 0.0, 0.0);
   //The extra parenthesis are paramount!
-  const DD4hep::Geometry::Rotation3D  incomingBeamPipeRotation( ( DD4hep::Geometry::RotationY( 0 ) ) );
-  const DD4hep::Geometry::Transform3D incomingBPTransform( incomingBeamPipeRotation, incomingBeamPipePosition );
+  const Rotation3D  incomingBeamPipeRotation( ( RotationY( 0 ) ) );
+  const Transform3D incomingBPTransform( incomingBeamPipeRotation, incomingBeamPipePosition );
 
   //Envelope to place the layers in
-  DD4hep::Geometry::Box envelopeBox (lhcalwidth*0.5, lhcalheight*0.5, lhcalThickness*0.5 );
-  DD4hep::Geometry::Tube incomingBeamPipe (0.0, lhcalInnerR, lhcalThickness);//we want this to be longer than the LHCal
+  Box envelopeBox (lhcalwidth*0.5, lhcalheight*0.5, lhcalThickness*0.5 );
+  Tube incomingBeamPipe (0.0, lhcalInnerR, lhcalThickness);//we want this to be longer than the LHCal
 
-  DD4hep::Geometry::SubtractionSolid LHCalModule (envelopeBox, incomingBeamPipe, incomingBPTransform);
-  DD4hep::Geometry::Volume     envelopeVol(detName+"_module",LHCalModule,air);
-  envelopeVol.setVisAttributes(lcdd,xmlLHCal.visStr());
+  SubtractionSolid LHCalModule (envelopeBox, incomingBeamPipe, incomingBPTransform);
+  Volume     envelopeVol(detName+"_module",LHCalModule,air);
+  envelopeVol.setVisAttributes(theDetector,xmlLHCal.visStr());
 
 
   ////////////////////////////////////////////////////////////////////////////////
@@ -98,15 +129,15 @@ static DD4hep::Geometry::Ref_t create_detector(DD4hep::Geometry::LCDD& lcdd,
   //Loop over all the layer (repeat=NN) sections
   //This is the starting point to place all layers, we need this when we have more than one layer block
   double referencePosition = -lhcalThickness*0.5;
-  for(DD4hep::XML::Collection_t coll(xmlLHCal,_U(layer)); coll; ++coll)  {
-    DD4hep::XML::Component xmlLayer(coll); //we know this thing is a layer
+  for(dd4hep::xml::Collection_t coll(xmlLHCal,_U(layer)); coll; ++coll)  {
+    dd4hep::xml::Component xmlLayer(coll); //we know this thing is a layer
 
 
     //This just calculates the total size of a single layer
     //Why no convenience function for this?
     double layerThickness = 0;
 
-    for(DD4hep::XML::Collection_t l(xmlLayer,_U(slice)); l; ++l)
+    for(dd4hep::xml::Collection_t l(xmlLayer,_U(slice)); l; ++l)
       layerThickness += xml_comp_t(l).thickness();
 
     std::cout << "Total Length "    << lhcalThickness/dd4hep::cm  << " cm" << std::endl;
@@ -115,13 +146,13 @@ static DD4hep::Geometry::Ref_t create_detector(DD4hep::Geometry::LCDD& lcdd,
     //Loop for repeat=NN
     for(int i=0, repeat=xmlLayer.repeat(); i<repeat; ++i)  {
 
-      std::string layer_name = detName + DD4hep::XML::_toString(thisLayerId,"_layer%d");
-      DD4hep::Geometry::Box layer_base(lhcalwidth*0.5, lhcalheight*0.5,layerThickness*0.5);
-      DD4hep::Geometry::SubtractionSolid layer_subtracted;
-      layer_subtracted = DD4hep::Geometry::SubtractionSolid(layer_base, incomingBeamPipe, incomingBPTransform);
+      std::string layer_name = detName + dd4hep::xml::_toString(thisLayerId,"_layer%d");
+      Box layer_base(lhcalwidth*0.5, lhcalheight*0.5,layerThickness*0.5);
+      SubtractionSolid layer_subtracted;
+      layer_subtracted = SubtractionSolid(layer_base, incomingBeamPipe, incomingBPTransform);
      
 
-      DD4hep::Geometry::Volume layer_vol(layer_name,layer_subtracted,air);
+      Volume layer_vol(layer_name,layer_subtracted,air);
 
 
       int sliceID=1;
@@ -129,7 +160,7 @@ static DD4hep::Geometry::Ref_t create_detector(DD4hep::Geometry::LCDD& lcdd,
 
       double radiator_thickness = 0.0;
 
-      DD4hep::DDRec::LayeredCalorimeterData::Layer caloLayer ;
+      LayeredCalorimeterData::Layer caloLayer ;
       caloLayer.cellSize0 = LHcal_cell_size ;
       caloLayer.cellSize1 = LHcal_cell_size ;
 
@@ -137,18 +168,18 @@ static DD4hep::Geometry::Ref_t create_detector(DD4hep::Geometry::LCDD& lcdd,
       double nInteractionLengths=0.;
       double thickness_sum=0;
 
-      for(DD4hep::XML::Collection_t collSlice(xmlLayer,_U(slice)); collSlice; ++collSlice)  {
-	DD4hep::XML::Component compSlice = collSlice;
+      for(dd4hep::xml::Collection_t collSlice(xmlLayer,_U(slice)); collSlice; ++collSlice)  {
+	dd4hep::xml::Component compSlice = collSlice;
 	const double      sliceThickness = compSlice.thickness();
-	const std::string sliceName = layer_name + DD4hep::XML::_toString(sliceID,"slice%d");
-	DD4hep::Geometry::Material   slice_mat  = lcdd.material(compSlice.materialStr());
+	const std::string sliceName = layer_name + dd4hep::xml::_toString(sliceID,"slice%d");
+	Material   slice_mat  = theDetector.material(compSlice.materialStr());
 
-	DD4hep::Geometry::Box sliceBase(lhcalwidth*0.5, lhcalheight*0.5,sliceThickness*0.5);
-	DD4hep::Geometry::SubtractionSolid slice_subtracted;
+	Box sliceBase(lhcalwidth*0.5, lhcalheight*0.5,sliceThickness*0.5);
+	SubtractionSolid slice_subtracted;
 
-	slice_subtracted = DD4hep::Geometry::SubtractionSolid(sliceBase, incomingBeamPipe, incomingBPTransform);
+	slice_subtracted = SubtractionSolid(sliceBase, incomingBeamPipe, incomingBPTransform);
 
-	DD4hep::Geometry::Volume slice_vol (sliceName,slice_subtracted,slice_mat);
+	Volume slice_vol (sliceName,slice_subtracted,slice_mat);
 
 	if ( compSlice.materialStr().compare("TungstenDens24") == 0 ) radiator_thickness = sliceThickness;
 
@@ -177,8 +208,8 @@ static DD4hep::Geometry::Ref_t create_detector(DD4hep::Geometry::LCDD& lcdd,
 	nInteractionLengths += sliceThickness/(2.*slice_mat.intLength());
 	thickness_sum       += sliceThickness/2.;
 
-	slice_vol.setAttributes(lcdd,compSlice.regionStr(),compSlice.limitsStr(),compSlice.visStr());
-	DD4hep::Geometry::PlacedVolume pv = layer_vol.placeVolume(slice_vol, DD4hep::Geometry::Position(0,0,inThisLayerPosition+sliceThickness*0.5));
+	slice_vol.setAttributes(theDetector,compSlice.regionStr(),compSlice.limitsStr(),compSlice.visStr());
+	PlacedVolume pv = layer_vol.placeVolume(slice_vol, Position(0,0,inThisLayerPosition+sliceThickness*0.5));
 
 	pv.addPhysVolID("slice",sliceID);
 	inThisLayerPosition += sliceThickness;
@@ -202,11 +233,11 @@ static DD4hep::Geometry::Ref_t create_detector(DD4hep::Geometry::LCDD& lcdd,
 
       //Why are we doing this for each layer, this just needs to be done once and then placed multiple times
       //Do we need unique IDs for each piece?
-      layer_vol.setVisAttributes(lcdd,xmlLayer.visStr());
+      layer_vol.setVisAttributes(theDetector,xmlLayer.visStr());
 
-      DD4hep::Geometry::Position layer_pos(0,0,referencePosition+0.5*layerThickness);
+      Position layer_pos(0,0,referencePosition+0.5*layerThickness);
       referencePosition += layerThickness;
-      DD4hep::Geometry::PlacedVolume pv = envelopeVol.placeVolume(layer_vol,layer_pos);
+      PlacedVolume pv = envelopeVol.placeVolume(layer_vol,layer_pos);
       pv.addPhysVolID("layer",thisLayerId);
 
       ++thisLayerId;
@@ -216,20 +247,20 @@ static DD4hep::Geometry::Ref_t create_detector(DD4hep::Geometry::LCDD& lcdd,
   }// for all layer collections
 
  
-  const DD4hep::Geometry::Position bcForwardPos (lhcaloffset,0.0, lhcalCentreZ);
-  const DD4hep::Geometry::Position bcBackwardPos(-1.0*lhcaloffset,0.0,-lhcalCentreZ);
-  const DD4hep::Geometry::Rotation3D bcForwardRot ( DD4hep::Geometry::RotationY( 0 ) );
-  const DD4hep::Geometry::Rotation3D bcBackwardRot( DD4hep::Geometry::RotationY( M_PI )  );
+  const Position bcForwardPos (lhcaloffset,0.0, lhcalCentreZ);
+  const Position bcBackwardPos(-1.0*lhcaloffset,0.0,-lhcalCentreZ);
+  const Rotation3D bcForwardRot ( RotationY( 0 ) );
+  const Rotation3D bcBackwardRot( RotationY( M_PI )  );
 
-  DD4hep::Geometry::PlacedVolume pv =
-    envelope.placeVolume(envelopeVol, DD4hep::Geometry::Transform3D( bcForwardRot, bcForwardPos ) );
+  PlacedVolume pv =
+    envelope.placeVolume(envelopeVol, Transform3D( bcForwardRot, bcForwardPos ) );
   pv.addPhysVolID("barrel", 1);
 
-  DD4hep::Geometry::PlacedVolume pv2 =
-    envelope.placeVolume(envelopeVol, DD4hep::Geometry::Transform3D( bcBackwardRot, bcBackwardPos ) );
+  PlacedVolume pv2 =
+    envelope.placeVolume(envelopeVol, Transform3D( bcBackwardRot, bcBackwardPos ) );
   pv2.addPhysVolID("barrel", 2);
 
-  sdet.addExtension< DD4hep::DDRec::LayeredCalorimeterData >( caloData ) ;
+  sdet.addExtension< LayeredCalorimeterData >( caloData ) ;
 
   return sdet;
 }

--- a/detector/fcal/LHCal_v01_geo.cpp
+++ b/detector/fcal/LHCal_v01_geo.cpp
@@ -5,13 +5,44 @@
 #include "DDRec/DetectorData.h"
 
 #include <string>
-using namespace DD4hep;
-using namespace DD4hep::Geometry;
 
+using dd4hep::Assembly;
+using dd4hep::BitField64;
+using dd4hep::BUILD_ENVELOPE;
+using dd4hep::Box;
+using dd4hep::Cone;
+using dd4hep::DetElement;
+using dd4hep::Detector;
+using dd4hep::DetType;
+using dd4hep::IntersectionSolid;
+using dd4hep::Layering;
+using dd4hep::Layer;
+using dd4hep::Material;
+using dd4hep::PlacedVolume;
+using dd4hep::PolyhedraRegular;
+using dd4hep::Position;
+using dd4hep::Readout;
+using dd4hep::Ref_t;
+using dd4hep::Rotation3D;
+using dd4hep::RotationY;
+using dd4hep::RotationZYX;
+using dd4hep::SensitiveDetector;
+using dd4hep::SubtractionSolid;
+using dd4hep::Transform3D;
+using dd4hep::Translation3D;
+using dd4hep::Trapezoid;
+using dd4hep::Tube;
+using dd4hep::Volume;
+using dd4hep::_toString;
+using dd4hep::UnionSolid;
+using dd4hep::IntersectionSolid;
+using dd4hep::Segmentation;
 
-static DD4hep::Geometry::Ref_t create_detector(DD4hep::Geometry::LCDD& lcdd,
-					       xml_h element,
-					       DD4hep::Geometry::SensitiveDetector sens) {
+using dd4hep::rec::LayeredCalorimeterData;
+
+static Ref_t create_detector(Detector& theDetector,
+                             xml_h element,
+                             SensitiveDetector sens) {
 
   std::cout << __PRETTY_FUNCTION__  << std::endl;
   std::cout << "Here is my LHCal_v01"  << std::endl;
@@ -19,46 +50,46 @@ static DD4hep::Geometry::Ref_t create_detector(DD4hep::Geometry::LCDD& lcdd,
   //std::cout << " and this is the sensitive detector: " << &sens  << std::endl;
   sens.setType("calorimeter");
   //Materials
-  DD4hep::Geometry::Material air = lcdd.air();
+  Material air = theDetector.air();
 
   //Access to the XML File
   xml_det_t     xmlLHCal     = element;
   std::string   detName  = xmlLHCal.nameStr();
 
 
-  DD4hep::Geometry::DetElement sdet ( detName,  xmlLHCal.id() );
+  DetElement sdet ( detName,  xmlLHCal.id() );
 
 
   // --- create an envelope volume and position it into the world ---------------------
   
-  DD4hep::Geometry::Volume envelope = DD4hep::XML::createPlacedEnvelope( lcdd,  element , sdet ) ;
+  Volume envelope = dd4hep::xml::createPlacedEnvelope( theDetector,  element , sdet ) ;
   
   sdet.setTypeFlag( DetType::CALORIMETER |  DetType::ENDCAP  | DetType::HADRONIC |  DetType::FORWARD ) ;
 
-  if( lcdd.buildType() == DD4hep::BUILD_ENVELOPE ) return sdet ;
+  if( theDetector.buildType() == BUILD_ENVELOPE ) return sdet ;
   
   //-----------------------------------------------------------------------------------
   //Parameters we have to know about
-  DD4hep::XML::Component xmlParameter = xmlLHCal.child(_Unicode(parameter));
+  dd4hep::xml::Component xmlParameter = xmlLHCal.child(_Unicode(parameter));
   const double mradFullCrossingAngle  = xmlParameter.attr< double >(_Unicode(crossingangle));
  
-  DD4hep::XML::Dimension dimensions =  xmlLHCal.dimensions();
+  dd4hep::xml::Dimension dimensions =  xmlLHCal.dimensions();
 
   //LHCal Dimensions
   const double lhcalInnerR = dimensions.inner_r();
   const double lhcalwidth = dimensions.width();
   const double lhcalheight = dimensions.height();
   const double lhcalInnerZ = dimensions.inner_z();
-  const double lhcalThickness = DD4hep::Layering(xmlLHCal).totalThickness();
+  const double lhcalThickness = Layering(xmlLHCal).totalThickness();
   const double lhcalCentreZ = lhcalInnerZ+lhcalThickness*0.5;
   //  const double lhcaloffset = dimensions.offset();
   const double lhcaloffset = std::tan( mradFullCrossingAngle/2. )*lhcalCentreZ;
 
-  double LHcal_cell_size      = lcdd.constant<double>("LHcal_cell_size");
-  double LHCal_outer_radius   = lcdd.constant<double>("LHCal_outer_radius");
+  double LHcal_cell_size      = theDetector.constant<double>("LHcal_cell_size");
+  double LHCal_outer_radius   = theDetector.constant<double>("LHCal_outer_radius");
   //========== fill data for reconstruction ============================
-  DD4hep::DDRec::LayeredCalorimeterData* caloData = new DD4hep::DDRec::LayeredCalorimeterData ;
-  caloData->layoutType = DD4hep::DDRec::LayeredCalorimeterData::EndcapLayout ;
+  LayeredCalorimeterData* caloData = new LayeredCalorimeterData ;
+  caloData->layoutType = LayeredCalorimeterData::EndcapLayout ;
   caloData->inner_symmetry = 8  ; // hard code octagonal inner cutout
   caloData->outer_symmetry = 4  ; // outer box
   caloData->phi0 = 0 ;
@@ -81,18 +112,18 @@ static DD4hep::Geometry::Ref_t create_detector(DD4hep::Geometry::LCDD& lcdd,
   int thisLayerId = 1;
 
   //Envelope to place the layers in
-  DD4hep::Geometry::Box envelopeBox (lhcalwidth*0.5, lhcalheight*0.5, lhcalThickness*0.5 );
+  Box envelopeBox (lhcalwidth*0.5, lhcalheight*0.5, lhcalThickness*0.5 );
 
   // octagon to make inner bore in LHcal
   int nSides = 8;
   double phiStart = 22.5*dd4hep::deg;
   double rMax = lhcalInnerR/std::cos( phiStart );
-  const DD4hep::Geometry::Position   innerBorePosition( lhcaloffset, 0.0, 0.0);
-  DD4hep::Geometry::PolyhedraRegular innerBore( nSides, phiStart, 0., rMax, lhcalThickness ); 
-  DD4hep::Geometry::SubtractionSolid LHCalModule (envelopeBox, innerBore, innerBorePosition);
+  const Position   innerBorePosition( lhcaloffset, 0.0, 0.0);
+  PolyhedraRegular innerBore( nSides, phiStart, 0., rMax, lhcalThickness ); 
+  SubtractionSolid LHCalModule (envelopeBox, innerBore, innerBorePosition);
   
-  DD4hep::Geometry::Volume     envelopeVol(detName+"_module",LHCalModule,air);
-  envelopeVol.setVisAttributes(lcdd,xmlLHCal.visStr());
+  Volume     envelopeVol(detName+"_module",LHCalModule,air);
+  envelopeVol.setVisAttributes(theDetector,xmlLHCal.visStr());
 
 
   ////////////////////////////////////////////////////////////////////////////////
@@ -104,26 +135,26 @@ static DD4hep::Geometry::Ref_t create_detector(DD4hep::Geometry::LCDD& lcdd,
   double referencePosition = -lhcalThickness*0.5;
   double totalThickness = 0.;
   double totalInteractionLength = 0.;
-  for(DD4hep::XML::Collection_t coll(xmlLHCal,_U(layer)); coll; ++coll)  {
-    DD4hep::XML::Component xmlLayer(coll); //we know this thing is a layer
+  for(dd4hep::xml::Collection_t coll(xmlLHCal,_U(layer)); coll; ++coll)  {
+    dd4hep::xml::Component xmlLayer(coll); //we know this thing is a layer
 
 
     //This just calculates the total size of a single layer
     double layerThickness = 0.;
-    for(DD4hep::XML::Collection_t l(xmlLayer,_U(slice)); l; ++l) layerThickness += xml_comp_t(l).thickness();
+    for(dd4hep::xml::Collection_t l(xmlLayer,_U(slice)); l; ++l) layerThickness += xml_comp_t(l).thickness();
  
     std::cout << " - Layer Thickness " << layerThickness/dd4hep::mm << " mm" << std::endl;
 
     //Loop for repeat=NN
     for(int i=0, repeat=xmlLayer.repeat(); i<repeat; ++i)  {
 
-      std::string layer_name = detName + DD4hep::XML::_toString(thisLayerId,"_layer%d");
-      DD4hep::Geometry::Box layer_base(lhcalwidth*0.5, lhcalheight*0.5,layerThickness*0.5);
-      DD4hep::Geometry::SubtractionSolid layer_subtracted;
-      layer_subtracted = DD4hep::Geometry::SubtractionSolid(layer_base, innerBore, innerBorePosition );
+      std::string layer_name = detName + dd4hep::xml::_toString(thisLayerId,"_layer%d");
+      Box layer_base(lhcalwidth*0.5, lhcalheight*0.5,layerThickness*0.5);
+      SubtractionSolid layer_subtracted;
+      layer_subtracted = SubtractionSolid(layer_base, innerBore, innerBorePosition );
      
 
-      DD4hep::Geometry::Volume layer_vol(layer_name,layer_subtracted,air);
+      Volume layer_vol(layer_name,layer_subtracted,air);
 
 
       int sliceID=1;
@@ -131,7 +162,7 @@ static DD4hep::Geometry::Ref_t create_detector(DD4hep::Geometry::LCDD& lcdd,
 
       double radiator_thickness = 0.0;
 
-      DD4hep::DDRec::LayeredCalorimeterData::Layer caloLayer ;
+      LayeredCalorimeterData::Layer caloLayer ;
       caloLayer.cellSize0 = LHcal_cell_size ;
       caloLayer.cellSize1 = LHcal_cell_size ;
 
@@ -139,18 +170,18 @@ static DD4hep::Geometry::Ref_t create_detector(DD4hep::Geometry::LCDD& lcdd,
       double nInteractionLengths=0.;
       double thickness_sum=0;
 
-      for(DD4hep::XML::Collection_t collSlice(xmlLayer,_U(slice)); collSlice; ++collSlice)  {
-	DD4hep::XML::Component compSlice = collSlice;
+      for(dd4hep::xml::Collection_t collSlice(xmlLayer,_U(slice)); collSlice; ++collSlice)  {
+	dd4hep::xml::Component compSlice = collSlice;
 	const double      sliceThickness = compSlice.thickness();
-	const std::string sliceName = layer_name + DD4hep::XML::_toString(sliceID,"slice%d");
-	DD4hep::Geometry::Material   slice_mat  = lcdd.material(compSlice.materialStr());
+	const std::string sliceName = layer_name + dd4hep::xml::_toString(sliceID,"slice%d");
+	Material   slice_mat  = theDetector.material(compSlice.materialStr());
 
-	DD4hep::Geometry::Box sliceBase(lhcalwidth*0.5, lhcalheight*0.5,sliceThickness*0.5);
-	DD4hep::Geometry::SubtractionSolid slice_subtracted;
+	Box sliceBase(lhcalwidth*0.5, lhcalheight*0.5,sliceThickness*0.5);
+	SubtractionSolid slice_subtracted;
 
-	slice_subtracted = DD4hep::Geometry::SubtractionSolid(sliceBase, innerBore, innerBorePosition );
+	slice_subtracted = SubtractionSolid(sliceBase, innerBore, innerBorePosition );
 
-	DD4hep::Geometry::Volume slice_vol (sliceName,slice_subtracted,slice_mat);
+	Volume slice_vol (sliceName,slice_subtracted,slice_mat);
 
 	if ( compSlice.materialStr().compare("TungstenDens24") == 0 ) radiator_thickness = sliceThickness;
 
@@ -181,8 +212,8 @@ static DD4hep::Geometry::Ref_t create_detector(DD4hep::Geometry::LCDD& lcdd,
 	nInteractionLengths += sliceThickness/(2.*slice_mat.intLength());
 	thickness_sum       += sliceThickness/2.;
 
-	slice_vol.setAttributes(lcdd,compSlice.regionStr(),compSlice.limitsStr(),compSlice.visStr());
-	DD4hep::Geometry::PlacedVolume pv = layer_vol.placeVolume(slice_vol, DD4hep::Geometry::Position(0,0,inThisLayerPosition+sliceThickness*0.5));
+	slice_vol.setAttributes(theDetector,compSlice.regionStr(),compSlice.limitsStr(),compSlice.visStr());
+	PlacedVolume pv = layer_vol.placeVolume(slice_vol, Position(0,0,inThisLayerPosition+sliceThickness*0.5));
 
 	pv.addPhysVolID("slice",sliceID);
 	inThisLayerPosition += sliceThickness;
@@ -206,11 +237,11 @@ static DD4hep::Geometry::Ref_t create_detector(DD4hep::Geometry::LCDD& lcdd,
       caloData->layers.push_back( caloLayer ) ;
       //-----------------------------------------------------------------------------------------
 
-      layer_vol.setVisAttributes(lcdd,xmlLayer.visStr());
+      layer_vol.setVisAttributes(theDetector,xmlLayer.visStr());
 
-      DD4hep::Geometry::Position layer_pos(0,0,referencePosition+0.5*layerThickness);
+      Position layer_pos(0,0,referencePosition+0.5*layerThickness);
       referencePosition += layerThickness;
-      DD4hep::Geometry::PlacedVolume pv = envelopeVol.placeVolume(layer_vol,layer_pos);
+      PlacedVolume pv = envelopeVol.placeVolume(layer_vol,layer_pos);
       pv.addPhysVolID("layer",thisLayerId);
 
       ++thisLayerId;
@@ -223,20 +254,20 @@ static DD4hep::Geometry::Ref_t create_detector(DD4hep::Geometry::LCDD& lcdd,
      std::cout << " - Total Interacion Length: "    << totalInteractionLength  << std::endl;
      std::cout << " --------------------------------------------------------------------------" << std::endl;
 
-  const DD4hep::Geometry::Position bcForwardPos ( 0.0, 0.0, lhcalCentreZ );
-  const DD4hep::Geometry::Position bcBackwardPos( 0.0, 0.0,-lhcalCentreZ );
-  const DD4hep::Geometry::RotationY bcForwardRot ( 0. );
-  const DD4hep::Geometry::RotationZYX bcBackwardRot( M_PI, M_PI, 0.0 );
+  const Position bcForwardPos ( 0.0, 0.0, lhcalCentreZ );
+  const Position bcBackwardPos( 0.0, 0.0,-lhcalCentreZ );
+  const RotationY bcForwardRot ( 0. );
+  const RotationZYX bcBackwardRot( M_PI, M_PI, 0.0 );
 
-  DD4hep::Geometry::PlacedVolume pv =
-    envelope.placeVolume(envelopeVol, DD4hep::Geometry::Transform3D( bcForwardRot, bcForwardPos ) );
+  PlacedVolume pv =
+    envelope.placeVolume(envelopeVol, Transform3D( bcForwardRot, bcForwardPos ) );
   pv.addPhysVolID("barrel", 1);
 
-  DD4hep::Geometry::PlacedVolume pv2 =
-    envelope.placeVolume(envelopeVol, DD4hep::Geometry::Transform3D( bcBackwardRot, bcBackwardPos ) );
+  PlacedVolume pv2 =
+    envelope.placeVolume(envelopeVol, Transform3D( bcBackwardRot, bcBackwardPos ) );
   pv2.addPhysVolID("barrel", 2);
 
-  sdet.addExtension< DD4hep::DDRec::LayeredCalorimeterData >( caloData ) ;
+  sdet.addExtension< LayeredCalorimeterData >( caloData ) ;
 
   return sdet;
 }

--- a/detector/fcal/LumiCal_o1_v01_geo.cpp
+++ b/detector/fcal/LumiCal_o1_v01_geo.cpp
@@ -6,56 +6,87 @@
 
 #include <string>
 
-using namespace DD4hep;
-using namespace DD4hep::Geometry;
+using dd4hep::Assembly;
+using dd4hep::BitField64;
+using dd4hep::BUILD_ENVELOPE;
+using dd4hep::Box;
+using dd4hep::Cone;
+using dd4hep::DetElement;
+using dd4hep::Detector;
+using dd4hep::DetType;
+using dd4hep::IntersectionSolid;
+using dd4hep::Layering;
+using dd4hep::Layer;
+using dd4hep::Material;
+using dd4hep::PlacedVolume;
+using dd4hep::PolyhedraRegular;
+using dd4hep::Position;
+using dd4hep::Readout;
+using dd4hep::Ref_t;
+using dd4hep::Rotation3D;
+using dd4hep::RotationY;
+using dd4hep::RotationZYX;
+using dd4hep::SensitiveDetector;
+using dd4hep::SubtractionSolid;
+using dd4hep::Transform3D;
+using dd4hep::Translation3D;
+using dd4hep::Trapezoid;
+using dd4hep::Tube;
+using dd4hep::Volume;
+using dd4hep::_toString;
+using dd4hep::UnionSolid;
+using dd4hep::IntersectionSolid;
+using dd4hep::Segmentation;
+
+using dd4hep::rec::LayeredCalorimeterData;
 
 // workaround for DD4hep v00-14 (and older) 
 #ifndef DD4HEP_VERSION_GE
 #define DD4HEP_VERSION_GE(a,b) 0 
 #endif
 
-static DD4hep::Geometry::Ref_t create_detector(DD4hep::Geometry::LCDD& lcdd,
-                                               xml_h element,
-                                               DD4hep::Geometry::SensitiveDetector sens) {
+static Ref_t create_detector(Detector& theDetector,
+                             xml_h element,
+                             SensitiveDetector sens) {
     
     std::cout << __PRETTY_FUNCTION__  << std::endl;
     std::cout << "Here is my LumiCal"  << std::endl;
     std::cout << " and this is the sensitive detector: " << &sens  << std::endl;
     sens.setType("calorimeter");
     //Materials
-    DD4hep::Geometry::Material air = lcdd.air();
+    Material air = theDetector.air();
     
     //Access to the XML File
     xml_det_t     xmlLumiCal    = element;
     const std::string detName   = xmlLumiCal.nameStr();
     
-    DD4hep::Geometry::DetElement sdet ( detName, xmlLumiCal.id() );
+    DetElement sdet ( detName, xmlLumiCal.id() );
     
     // --- create an envelope volume and position it into the world ---------------------
     
-    DD4hep::Geometry::Volume envelope = DD4hep::XML::createPlacedEnvelope( lcdd, element , sdet ) ;
-    DD4hep::Geometry::DetElement lumiCalDE_1(sdet,"Calorimeter1",1);
-    DD4hep::Geometry::DetElement lumiCalDE_2(sdet,"Calorimeter2",2);
+    Volume envelope = dd4hep::xml::createPlacedEnvelope( theDetector, element , sdet ) ;
+    DetElement lumiCalDE_1(sdet,"Calorimeter1",1);
+    DetElement lumiCalDE_2(sdet,"Calorimeter2",2);
 
     sdet.setTypeFlag( DetType::CALORIMETER |  DetType::ENDCAP  | DetType::ELECTROMAGNETIC |  DetType::FORWARD ) ;
 
-    if( lcdd.buildType() == DD4hep::BUILD_ENVELOPE ) return sdet ;
+    if( theDetector.buildType() == BUILD_ENVELOPE ) return sdet ;
     
     //-----------------------------------------------------------------------------------
     
-    DD4hep::XML::Dimension dimensions =  xmlLumiCal.dimensions();
+    dd4hep::xml::Dimension dimensions =  xmlLumiCal.dimensions();
     
     //LumiCal Dimensions
     const double lcalInnerR = dimensions.inner_r();
     const double lcalOuterR = dimensions.outer_r();
     const double lcalInnerZ = dimensions.inner_z();
-    const double lcalThickness = DD4hep::Layering(xmlLumiCal).totalThickness();
+    const double lcalThickness = Layering(xmlLumiCal).totalThickness();
     const double lcalCentreZ = lcalInnerZ+lcalThickness*0.5;
     
-    double LumiCal_cell_size      = lcdd.constant<double>("LumiCal_cell_size");
+    double LumiCal_cell_size      = theDetector.constant<double>("LumiCal_cell_size");
     //========== fill data for reconstruction ============================
-    DD4hep::DDRec::LayeredCalorimeterData* caloData = new DD4hep::DDRec::LayeredCalorimeterData ;
-    caloData->layoutType = DD4hep::DDRec::LayeredCalorimeterData::EndcapLayout ;
+    LayeredCalorimeterData* caloData = new LayeredCalorimeterData ;
+    caloData->layoutType = LayeredCalorimeterData::EndcapLayout ;
     caloData->inner_symmetry = 0  ; // hardcoded tube
     caloData->outer_symmetry = 0  ; 
     caloData->phi0 = 0 ;
@@ -70,15 +101,15 @@ static DD4hep::Geometry::Ref_t create_detector(DD4hep::Geometry::LCDD& lcdd,
     int thisLayerId = 0;
     
     //Parameters we have to know about
-    DD4hep::XML::Component xmlParameter = xmlLumiCal.child(_Unicode(parameter));
+    dd4hep::xml::Component xmlParameter = xmlLumiCal.child(_Unicode(parameter));
     const double fullCrossingAngle  = xmlParameter.attr< double >(_Unicode(crossingangle));
     std::cout << " The crossing angle is: " << fullCrossingAngle << " radian"  << std::endl;
     
     
     //Envelope to place the layers in
-    DD4hep::Geometry::Tube envelopeTube (lcalInnerR, lcalOuterR, lcalThickness*0.5 );
-    DD4hep::Geometry::Volume     envelopeVol(detName+"_module",envelopeTube,air);
-    envelopeVol.setVisAttributes(lcdd,xmlLumiCal.visStr());
+    Tube envelopeTube (lcalInnerR, lcalOuterR, lcalThickness*0.5 );
+    Volume     envelopeVol(detName+"_module",envelopeTube,air);
+    envelopeVol.setVisAttributes(theDetector,xmlLumiCal.visStr());
     
     ////////////////////////////////////////////////////////////////////////////////
     // Create all the layers
@@ -87,14 +118,14 @@ static DD4hep::Geometry::Ref_t create_detector(DD4hep::Geometry::LCDD& lcdd,
     //Loop over all the layer (repeat=NN) sections
     //This is the starting point to place all layers, we need this when we have more than one layer block
     double referencePosition = -lcalThickness*0.5;
-    for(DD4hep::XML::Collection_t coll(xmlLumiCal,_U(layer)); coll; ++coll)  {
-        DD4hep::XML::Component xmlLayer(coll); //we know this thing is a layer
+    for(dd4hep::xml::Collection_t coll(xmlLumiCal,_U(layer)); coll; ++coll)  {
+        dd4hep::xml::Component xmlLayer(coll); //we know this thing is a layer
         
         
         //This just calculates the total size of a single layer
         //Why no convenience function for this?
         double layerThickness = 0;
-        for(DD4hep::XML::Collection_t l(xmlLayer,_U(slice)); l; ++l)
+        for(dd4hep::xml::Collection_t l(xmlLayer,_U(slice)); l; ++l)
             layerThickness += xml_comp_t(l).thickness();
         
         std::cout << "Total Length "    << lcalThickness/dd4hep::cm  << " cm" << std::endl;
@@ -103,10 +134,10 @@ static DD4hep::Geometry::Ref_t create_detector(DD4hep::Geometry::LCDD& lcdd,
         //Loop for repeat=NN
         for(int i=0, repeat=xmlLayer.repeat(); i<repeat; ++i)  {
             
-            std::string layer_name = detName + DD4hep::XML::_toString(thisLayerId,"_layer%d");
-            DD4hep::Geometry::Tube layer_base(lcalInnerR,lcalOuterR,layerThickness*0.5);
+            std::string layer_name = detName + dd4hep::xml::_toString(thisLayerId,"_layer%d");
+            Tube layer_base(lcalInnerR,lcalOuterR,layerThickness*0.5);
             
-            DD4hep::Geometry::Volume layer_vol(layer_name,layer_base,air);
+            Volume layer_vol(layer_name,layer_base,air);
             
             
             int sliceID=0;
@@ -116,17 +147,17 @@ static DD4hep::Geometry::Ref_t create_detector(DD4hep::Geometry::LCDD& lcdd,
             double nInteractionLengths=0.;
             double thickness_sum=0;
             
-            DD4hep::DDRec::LayeredCalorimeterData::Layer caloLayer ;
+            LayeredCalorimeterData::Layer caloLayer ;
             
-            for(DD4hep::XML::Collection_t collSlice(xmlLayer,_U(slice)); collSlice; ++collSlice)  {
-                DD4hep::XML::Component compSlice = collSlice;
+            for(dd4hep::xml::Collection_t collSlice(xmlLayer,_U(slice)); collSlice; ++collSlice)  {
+                dd4hep::xml::Component compSlice = collSlice;
                 const double      slice_thickness = compSlice.thickness();
-                const std::string sliceName = layer_name + DD4hep::XML::_toString(sliceID,"slice%d");
-                DD4hep::Geometry::Material   slice_material  = lcdd.material(compSlice.materialStr());
+                const std::string sliceName = layer_name + dd4hep::xml::_toString(sliceID,"slice%d");
+                Material   slice_material  = theDetector.material(compSlice.materialStr());
                 
-                DD4hep::Geometry::Tube sliceBase(lcalInnerR,lcalOuterR,slice_thickness/2);
+                Tube sliceBase(lcalInnerR,lcalOuterR,slice_thickness/2);
                 
-                DD4hep::Geometry::Volume slice_vol (sliceName,sliceBase,slice_material);
+                Volume slice_vol (sliceName,sliceBase,slice_material);
                 
                 nRadiationLengths += slice_thickness/(2.*slice_material.radLength());
                 nInteractionLengths += slice_thickness/(2.*slice_material.intLength());
@@ -153,8 +184,8 @@ static DD4hep::Geometry::Ref_t create_detector(DD4hep::Geometry::LCDD& lcdd,
                 nInteractionLengths += slice_thickness/(2.*slice_material.intLength());
                 thickness_sum += slice_thickness/2;
                 
-                slice_vol.setAttributes(lcdd,compSlice.regionStr(),compSlice.limitsStr(),compSlice.visStr());
-                layer_vol.placeVolume(slice_vol,DD4hep::Geometry::Position(0,0,inThisLayerPosition+slice_thickness*0.5));
+                slice_vol.setAttributes(theDetector,compSlice.regionStr(),compSlice.limitsStr(),compSlice.visStr());
+                layer_vol.placeVolume(slice_vol,Position(0,0,inThisLayerPosition+slice_thickness*0.5));
                     
                 inThisLayerPosition += slice_thickness;
                 ++sliceID;
@@ -179,11 +210,11 @@ static DD4hep::Geometry::Ref_t create_detector(DD4hep::Geometry::LCDD& lcdd,
             
             //Why are we doing this for each layer, this just needs to be done once and then placed multiple times
             //Do we need unique IDs for each piece?
-            layer_vol.setVisAttributes(lcdd,xmlLayer.visStr());
+            layer_vol.setVisAttributes(theDetector,xmlLayer.visStr());
             
-            DD4hep::Geometry::Position layer_pos(0,0,referencePosition+0.5*layerThickness);
+            Position layer_pos(0,0,referencePosition+0.5*layerThickness);
             referencePosition += layerThickness;
-            DD4hep::Geometry::PlacedVolume pv = envelopeVol.placeVolume(layer_vol,layer_pos);
+            PlacedVolume pv = envelopeVol.placeVolume(layer_vol,layer_pos);
             pv.addPhysVolID("layer",thisLayerId);
             
             ++thisLayerId;
@@ -192,22 +223,22 @@ static DD4hep::Geometry::Ref_t create_detector(DD4hep::Geometry::LCDD& lcdd,
         
     }// for all layer collections
     
-    const DD4hep::Geometry::Position bcForwardPos (std::tan(0.5*fullCrossingAngle)*lcalCentreZ,0.0, lcalCentreZ);
-    const DD4hep::Geometry::Position bcBackwardPos(std::tan(0.5*fullCrossingAngle)*lcalCentreZ,0.0,-lcalCentreZ);
-    const DD4hep::Geometry::Rotation3D bcForwardRot ( DD4hep::Geometry::RotationY(fullCrossingAngle*0.5 ) );
-    const DD4hep::Geometry::Rotation3D bcBackwardRot( DD4hep::Geometry::RotationZYX ( (M_PI), (M_PI-fullCrossingAngle*0.5), (0.0)));
+    const Position bcForwardPos (std::tan(0.5*fullCrossingAngle)*lcalCentreZ,0.0, lcalCentreZ);
+    const Position bcBackwardPos(std::tan(0.5*fullCrossingAngle)*lcalCentreZ,0.0,-lcalCentreZ);
+    const Rotation3D bcForwardRot ( RotationY(fullCrossingAngle*0.5 ) );
+    const Rotation3D bcBackwardRot( RotationZYX ( (M_PI), (M_PI-fullCrossingAngle*0.5), (0.0)));
     
-    DD4hep::Geometry::PlacedVolume pv =
-    envelope.placeVolume(envelopeVol, DD4hep::Geometry::Transform3D( bcForwardRot, bcForwardPos ) );
+    PlacedVolume pv =
+    envelope.placeVolume(envelopeVol, Transform3D( bcForwardRot, bcForwardPos ) );
     pv.addPhysVolID("barrel", 1);
     lumiCalDE_1.setPlacement(pv);
 
-    DD4hep::Geometry::PlacedVolume pv2 =
-    envelope.placeVolume(envelopeVol, DD4hep::Geometry::Transform3D( bcBackwardRot, bcBackwardPos ) );
+    PlacedVolume pv2 =
+    envelope.placeVolume(envelopeVol, Transform3D( bcBackwardRot, bcBackwardPos ) );
     pv2.addPhysVolID("barrel", 2);
     lumiCalDE_2.setPlacement(pv2);
     
-    sdet.addExtension< DD4hep::DDRec::LayeredCalorimeterData >( caloData ) ;
+    sdet.addExtension< LayeredCalorimeterData >( caloData ) ;
     
     return sdet;
 }

--- a/detector/fcal/LumiCal_o1_v02_geo.cpp
+++ b/detector/fcal/LumiCal_o1_v02_geo.cpp
@@ -3,36 +3,65 @@
 
 #include <string>
 
-using namespace DD4hep;
-using namespace DD4hep::Geometry;
+using dd4hep::Assembly;
+using dd4hep::BitField64;
+using dd4hep::BUILD_ENVELOPE;
+using dd4hep::Box;
+using dd4hep::Cone;
+using dd4hep::DetElement;
+using dd4hep::Detector;
+using dd4hep::IntersectionSolid;
+using dd4hep::Layering;
+using dd4hep::Layer;
+using dd4hep::Material;
+using dd4hep::PlacedVolume;
+using dd4hep::PolyhedraRegular;
+using dd4hep::Position;
+using dd4hep::Readout;
+using dd4hep::Ref_t;
+using dd4hep::Rotation3D;
+using dd4hep::RotationY;
+using dd4hep::RotationZ;
+using dd4hep::RotationZYX;
+using dd4hep::SensitiveDetector;
+using dd4hep::SubtractionSolid;
+using dd4hep::Transform3D;
+using dd4hep::Translation3D;
+using dd4hep::Trapezoid;
+using dd4hep::Tube;
+using dd4hep::Volume;
+using dd4hep::_toString;
+using dd4hep::UnionSolid;
+using dd4hep::IntersectionSolid;
+using dd4hep::Segmentation;
 
 
-static DD4hep::Geometry::Ref_t create_detector(DD4hep::Geometry::LCDD& lcdd,
-					        xml_h element,
-					       DD4hep::Geometry::SensitiveDetector sens) {
+static Ref_t create_detector(Detector& theDetector,
+                             xml_h element,
+                             SensitiveDetector sens) {
 
   std::cout << __PRETTY_FUNCTION__  << std::endl;
   std::cout << "Here is my LumiCal"  << std::endl;
   std::cout << " and this is the sensitive detector: " << &sens  << std::endl;
   sens.setType("calorimeter");
   //Materials
-  DD4hep::Geometry::Material air = lcdd.air();
+  Material air = theDetector.air();
 
   //Access to the XML File
   xml_det_t     xmlLumiCal    = element;
   const std::string detName = xmlLumiCal.nameStr();
 
  //--------------------------------
-  DD4hep::Geometry::Assembly assembly( detName + "_assembly"  ) ;
+  Assembly assembly( detName + "_assembly"  ) ;
   //--------------------------------
 
-  DD4hep::XML::Dimension dimensions =  xmlLumiCal.dimensions();
+  dd4hep::xml::Dimension dimensions =  xmlLumiCal.dimensions();
 
   //LumiCal Dimensions
   const double lcalInnerR = dimensions.inner_r();
   const double lcalOuterR = dimensions.outer_r();
   // const double lcalInnerZ = dimensions.inner_z();
-  const double lcalThickness = DD4hep::Layering(xmlLumiCal).totalThickness();
+  const double lcalThickness = Layering(xmlLumiCal).totalThickness();
   // const double lcalCentreZ = lcalInnerZ+lcalThickness*0.5;
   const double BoltR = 4.*dd4hep::mm ; 
   const double BoltEarThickenss = 2.*dd4hep::mm ; 
@@ -45,34 +74,34 @@ static DD4hep::Geometry::Ref_t create_detector(DD4hep::Geometry::LCDD& lcdd,
   // int thisLayerId = 1;
 
   //Parameters we have to know about
-  DD4hep::XML::Component xmlParameter = xmlLumiCal.child(_Unicode(parameter));
+  dd4hep::xml::Component xmlParameter = xmlLumiCal.child(_Unicode(parameter));
   const double mradFullCrossingAngle  = xmlParameter.attr< double >(_Unicode(crossingangle));
   std::cout << " The crossing angle is: " << mradFullCrossingAngle << " radian"  << std::endl;
 
 
   //Envelope to place the layers in
-//  DD4hep::Geometry::Tube envelopeTube (lcalInnerR, 2*lcalOuterR, lcalThickness*0.5 );
-DD4hep::Geometry::Box envelopeTube (5*dd4hep::m, 5*dd4hep::m, 5*dd4hep::m );
-  DD4hep::Geometry::Volume     envelopeVol(detName+"_envelope",envelopeTube,air);
-  envelopeVol.setVisAttributes(lcdd,xmlLumiCal.visStr());
+//  Tube envelopeTube (lcalInnerR, 2*lcalOuterR, lcalThickness*0.5 );
+Box envelopeTube (5*dd4hep::m, 5*dd4hep::m, 5*dd4hep::m );
+  Volume     envelopeVol(detName+"_envelope",envelopeTube,air);
+  envelopeVol.setVisAttributes(theDetector,xmlLumiCal.visStr());
 
 
   //Start building the support structures 
-  DD4hep::Geometry::Tube BoltTube(0, BoltR, lcalThickness*0.5 );
-  DD4hep::Geometry::Volume BoltVol (detName+"_Bolt",BoltTube,air);
-  BoltVol.setVisAttributes(lcdd,"BCLayerVis1");
+  Tube BoltTube(0, BoltR, lcalThickness*0.5 );
+  Volume BoltVol (detName+"_Bolt",BoltTube,air);
+  BoltVol.setVisAttributes(theDetector,"BCLayerVis1");
 
-  DD4hep::Geometry::Tube BoltEarTube1(0, 2*(BoltR+BoltEarThickenss), lcalThickness*0.5 );
-  DD4hep::Geometry::Tube BoltEarTube2(0, lcalInnerR, lcalThickness*0.5*1.1,-1.0*M_PI/(double)NSectors, M_PI/(double)NSectors );
+  Tube BoltEarTube1(0, 2*(BoltR+BoltEarThickenss), lcalThickness*0.5 );
+  Tube BoltEarTube2(0, lcalInnerR, lcalThickness*0.5*1.1,-1.0*M_PI/(double)NSectors, M_PI/(double)NSectors );
 
-  DD4hep::Geometry::Position BoltTransform (-1.0*lcalInnerR, 0.0, 0.0);
-  DD4hep::Geometry::SubtractionSolid BoltEarShape (BoltEarTube1, BoltEarTube2, BoltTransform);
+  Position BoltTransform (-1.0*lcalInnerR, 0.0, 0.0);
+  SubtractionSolid BoltEarShape (BoltEarTube1, BoltEarTube2, BoltTransform);
 
-  DD4hep::Geometry::Volume BoltEarVol (detName+"_BoltEar",BoltEarShape,air);
-  BoltEarVol.setVisAttributes(lcdd,"BCLayerVis3");
+  Volume BoltEarVol (detName+"_BoltEar",BoltEarShape,air);
+  BoltEarVol.setVisAttributes(theDetector,"BCLayerVis3");
 
-  // DD4hep::Geometry::PlacedVolume pvt =
-    BoltEarVol.placeVolume(BoltVol,DD4hep::Geometry::Position(BoltR+BoltEarThickenss, 0.0, 0.0));
+  // PlacedVolume pvt =
+    BoltEarVol.placeVolume(BoltVol,Position(BoltR+BoltEarThickenss, 0.0, 0.0));
 
 
 
@@ -81,11 +110,11 @@ DD4hep::Geometry::Box envelopeTube (5*dd4hep::m, 5*dd4hep::m, 5*dd4hep::m );
    
 	for ( int ie=0 ; ie < NSectors; ie++ ){
 		
-  		const DD4hep::Geometry::Position EarPos (lcalOuterR * cos (suppAng),-1.0*lcalOuterR * sin (suppAng),0);
-  		const DD4hep::Geometry::RotationZ EarRot( -1.0*suppAng ) ;
+  		const Position EarPos (lcalOuterR * cos (suppAng),-1.0*lcalOuterR * sin (suppAng),0);
+  		const RotationZ EarRot( -1.0*suppAng ) ;
 		if(ie!=0 && ie!=5 && ie!=6 && ie!=11)	// this line is terrible it has to be corrected	
-		// DD4hep::Geometry::PlacedVolume pvear5 =
-		  envelopeVol.placeVolume(BoltEarVol, DD4hep::Geometry::Transform3D( EarRot, EarPos ) );
+		// PlacedVolume pvear5 =
+		  envelopeVol.placeVolume(BoltEarVol, Transform3D( EarRot, EarPos ) );
 
 		suppAng += dPhi;
 
@@ -107,69 +136,69 @@ DD4hep::Geometry::Box envelopeTube (5*dd4hep::m, 5*dd4hep::m, 5*dd4hep::m );
       double FEChip_hdz  = 0.25 *dd4hep::mm;
       double FECool_hdz  = 1.00 *dd4hep::mm;
 
-      DD4hep::Geometry::Tube FEMothSolid (lcalOuterR, lcalOuterR+lcalExtra, lcalThickness, FE_phi0, FE_dphi);
-      DD4hep::Geometry::Tube FEBoardSolid (lcalOuterR, lcalOuterR+lcalExtra, FE_hth, FE_phi0, FE_dphi);
-      DD4hep::Geometry::Tube FECoolSolid (lcalOuterR, lcalOuterR+lcalExtra, FECool_hdz, FE_phi0, FE_dphi);
-      DD4hep::Geometry::Tube FESectorSolid (lcalOuterR, lcalOuterR+lcalExtra, FEChip_hdz, FE_phi0, FE_Sec_dphi);
-      DD4hep::Geometry::Tube ChipMothSolid (lcalOuterR, lcalOuterR+lcalExtra, FEChip_hdz, FE_phi0, FE_dphi);
+      Tube FEMothSolid (lcalOuterR, lcalOuterR+lcalExtra, lcalThickness, FE_phi0, FE_dphi);
+      Tube FEBoardSolid (lcalOuterR, lcalOuterR+lcalExtra, FE_hth, FE_phi0, FE_dphi);
+      Tube FECoolSolid (lcalOuterR, lcalOuterR+lcalExtra, FECool_hdz, FE_phi0, FE_dphi);
+      Tube FESectorSolid (lcalOuterR, lcalOuterR+lcalExtra, FEChip_hdz, FE_phi0, FE_Sec_dphi);
+      Tube ChipMothSolid (lcalOuterR, lcalOuterR+lcalExtra, FEChip_hdz, FE_phi0, FE_dphi);
     // FE chips
-      DD4hep::Geometry::Box ChipSolid(FEChip_hx, FEChip_hy, FEChip_hdz);
+      Box ChipSolid(FEChip_hx, FEChip_hy, FEChip_hdz);
 
 std::cout<<lcalOuterR<<"\t"<<lcalOuterR+lcalExtra<<"\t"<<FEChip_hdz<<"\t"<<FE_phi0<<"\t"<<FE_Sec_dphi<<std::endl;
 
  // FE chips
-      DD4hep::Geometry::Volume FEMothLog  ("FEMotherLog", FEMothSolid, air ); 
-      DD4hep::Geometry::Volume FECoolLog  ("FECoolLog", FECoolSolid, air ); //Alu);
-      DD4hep::Geometry::Volume FEBoardLog ("FEBoardLog",  FEBoardSolid, air ); //fanele2);
-      DD4hep::Geometry::Volume ChipMothLog ("ChipMothLog", ChipMothSolid, air ); //silicon,);
-      DD4hep::Geometry::Volume FESectorLog ("FESectorLog",  FESectorSolid, air ); 
-      DD4hep::Geometry::Volume FEChipLog ("FEChipLog", ChipSolid, air ); //silicon );
+      Volume FEMothLog  ("FEMotherLog", FEMothSolid, air ); 
+      Volume FECoolLog  ("FECoolLog", FECoolSolid, air ); //Alu);
+      Volume FEBoardLog ("FEBoardLog",  FEBoardSolid, air ); //fanele2);
+      Volume ChipMothLog ("ChipMothLog", ChipMothSolid, air ); //silicon,);
+      Volume FESectorLog ("FESectorLog",  FESectorSolid, air ); 
+      Volume FEChipLog ("FEChipLog", ChipSolid, air ); //silicon );
 
       double xCh = lcalOuterR+lcalExtra/2.;
 
-  	const DD4hep::Geometry::Position FE1Pos (xCh * cos (FE_phi0 + FE_Sec_dphi/2),-1.0*xCh * sin (FE_phi0 + FE_Sec_dphi/2),0);
-  	const DD4hep::Geometry::RotationZ FE1Rot( FE_phi0 + FE_Sec_dphi/2 ) ;
+  	const Position FE1Pos (xCh * cos (FE_phi0 + FE_Sec_dphi/2),-1.0*xCh * sin (FE_phi0 + FE_Sec_dphi/2),0);
+  	const RotationZ FE1Rot( FE_phi0 + FE_Sec_dphi/2 ) ;
 
 
-  FEChipLog.setVisAttributes(lcdd,"BCLayerVis1");
-  FESectorLog.setVisAttributes(lcdd,"BCLayerVis3");
+  FEChipLog.setVisAttributes(theDetector,"BCLayerVis1");
+  FESectorLog.setVisAttributes(theDetector,"BCLayerVis3");
 
-    // DD4hep::Geometry::PlacedVolume pvear6 =
-      FESectorLog.placeVolume(FEChipLog, DD4hep::Geometry::Transform3D( FE1Rot, FE1Pos ) );
-    // DD4hep::Geometry::PlacedVolume pvear7 =
+    // PlacedVolume pvear6 =
+      FESectorLog.placeVolume(FEChipLog, Transform3D( FE1Rot, FE1Pos ) );
+    // PlacedVolume pvear7 =
       envelopeVol.placeVolume(FESectorLog);
 
 
         double zpos = lcalThickness - FECool_hdz;
-        // DD4hep::Geometry::PlacedVolume pvear8 =
-	  FEMothLog.placeVolume(FECoolLog, DD4hep::Geometry::Position( 0,0,zpos) );
+        // PlacedVolume pvear8 =
+	  FEMothLog.placeVolume(FECoolLog, Position( 0,0,zpos) );
   //      new G4PVPlacement ( 0, G4ThreeVector(0.,0.,zpos), FECoolLog, "LCalFECooling", FEMothLog, false, 1);
 	// PCB
 	zpos -= (FECool_hdz + FE_hth);
-        // DD4hep::Geometry::PlacedVolume pvear9 =
-	  FEMothLog.placeVolume(FEBoardLog, DD4hep::Geometry::Position( 0,0,zpos) );
+        // PlacedVolume pvear9 =
+	  FEMothLog.placeVolume(FEBoardLog, Position( 0,0,zpos) );
         //new G4PVPlacement ( 0, G4ThreeVector(0.,0.,zpos), FEBoardLog, "LCalFEBoard", FEMothLog, false, 1);
 	// chips
 	zpos -= (FE_hth + FEChip_hdz);
         //new G4PVPlacement ( 0, G4ThreeVector(0.,0.,zpos), ChipMothLog, "LCalFEchip", FEMothLog, false, 1);
-        // DD4hep::Geometry::PlacedVolume pvear10 =
-	  FEMothLog.placeVolume(ChipMothLog, DD4hep::Geometry::Position( 0,0,zpos) );
+        // PlacedVolume pvear10 =
+	  FEMothLog.placeVolume(ChipMothLog, Position( 0,0,zpos) );
 
 	// everything in support layer
         zpos = -0.1*dd4hep::mm/2.;
         double phi_rot = 0.; 
 
         for ( int k=0; k< NBolts ; k++ ){
-  		const DD4hep::Geometry::Position SubPos1 (zpos * cos (phi_rot),-1.0*zpos * sin (phi_rot),0);
-  		const DD4hep::Geometry::RotationZ SubRot1( phi_rot ) ;
+  		const Position SubPos1 (zpos * cos (phi_rot),-1.0*zpos * sin (phi_rot),0);
+  		const RotationZ SubRot1( phi_rot ) ;
 
-  		const DD4hep::Geometry::Position SubPos2 (zpos * cos (phi_rot+M_PI),-1.0*zpos * sin (phi_rot+M_PI),0);
-  		const DD4hep::Geometry::RotationZ SubRot2( phi_rot+M_PI ) ;
+  		const Position SubPos2 (zpos * cos (phi_rot+M_PI),-1.0*zpos * sin (phi_rot+M_PI),0);
+  		const RotationZ SubRot2( phi_rot+M_PI ) ;
 
-        // DD4hep::Geometry::PlacedVolume pvear11 =
-	  envelopeVol.placeVolume(FEMothLog, DD4hep::Geometry::Transform3D( SubRot1, SubPos1 ) );
-        // DD4hep::Geometry::PlacedVolume pvear12 =
-	  envelopeVol.placeVolume(FEMothLog, DD4hep::Geometry::Transform3D( SubRot2, SubPos2 ) );
+        // PlacedVolume pvear11 =
+	  envelopeVol.placeVolume(FEMothLog, Transform3D( SubRot1, SubPos1 ) );
+        // PlacedVolume pvear12 =
+	  envelopeVol.placeVolume(FEMothLog, Transform3D( SubRot2, SubPos2 ) );
         	phi_rot += dPhi;
 	}
 
@@ -178,12 +207,12 @@ std::cout<<lcalOuterR<<"\t"<<lcalOuterR+lcalExtra<<"\t"<<FEChip_hdz<<"\t"<<FE_ph
      //
 
 
-  //DD4hep::Geometry::PlacedVolume pv = assembly.placeVolume(envelopeVol, DD4hep::Geometry::Transform3D( bcForwardRot2, bcForwardPos2 ) );
+  //PlacedVolume pv = assembly.placeVolume(envelopeVol, Transform3D( bcForwardRot2, bcForwardPos2 ) );
 
 /*
 
-  DD4hep::Geometry::Volume BoltEarVol2 (detName+"_BoltEar2",BoltEarTube1,air);
-  BoltEarVol2.setVisAttributes(lcdd,"BCLayerVis1");
+  Volume BoltEarVol2 (detName+"_BoltEar2",BoltEarTube1,air);
+  BoltEarVol2.setVisAttributes(theDetector,"BCLayerVis1");
 
 
 
@@ -194,14 +223,14 @@ std::cout<<lcalOuterR<<"\t"<<lcalOuterR+lcalExtra<<"\t"<<FEChip_hdz<<"\t"<<FE_ph
   //Loop over all the layer (repeat=NN) sections
   //This is the starting point to place all layers, we need this when we have more than one layer block
   double referencePosition = -lcalThickness*0.5;
-  for(DD4hep::XML::Collection_t coll(xmlLumiCal,_U(layer)); coll; ++coll)  {
-    DD4hep::XML::Component xmlLayer(coll); //we know this thing is a layer
+  for(dd4hep::xml::Collection_t coll(xmlLumiCal,_U(layer)); coll; ++coll)  {
+    dd4hep::xml::Component xmlLayer(coll); //we know this thing is a layer
 
 
     //This just calculates the total size of a single layer
     //Why no convenience function for this?
     double layerThickness = 0;
-    for(DD4hep::XML::Collection_t l(xmlLayer,_U(slice)); l; ++l)
+    for(dd4hep::xml::Collection_t l(xmlLayer,_U(slice)); l; ++l)
       layerThickness += xml_comp_t(l).thickness();
 
     std::cout << "Total Length "    << lcalThickness/dd4hep::cm  << " cm" << std::endl;
@@ -210,31 +239,31 @@ std::cout<<lcalOuterR<<"\t"<<lcalOuterR+lcalExtra<<"\t"<<FEChip_hdz<<"\t"<<FE_ph
     //Loop for repeat=NN
     for(int i=0, repeat=xmlLayer.repeat(); i<repeat; ++i)  {
 
-      std::string layer_name = detName + DD4hep::XML::_toString(thisLayerId,"_layer%d");
-      DD4hep::Geometry::Tube layer_base(lcalInnerR,lcalOuterR,layerThickness*0.5);
+      std::string layer_name = detName + dd4hep::xml::_toString(thisLayerId,"_layer%d");
+      Tube layer_base(lcalInnerR,lcalOuterR,layerThickness*0.5);
       
-      DD4hep::Geometry::Volume layer_vol(layer_name,layer_base,air);
+      Volume layer_vol(layer_name,layer_base,air);
 
 
       int sliceID=1;
       double inThisLayerPosition = -layerThickness*0.5;
-      for(DD4hep::XML::Collection_t collSlice(xmlLayer,_U(slice)); collSlice; ++collSlice)  {
-	DD4hep::XML::Component compSlice = collSlice;
+      for(dd4hep::xml::Collection_t collSlice(xmlLayer,_U(slice)); collSlice; ++collSlice)  {
+	dd4hep::xml::Component compSlice = collSlice;
 	const double      sliceThickness = compSlice.thickness();
-	const std::string sliceName = layer_name + DD4hep::XML::_toString(sliceID,"slice%d");
-	DD4hep::Geometry::Material   slice_mat  = lcdd.material(compSlice.materialStr());
+	const std::string sliceName = layer_name + dd4hep::xml::_toString(sliceID,"slice%d");
+	Material   slice_mat  = theDetector.material(compSlice.materialStr());
 
-	DD4hep::Geometry::Tube sliceBase(lcalInnerR,lcalOuterR,sliceThickness/2);
+	Tube sliceBase(lcalInnerR,lcalOuterR,sliceThickness/2);
 
-	DD4hep::Geometry::Volume slice_vol (sliceName,sliceBase,slice_mat);
+	Volume slice_vol (sliceName,sliceBase,slice_mat);
 
 	if ( compSlice.isSensitive() )  {
 	  slice_vol.setSensitiveDetector(sens);
 	}
 
-	slice_vol.setAttributes(lcdd,compSlice.regionStr(),compSlice.limitsStr(),compSlice.visStr());
-	DD4hep::Geometry::PlacedVolume pv = layer_vol.placeVolume(slice_vol,
-								  DD4hep::Geometry::Position(0,0,inThisLayerPosition+sliceThickness*0.5));
+	slice_vol.setAttributes(theDetector,compSlice.regionStr(),compSlice.limitsStr(),compSlice.visStr());
+	PlacedVolume pv = layer_vol.placeVolume(slice_vol,
+								  Position(0,0,inThisLayerPosition+sliceThickness*0.5));
 	pv.addPhysVolID("slice",sliceID);
 	inThisLayerPosition += sliceThickness;
 	++sliceID;
@@ -242,11 +271,11 @@ std::cout<<lcalOuterR<<"\t"<<lcalOuterR+lcalExtra<<"\t"<<FEChip_hdz<<"\t"<<FE_ph
 
       //Why are we doing this for each layer, this just needs to be done once and then placed multiple times
       //Do we need unique IDs for each piece?
-      layer_vol.setVisAttributes(lcdd,xmlLayer.visStr());
+      layer_vol.setVisAttributes(theDetector,xmlLayer.visStr());
 
-      DD4hep::Geometry::Position layer_pos(0,0,referencePosition+0.5*layerThickness);
+      Position layer_pos(0,0,referencePosition+0.5*layerThickness);
       referencePosition += layerThickness;
-      DD4hep::Geometry::PlacedVolume pv = envelopeVol.placeVolume(layer_vol,layer_pos);
+      PlacedVolume pv = envelopeVol.placeVolume(layer_vol,layer_pos);
       pv.addPhysVolID("layer",thisLayerId);
 
       ++thisLayerId;
@@ -256,24 +285,24 @@ std::cout<<lcalOuterR<<"\t"<<lcalOuterR+lcalExtra<<"\t"<<FEChip_hdz<<"\t"<<FE_ph
   }// for all layer collections
 */
 
-  const DD4hep::Geometry::Position bcForwardPos (0,0,0);
-  const DD4hep::Geometry::Position bcBackwardPos(0,0,0);
-  const DD4hep::Geometry::Rotation3D bcForwardRot ( DD4hep::Geometry::RotationY(0 ) );
-  const DD4hep::Geometry::Rotation3D bcBackwardRot ( DD4hep::Geometry::RotationY(0 ) );
+  const Position bcForwardPos (0,0,0);
+  const Position bcBackwardPos(0,0,0);
+  const Rotation3D bcForwardRot ( RotationY(0 ) );
+  const Rotation3D bcBackwardRot ( RotationY(0 ) );
 
-  DD4hep::Geometry::DetElement LumiCals ( detName, xmlLumiCal.id() );
-  DD4hep::Geometry::DetElement sdet ( "LumiCal01", xmlLumiCal.id() );
-  DD4hep::Geometry::DetElement rdet ( "LumiCal02", xmlLumiCal.id() );
+  DetElement LumiCals ( detName, xmlLumiCal.id() );
+  DetElement sdet ( "LumiCal01", xmlLumiCal.id() );
+  DetElement rdet ( "LumiCal02", xmlLumiCal.id() );
 
-  DD4hep::Geometry::Volume motherVol = lcdd.pickMotherVolume(sdet);
+  Volume motherVol = theDetector.pickMotherVolume(sdet);
 
-  DD4hep::Geometry::PlacedVolume pv = assembly.placeVolume(envelopeVol, DD4hep::Geometry::Transform3D( bcForwardRot, bcForwardPos ) );
+  PlacedVolume pv = assembly.placeVolume(envelopeVol, Transform3D( bcForwardRot, bcForwardPos ) );
   pv.addPhysVolID("system",xmlLumiCal.id());
   pv.addPhysVolID("barrel", 1);
   sdet.setPlacement(pv);
 /*
-  DD4hep::Geometry::PlacedVolume pv2 =
-    assembly.placeVolume(BoltEarVol, DD4hep::Geometry::Transform3D( bcBackwardRot, bcBackwardPos ) );
+  PlacedVolume pv2 =
+    assembly.placeVolume(BoltEarVol, Transform3D( bcBackwardRot, bcBackwardPos ) );
   pv2.addPhysVolID("system",xmlLumiCal.id());
   pv2.addPhysVolID("barrel", 2);
   rdet.setPlacement(pv2);

--- a/detector/include/FieldMapBrBz.h
+++ b/detector/include/FieldMapBrBz.h
@@ -6,7 +6,7 @@
 #include <string>
 #include <vector>
 
-class FieldMapBrBz: public DD4hep::Geometry::CartesianField::Object {
+class FieldMapBrBz: public dd4hep::CartesianField::Object {
 public:
 
   struct FieldValues_t {

--- a/detector/include/FieldMapXYZ.h
+++ b/detector/include/FieldMapXYZ.h
@@ -6,7 +6,7 @@
 #include <string>
 #include <vector>
 
-class FieldMapXYZ: public DD4hep::Geometry::CartesianField::Object {
+class FieldMapXYZ: public dd4hep::CartesianField::Object {
 public:
 
   struct FieldValues_t {

--- a/detector/include/XMLHandlerDB.h
+++ b/detector/include/XMLHandlerDB.h
@@ -10,11 +10,11 @@ namespace {
     /** C'tor initializes the handle */
   XMLHandlerDB(xml_comp_t det) : x_det(det) {}
   
-    double fetchDouble( const char* _name){ return  x_det.attr<double>( DD4hep::XML::Strng_t(_name) )  ; }
+    double fetchDouble( const char* _name){ return  x_det.attr<double>( dd4hep::xml::Strng_t(_name) )  ; }
 
-    int    fetchInt( const char* _name){ return  x_det.attr<int>( DD4hep::XML::Strng_t(_name) ) ; }
+    int    fetchInt( const char* _name){ return  x_det.attr<int>( dd4hep::xml::Strng_t(_name) ) ; }
 
-    std::string fetchString( const char* _name){ return  x_det.attr<std::string>( DD4hep::XML::Strng_t(_name) ) ;}
+    std::string fetchString( const char* _name){ return  x_det.attr<std::string>( dd4hep::xml::Strng_t(_name) ) ;}
 
     /** allow this to be used as a 'pointer' ( as was used for Mokka Database object)*/
     XMLHandlerDB* operator->() { return this ; }

--- a/detector/other/ConicalSupport_o1_v01_geo.cpp
+++ b/detector/other/ConicalSupport_o1_v01_geo.cpp
@@ -9,25 +9,35 @@
 #include <string>
 
 using namespace std;
-using namespace DD4hep;
-using namespace DD4hep::Geometry;
-using namespace DD4hep::DDRec ;
-using namespace DDSurfaces ;
 
-using DD4hep::Geometry::Transform3D;
-using DD4hep::Geometry::Position;
-using DD4hep::Geometry::RotationY;
-using DD4hep::Geometry::RotateY;
-using DD4hep::Geometry::ConeSegment;
-using DD4hep::Geometry::SubtractionSolid;
-using DD4hep::Geometry::Material;
-using DD4hep::Geometry::Volume;
-using DD4hep::Geometry::Solid;
-using DD4hep::Geometry::Tube;
-using DD4hep::Geometry::PlacedVolume;
-using DD4hep::Geometry::Assembly;
+using dd4hep::Assembly;
+using dd4hep::BUILD_ENVELOPE;
+using dd4hep::ConeSegment;
+using dd4hep::DetElement;
+using dd4hep::Detector;
+using dd4hep::Material;
+using dd4hep::PlacedVolume;
+using dd4hep::Position;
+using dd4hep::Ref_t;
+using dd4hep::RotateY;
+using dd4hep::RotationY;
+using dd4hep::SensitiveDetector;
+using dd4hep::Solid;
+using dd4hep::SubtractionSolid;
+using dd4hep::Transform3D;
+using dd4hep::Tube;
+using dd4hep::Volume;
 
-static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector /*sens*/)
+using dd4hep::rec::ConicalSupportData;
+using dd4hep::rec::SurfaceType;
+using dd4hep::rec::Vector3D;
+using dd4hep::rec::VolCone;
+using dd4hep::rec::VolCylinder;
+using dd4hep::rec::VolCylinderImpl;
+using dd4hep::rec::VolSurface;
+using dd4hep::rec::volSurfaceList;
+
+static Ref_t create_detector(Detector& lcdd, xml_h e, SensitiveDetector /*sens*/)
 {
 
   xml_det_t     x_det     = e;
@@ -36,7 +46,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector /*sens*/)
   DetElement    sdet(det_name, det_id);
   bool          reflect   = x_det.reflect();
 
-  Volume envelope = XML::createPlacedEnvelope(lcdd,  e , sdet) ;
+  Volume envelope = dd4hep::xml::createPlacedEnvelope(lcdd,  e , sdet) ;
 
   if (lcdd.buildType() == BUILD_ENVELOPE) return sdet ;
 

--- a/detector/other/FieldMapBrBz.cpp
+++ b/detector/other/FieldMapBrBz.cpp
@@ -26,6 +26,10 @@
 #include <iostream>
 #include <iomanip>
 
+using dd4hep::CartesianField;
+using dd4hep::Detector;
+using dd4hep::Ref_t;
+
 DD4HEP_INSTANTIATE_HANDLE(FieldMapBrBz);
 
 namespace {
@@ -40,7 +44,7 @@ namespace {
 }
 
 FieldMapBrBz::FieldMapBrBz() {
-  type = DD4hep::Geometry::CartesianField::MAGNETIC;
+  type = CartesianField::MAGNETIC;
 } //ctor
 
 
@@ -286,9 +290,9 @@ void FieldMapBrBz::fillFieldMapFromTree(const std::string& filename,
 
 }
 
-static DD4hep::Geometry::Ref_t create_FieldMap_rzBrBz(DD4hep::Geometry::LCDD& ,
-						      DD4hep::XML::Handle_t handle ) {
-  DD4hep::XML::Component xmlParameter(handle);
+static Ref_t create_FieldMap_rzBrBz(Detector& ,
+                                    dd4hep::xml::Handle_t handle ) {
+  dd4hep::xml::Component xmlParameter(handle);
   bool hasFilename = xmlParameter.hasAttr(_Unicode(filename));
 
   if (!hasFilename) {
@@ -311,7 +315,7 @@ static DD4hep::Geometry::Ref_t create_FieldMap_rzBrBz(DD4hep::Geometry::LCDD& ,
   double coorUnits   = xmlParameter.attr< double >(_Unicode(coorUnits));
   double BfieldUnits = xmlParameter.attr< double >(_Unicode(BfieldUnits));
 
-  DD4hep::Geometry::CartesianField obj;
+  CartesianField obj;
   FieldMapBrBz* ptr = new FieldMapBrBz();
   ptr->rScale     = rScale;
   ptr->zScale     = zScale;

--- a/detector/other/FieldMapXYZ.cpp
+++ b/detector/other/FieldMapXYZ.cpp
@@ -26,6 +26,10 @@
 #include <iostream>
 #include <iomanip>
 
+using dd4hep::CartesianField;
+using dd4hep::Detector;
+using dd4hep::Ref_t;
+
 DD4HEP_INSTANTIATE_HANDLE(FieldMapXYZ);
 
 namespace {
@@ -40,7 +44,7 @@ namespace {
 }
 
 FieldMapXYZ::FieldMapXYZ() {
-  type = DD4hep::Geometry::CartesianField::MAGNETIC;
+  type = CartesianField::MAGNETIC;
 } //ctor
 
 
@@ -355,9 +359,9 @@ void FieldMapXYZ::fillFieldMapFromTree(const std::string& filename,
 
 }
 
-static DD4hep::Geometry::Ref_t create_FieldMap_XYZ(DD4hep::Geometry::LCDD& ,
-						   DD4hep::XML::Handle_t handle ) {
-  DD4hep::XML::Component xmlParameter(handle);
+static Ref_t create_FieldMap_XYZ(Detector& ,
+                                 dd4hep::xml::Handle_t handle ) {
+  dd4hep::xml::Component xmlParameter(handle);
   bool hasFilename = xmlParameter.hasAttr(_Unicode(filename));
 
   if (!hasFilename) {
@@ -383,7 +387,7 @@ static DD4hep::Geometry::Ref_t create_FieldMap_XYZ(DD4hep::Geometry::LCDD& ,
   double coorUnits   = xmlParameter.attr< double >(_Unicode(coorUnits));
   double BfieldUnits = xmlParameter.attr< double >(_Unicode(BfieldUnits));
 
-  DD4hep::Geometry::CartesianField obj;
+  CartesianField obj;
   FieldMapXYZ* ptr = new FieldMapXYZ();
   ptr->xScale     = xScale;
   ptr->yScale     = yScale;

--- a/detector/other/GenericBarrelEnvelope.cpp
+++ b/detector/other/GenericBarrelEnvelope.cpp
@@ -2,10 +2,22 @@
 
 
 using namespace std;
-using namespace DD4hep;
-using namespace DD4hep::Geometry;
 
-static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector /*sens*/) {
+using dd4hep::Ref_t;
+using dd4hep::Detector;
+using dd4hep::SensitiveDetector;
+using dd4hep::PolyhedraRegular;
+using dd4hep::SubtractionSolid;
+using dd4hep::Tube;
+using dd4hep::Position;
+using dd4hep::RotationZYX;
+using dd4hep::DetElement;
+using dd4hep::Volume;
+using dd4hep::Material;
+using dd4hep::Transform3D;
+using dd4hep::PlacedVolume;
+
+static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector /*sens*/) {
     
     xml_det_t Detector = e;
     
@@ -25,7 +37,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector /*sens*/) {
     double phi_offset = Dimensions.phi0_offset();
 
     Volume envelope;
-    Material envelope_material = lcdd.material(Dimensions.materialStr());
+    Material envelope_material = theDetector.material(Dimensions.materialStr());
 
     if(nsides_inner!=0 && nsides_outer!=0){
         if( (nsides_outer-nsides_inner)==0 && phi_offset==0){
@@ -66,12 +78,12 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector /*sens*/) {
 
     
     DetElement sdet (DetectorName,DetectorID);
-    Volume motherVol = lcdd.pickMotherVolume(sdet);
+    Volume motherVol = theDetector.pickMotherVolume(sdet);
 
     PlacedVolume  env_phv = motherVol.placeVolume(envelope,tr);
     sdet.setPlacement( env_phv );
 
-    envelope.setAttributes(lcdd,Detector.regionStr(),Detector.limitsStr(),Detector.visStr());
+    envelope.setAttributes(theDetector,Detector.regionStr(),Detector.limitsStr(),Detector.visStr());
 
     return sdet;
 }

--- a/detector/other/GenericSurfaceInstaller.cpp
+++ b/detector/other/GenericSurfaceInstaller.cpp
@@ -56,7 +56,7 @@ namespace{
             char* ptr = ::strchr(argv[i],'=');
             if ( ptr )  {
                 std::string name( argv[i] , ptr ) ;
-                value = DD4hep::_toDouble(++ptr);
+                value = dd4hep::_toDouble(++ptr);
                 std::cout << "GenericSurfaceInstallerPlugin: argument[" << i << "] = " << name 
                 << " = " << value << std::endl;
                 if( name=="dimension" ) data.dimension = value ; 
@@ -85,14 +85,14 @@ namespace{
     
     /// Install measurement surfaces
     template <typename UserData> 
-    void Installer<UserData>::install(DetElement component, PlacedVolume pv)   {
+      void Installer<UserData>::install(dd4hep::DetElement component, dd4hep::PlacedVolume pv)   {
         
         
-        Volume comp_vol = pv.volume();
+        dd4hep::Volume comp_vol = pv.volume();
         if ( comp_vol.isSensitive() )  {  
-            Volume mod_vol  = parentVolume(component);
+            dd4hep::Volume mod_vol  = parentVolume(component);
             //FIXME: WHAT IF TRAPEZOID? Should work if trapezoid since it will fit minimal box and dy1=dy2=dy
-            DD4hep::Geometry::Box mod_shape(mod_vol.solid()), comp_shape(comp_vol.solid());
+            dd4hep::Box mod_shape(mod_vol.solid()), comp_shape(comp_vol.solid());
             
             if ( !comp_shape.isValid() || !mod_shape.isValid() )   {
                 invalidInstaller("Components and/or modules are not boxes -- invalid shapes");

--- a/detector/other/ILDSServices.cpp
+++ b/detector/other/ILDSServices.cpp
@@ -19,25 +19,24 @@
 #include <string>
 
 using namespace std;
-using namespace DD4hep;
-using namespace DD4hep::Geometry;
-using namespace DD4hep::DDRec ;
-using namespace DDSurfaces ;
 
-using DD4hep::Geometry::Transform3D;
-using DD4hep::Geometry::Position;
-using DD4hep::Geometry::RotationY;
-using DD4hep::Geometry::RotateY;
-using DD4hep::Geometry::ConeSegment;
-using DD4hep::Geometry::SubtractionSolid;
-using DD4hep::Geometry::Material;
-using DD4hep::Geometry::Volume;
-using DD4hep::Geometry::Solid;
-using DD4hep::Geometry::Tube;
-using DD4hep::Geometry::PlacedVolume;
-using DD4hep::Geometry::Assembly;
+using dd4hep::Assembly;
+using dd4hep::ConeSegment;
+using dd4hep::Material;
+using dd4hep::PlacedVolume;
+using dd4hep::Position;
+using dd4hep::RotateY;
+using dd4hep::RotationY;
+using dd4hep::Solid;
+using dd4hep::SubtractionSolid;
+using dd4hep::Transform3D;
+using dd4hep::Tube;
+using dd4hep::Volume;
+using dd4hep::Ref_t;
+using dd4hep::Detector;
+using dd4hep::DetElement;
 
-static Ref_t create_element(LCDD& lcdd, xml_h element, Ref_t)  {
+static Ref_t create_element(Detector& lcdd, xml_h element, Ref_t)  {
 
   //unused:  static double tolerance = 0e0;
 
@@ -51,7 +50,7 @@ static Ref_t create_element(LCDD& lcdd, xml_h element, Ref_t)  {
   Assembly envelope_assembly( det_name + "assembly" ) ;
   PlacedVolume pv;
 
-  XML::setDetectorTypeFlag( element, sdet ) ;
+  dd4hep::xml::setDetectorTypeFlag( element, sdet ) ;
 
 //====================================================================
 // build all services

--- a/detector/other/MaterialEnvelope_o1_v01.cpp
+++ b/detector/other/MaterialEnvelope_o1_v01.cpp
@@ -11,20 +11,23 @@
 #include "XML/Utilities.h"
 
 using namespace std;
-using namespace DD4hep;
-using namespace DD4hep::Geometry;
+
+using dd4hep::DetElement;
+using dd4hep::Detector;
+using dd4hep::Ref_t;
+using dd4hep::SensitiveDetector;
 
 // workaround for DD4hep v00-14 (and older) 
 #ifndef DD4HEP_VERSION_GE
 #define DD4HEP_VERSION_GE(a,b) 0 
 #endif
 
-static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector) {
+static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector) {
     xml_det_t x_det = e;
     string det_name = x_det.nameStr();
     DetElement sdet(det_name, x_det.id());
 
-    XML::createPlacedEnvelope( lcdd,  e , sdet ) ;
+    dd4hep::xml::createPlacedEnvelope( theDetector,  e , sdet ) ;
     
     return sdet ;
     

--- a/detector/other/PolyhedralBarrelSurfaces_geo.cpp
+++ b/detector/other/PolyhedralBarrelSurfaces_geo.cpp
@@ -14,14 +14,28 @@
 #include "DDRec/DetectorData.h"
 #include "XML/Utilities.h"
 
+using dd4hep::BUILD_ENVELOPE;
+using dd4hep::Box;
+using dd4hep::DetElement;
+using dd4hep::Detector;
+using dd4hep::Material;
+using dd4hep::PlacedVolume;
+using dd4hep::Position;
+using dd4hep::Ref_t;
+using dd4hep::RotationZYX;
+using dd4hep::SensitiveDetector;
+using dd4hep::Transform3D;
+using dd4hep::Volume;
 
-using namespace DD4hep;
-using namespace DD4hep::Geometry;
-using namespace DD4hep::DDRec ;
-using namespace DDSurfaces ;
+using dd4hep::xml::_toString;
 
-static Ref_t create_element(LCDD& lcdd, xml_h element, SensitiveDetector sens)  {
-  
+using dd4hep::rec::SurfaceType;
+using dd4hep::rec::Vector3D;
+using dd4hep::rec::VolPlane;
+using dd4hep::rec::volSurfaceList;
+
+static Ref_t create_element(Detector& theDetector, xml_h element, SensitiveDetector sens)  {
+
   xml_det_t    x_det = element;
   std::string  name  = x_det.nameStr();
   
@@ -32,9 +46,9 @@ static Ref_t create_element(LCDD& lcdd, xml_h element, SensitiveDetector sens)  
 
   // --- create an envelope volume and position it into the world ---------------------
   
-  Volume envelope = XML::createPlacedEnvelope( lcdd,  element , sdet ) ;
+  Volume envelope = dd4hep::xml::createPlacedEnvelope( theDetector,  element , sdet ) ;
   
-  if( lcdd.buildType() == BUILD_ENVELOPE ) return sdet ;
+  if( theDetector.buildType() == BUILD_ENVELOPE ) return sdet ;
   
   //-----------------------------------------------------------------------------------
   
@@ -61,9 +75,9 @@ static Ref_t create_element(LCDD& lcdd, xml_h element, SensitiveDetector sens)  
   sens.setType("tracker");
 
   // base vectors for surfaces:
-  DDSurfaces::Vector3D u(0,1,0) ;
-  DDSurfaces::Vector3D v(0,0,1) ;
-  DDSurfaces::Vector3D n(1,0,0) ;
+  Vector3D u(0,1,0) ;
+  Vector3D v(0,0,1) ;
+  Vector3D n(1,0,0) ;
   
   for(unsigned i=0 ; i < nsides ; ++i ){
 
@@ -79,9 +93,9 @@ static Ref_t create_element(LCDD& lcdd, xml_h element, SensitiveDetector sens)  
 
     boxVol.setSensitiveDetector(sens);
 
-    DDRec::VolPlane surf( boxVol,DDSurfaces::SurfaceType(DDSurfaces::SurfaceType::Sensitive), thick/4., thick/4., u,v,n ) ;
+    VolPlane surf( boxVol,SurfaceType(SurfaceType::Sensitive), thick/4., thick/4., u,v,n ) ;
 	      
-    DDRec::volSurfaceList( moduleDE  )->push_back(  surf ) ;
+    volSurfaceList( moduleDE  )->push_back(  surf ) ;
 
     pv = envelope.placeVolume( boxVol , Transform3D( rot, Position( ( inner_r + thick/2. ) * cos( phi ) ,
 								    ( inner_r + thick/2. ) * sin( phi ) , 

--- a/detector/other/PolyhedralEndcapSurfaces_geo.cpp
+++ b/detector/other/PolyhedralEndcapSurfaces_geo.cpp
@@ -14,13 +14,28 @@
 #include "DDRec/DetectorData.h"
 #include "XML/Utilities.h"
 
+using dd4hep::BUILD_ENVELOPE;
+using dd4hep::Box;
+using dd4hep::DetElement;
+using dd4hep::Detector;
+using dd4hep::Material;
+using dd4hep::PlacedVolume;
+using dd4hep::PolyhedraRegular;
+using dd4hep::Position;
+using dd4hep::Ref_t;
+using dd4hep::RotationZYX;
+using dd4hep::SensitiveDetector;
+using dd4hep::Transform3D;
+using dd4hep::Volume;
 
-using namespace DD4hep;
-using namespace DD4hep::Geometry;
-using namespace DD4hep::DDRec ;
-using namespace DDSurfaces ;
+using dd4hep::xml::_toString;
 
-static Ref_t create_element(LCDD& lcdd, xml_h element, SensitiveDetector sens)  {
+using dd4hep::rec::SurfaceType;
+using dd4hep::rec::Vector3D;
+using dd4hep::rec::VolPlane;
+using dd4hep::rec::volSurfaceList;
+
+static Ref_t create_element(Detector& theDetector, xml_h element, SensitiveDetector sens)  {
   
   xml_det_t    x_det = element;
   std::string  name  = x_det.nameStr();
@@ -32,9 +47,9 @@ static Ref_t create_element(LCDD& lcdd, xml_h element, SensitiveDetector sens)  
 
   // --- create an envelope volume and position it into the world ---------------------
   
-  Volume envelope = XML::createPlacedEnvelope( lcdd,  element , sdet ) ;
+  Volume envelope = dd4hep::xml::createPlacedEnvelope( theDetector,  element , sdet ) ;
   
-  if( lcdd.buildType() == BUILD_ENVELOPE ) return sdet ;
+  if( theDetector.buildType() == BUILD_ENVELOPE ) return sdet ;
   
   //-----------------------------------------------------------------------------------
   
@@ -60,9 +75,9 @@ static Ref_t create_element(LCDD& lcdd, xml_h element, SensitiveDetector sens)  
   sens.setType("tracker");
 
   // base vectors for surfaces:
-  DDSurfaces::Vector3D u(0,1,0) ;
-  DDSurfaces::Vector3D v(1,0,0) ;
-  DDSurfaces::Vector3D n(0,0,1) ;
+  Vector3D u(0,1,0) ;
+  Vector3D v(1,0,0) ;
+  Vector3D n(0,0,1) ;
   
   
   PolyhedraRegular phSolid ( nsides, inner_r, outer_r , 0.5*thick ) ;
@@ -77,11 +92,11 @@ static Ref_t create_element(LCDD& lcdd, xml_h element, SensitiveDetector sens)  
   
   //fixme: the drawing of endcap surfaces in a polyhedral shape does not work right now 
   //       -> set surface to be invisible for now
-  DDRec::VolPlane surf( phVol,DDSurfaces::SurfaceType(DDSurfaces::SurfaceType::Sensitive, 
-						      DDSurfaces::SurfaceType::Invisible), 
-			thick/4., thick/4., u,v,n ) ;
+  VolPlane surf( phVol,SurfaceType(SurfaceType::Sensitive, 
+                                   SurfaceType::Invisible), 
+                 thick/4., thick/4., u,v,n ) ;
   
-  DDRec::volSurfaceList( fwdDE  )->push_back(  surf ) ;
+  volSurfaceList( fwdDE  )->push_back(  surf ) ;
 
   pv = envelope.placeVolume( phVol , Position( 0., 0., zpos ) ) ;
 
@@ -98,7 +113,7 @@ static Ref_t create_element(LCDD& lcdd, xml_h element, SensitiveDetector sens)  
   phVol.setSensitiveDetector(sens);
   
   
-  DDRec::volSurfaceList( bwdDE  )->push_back(  surf ) ;
+  volSurfaceList( bwdDE  )->push_back(  surf ) ;
 
   pv = envelope.placeVolume( phVol , Position( 0., 0., -zpos ) ) ;
 

--- a/detector/other/SServices00.h
+++ b/detector/other/SServices00.h
@@ -5,9 +5,6 @@
 #include "DD4hep/DD4hepUnits.h"
  
 using namespace std;
-using namespace DD4hep;
-using namespace dd4hep;
-using namespace DD4hep::Geometry;
 
 //=====================================
 // class for  BuildTPCEndplateServices
@@ -22,30 +19,30 @@ public:
   BuildTPCEndplateServices(){};
   ~BuildTPCEndplateServices(){};
 
-  void setMaterial (Material copper4cooling) {cooling_Material = copper4cooling;};
+  void setMaterial (dd4hep::Material copper4cooling) {cooling_Material = copper4cooling;};
   void sethalfZ (double TPC_Ecal_Hcal_barrel_halfZ){TPC_barrel_halfZ = TPC_Ecal_Hcal_barrel_halfZ ;};
   void settpcEndplateServicesRing_R_ro( double tpcEndplateServicesRing_R, double tpcEndplateServicesRing_ro) {
     tpcEndplateServicesRing_R_ro.push_back(make_pair(tpcEndplateServicesRing_R,tpcEndplateServicesRing_ro));
   };
 
   // to build TPC cooling rings into the service assembly 
-  bool DoBuildTPCEndplateServices(PlacedVolume &pVol,Assembly &envelope){
+  bool DoBuildTPCEndplateServices(dd4hep::PlacedVolume &pVol,dd4hep::Assembly &envelope){
     for( vector< pair<double,double> >::const_iterator it = tpcEndplateServicesRing_R_ro.begin() ; 
 	 it != tpcEndplateServicesRing_R_ro.end(); ++it){
-      Torus solidTube(it->first, 0, it->second, 0, 2*M_PI);
+      dd4hep::Torus solidTube(it->first, 0, it->second, 0, 2*M_PI);
       double z_position = TPC_barrel_halfZ + it->second;
-      Volume EnvTube("service_tube",solidTube,cooling_Material);
+      dd4hep::Volume EnvTube("service_tube",solidTube,cooling_Material);
       //EnvTube.setVisAttributes("RedVis");
-      Position pos1(0,0,z_position);
+      dd4hep::Position pos1(0,0,z_position);
       pVol = envelope.placeVolume(EnvTube,pos1);
-      Position pos2(0,0,-z_position);
+      dd4hep::Position pos2(0,0,-z_position);
       pVol = envelope.placeVolume(EnvTube,pos2);
     } 
     return true;
   };
 
 private:
-  Material cooling_Material;
+  dd4hep::Material cooling_Material;
   double TPC_barrel_halfZ;
   vector< pair<double,double> > tpcEndplateServicesRing_R_ro;  
 };
@@ -61,10 +58,10 @@ public:
   BuildEcalBarrelServices(){};
   ~BuildEcalBarrelServices(){};
 
-  void setMaterialAir (Material air4container) {air = air4container;};
-  void setMaterialAluminium (Material al) {aluminium = al;};
-  void setMaterialPolyethylene (Material PE) {polyethylene = PE;};
-  void setMaterialCopper (Material Cu) {copper = Cu;};
+  void setMaterialAir (dd4hep::Material air4container) {air = air4container;};
+  void setMaterialAluminium (dd4hep::Material al) {aluminium = al;};
+  void setMaterialPolyethylene (dd4hep::Material PE) {polyethylene = PE;};
+  void setMaterialCopper (dd4hep::Material Cu) {copper = Cu;};
 
   void sethalfZ (double TPC_Ecal_Hcal_barrel_halfZ){Ecal_barrel_halfZ = TPC_Ecal_Hcal_barrel_halfZ ;};
   void setTopDimX (double dim_x){top_dim_x = dim_x ;};
@@ -84,7 +81,7 @@ public:
   void setRailSeparationChanged(void) {RailSeparationChanged = false;};
 
   // to fill the detail service layers into the container
-  bool FillEcalBarrelServicesContainer(PlacedVolume &pVol, Volume &pContainerLogical){
+  bool FillEcalBarrelServicesContainer(dd4hep::PlacedVolume &pVol, dd4hep::Volume &pContainerLogical){
 
     const int NRAILS=2;
     if ( RailSeparation*(NRAILS-1) > top_dim_x - RailWidth ) {
@@ -98,13 +95,13 @@ public:
       railPositions[i] = i*RailSeparation - RailSeparation*(NRAILS-1)/2.;
     }
    
-    Box railSolid(RailWidth/2., RailHeight/2., Ecal_barrel_halfZ); 
+    dd4hep::Box railSolid(RailWidth/2., RailHeight/2., Ecal_barrel_halfZ); 
 
-    Volume railLogical("railLogical", railSolid, aluminium);
+    dd4hep::Volume railLogical("railLogical", railSolid, aluminium);
 
     for(int i=0; i<NRAILS; i++)
       {
-	Position pos(railPositions[i],0,0);
+	dd4hep::Position pos(railPositions[i],0,0);
 	pVol = pContainerLogical.placeVolume(railLogical,pos);
       }
     
@@ -125,28 +122,28 @@ public:
     }
 
     // polyethylene
-    Box PESolid( internalZoneWidth/2. , pe_thick / 2., moduleLength / 2.); 
+    dd4hep::Box PESolid( internalZoneWidth/2. , pe_thick / 2., moduleLength / 2.); 
     
-    string PELogical_name  = "PELogical"+_toString(i,"_%d");
-    Volume PELogical(PELogical_name,PESolid,polyethylene);
+    string PELogical_name  = "PELogical"+dd4hep::_toString(i,"_%d");
+    dd4hep::Volume PELogical(PELogical_name,PESolid,polyethylene);
     //PELogical.setVisAttributes("GreenVis");
 
-    Position posPE( 0 , 
-		    -RailHeight/2. + pe_thick/2.,
-		    -Ecal_barrel_halfZ + moduleLength*(i+1/2.));
+    dd4hep::Position posPE( 0 , 
+                            -RailHeight/2. + pe_thick/2.,
+                            -Ecal_barrel_halfZ + moduleLength*(i+1/2.));
     
     pVol = pContainerLogical.placeVolume(PELogical,posPE);
     
     // Cu_1
-    Box Cu_1_Solid( internalZoneWidth/2., cu_thick / 2., moduleLength / 2.); 
+    dd4hep::Box Cu_1_Solid( internalZoneWidth/2., cu_thick / 2., moduleLength / 2.); 
     
-    string Cu_1_Logical_name  = "Cu_1_Logical"+_toString(i,"_%d");
-    Volume Cu_1_Logical(Cu_1_Logical_name, Cu_1_Solid,copper);
+    string Cu_1_Logical_name  = "Cu_1_Logical"+dd4hep::_toString(i,"_%d");
+    dd4hep::Volume Cu_1_Logical(Cu_1_Logical_name, Cu_1_Solid,copper);
     //Cu_1_Logical.setVisAttributes("BlueVis");
 
-    Position posCu1( 0 , 
-		     -RailHeight/2. + pe_thick + cu_thick/2.,
-		     -Ecal_barrel_halfZ + moduleLength*(i+1/2.));
+    dd4hep::Position posCu1( 0 , 
+                             -RailHeight/2. + pe_thick + cu_thick/2.,
+                             -Ecal_barrel_halfZ + moduleLength*(i+1/2.));
     
     pVol = pContainerLogical.placeVolume(Cu_1_Logical,posCu1);
 
@@ -156,10 +153,10 @@ public:
   };
 
   // to build Ecal Barrel service into the service assembly 
-  bool DoBuildEcalBarrelServices(PlacedVolume &pVol,Assembly &envelope){
+  bool DoBuildEcalBarrelServices(dd4hep::PlacedVolume &pVol,dd4hep::Assembly &envelope){
 
-    Box ContainerSolid(top_dim_x/2., RailHeight/2., Ecal_barrel_halfZ); 
-    Volume containerLogical("EcalBarrelServicesContainerLogical",ContainerSolid,air);
+    dd4hep::Box ContainerSolid(top_dim_x/2., RailHeight/2., Ecal_barrel_halfZ); 
+    dd4hep::Volume containerLogical("EcalBarrelServicesContainerLogical",ContainerSolid,air);
     //containerLogical.setVisAttributes("SeeThrough");
     //containerLogical.setVisAttributes("MagentaVis");
 
@@ -169,12 +166,12 @@ public:
     for (int stave_id = 1; stave_id < 9 ; stave_id++)
       {
 	double phirot = (stave_id-1) * M_PI/4.;
-	RotationZYX rot(-phirot,0,0);
+	dd4hep::RotationZYX rot(-phirot,0,0);
 	//Position  stavePosition(module_thickness * sin(M_PI/4.), Ecal_outer_radius + RailHeight/2., 0);
-	Position  stavePosition( (Ecal_outer_radius + RailHeight/2.)*sin(phirot) - module_thickness * sin(M_PI/4.)*cos(-phirot), 
-				 (Ecal_outer_radius + RailHeight/2.)*cos(phirot) - module_thickness * sin(M_PI/4.)*sin(-phirot), 
+	dd4hep::Position stavePosition((Ecal_outer_radius + RailHeight/2.)*sin(phirot) - module_thickness * sin(M_PI/4.)*cos(-phirot), 
+                                       (Ecal_outer_radius + RailHeight/2.)*cos(phirot) - module_thickness * sin(M_PI/4.)*sin(-phirot), 
 				0 );
-	Transform3D tran3D(rot,stavePosition);
+	dd4hep::Transform3D tran3D(rot,stavePosition);
 	pVol = envelope.placeVolume(containerLogical,tran3D);
       }
     
@@ -201,10 +198,10 @@ private:
   double ZPlus_FirstInterrail_PE_Thickness;
   double ZPlus_FirstInterrail_Cu_Thickness;
 
-  Material air;
-  Material aluminium;
-  Material polyethylene;
-  Material copper;
+  dd4hep::Material air;
+  dd4hep::Material aluminium;
+  dd4hep::Material polyethylene;
+  dd4hep::Material copper;
 
 };
 
@@ -222,9 +219,9 @@ public:
   BuildEcalBarrel_EndCapServices(){};
   ~BuildEcalBarrel_EndCapServices(){};
 
-  void setMaterialAir (Material air4container) {air = air4container;};
-  void setMaterialPolyethylene (Material PE) {polyethylene = PE;};
-  void setMaterialCopper (Material Cu) {copper = Cu;};
+  void setMaterialAir (dd4hep::Material air4container) {air = air4container;};
+  void setMaterialPolyethylene (dd4hep::Material PE) {polyethylene = PE;};
+  void setMaterialCopper (dd4hep::Material Cu) {copper = Cu;};
 
   void sethalfZ (double TPC_Ecal_Hcal_barrel_halfZ){Ecal_barrel_halfZ = TPC_Ecal_Hcal_barrel_halfZ ;};
   void setTopDimX (double dim_x){top_dim_x = dim_x ;};
@@ -241,11 +238,11 @@ public:
 
 
   // to build Ecal Barrel service into the service assembly 
-  bool DoBuildEcalBarrel_EndCapServices(PlacedVolume &pVol,Assembly &envelope){
+  bool DoBuildEcalBarrel_EndCapServices(dd4hep::PlacedVolume &pVol,dd4hep::Assembly &envelope){
 
     double containerThickness = ZMinus_PE_Thickness + ZMinus_Cu_Thickness;
     double z_position = -Ecal_barrel_halfZ -containerThickness/2.;
-    double container_x_dim = top_dim_x/2. + module_thickness*sin(pi/4.) - InnerServicesWidth/2.;
+    double container_x_dim = top_dim_x/2. + module_thickness*sin(M_PI/4.) - InnerServicesWidth/2.;
     double Cu_Thickness = ZMinus_Cu_Thickness;
     double PE_Thickness = ZMinus_PE_Thickness;
 
@@ -256,27 +253,27 @@ public:
 	//	       "EcalBarrel_EndCap services: Cu+PE thicknesses exceed Ecal_cables_gap",
 	//	       MOKKA_ERROR_BAD_DATABASE_PARAMETERS);
 
-      Box ContainerSolid(container_x_dim/2., module_thickness/2., containerThickness/2.); 
+      dd4hep::Box ContainerSolid(container_x_dim/2., module_thickness/2., containerThickness/2.); 
 
-      string containerLogical_name  = "containerLogical"+_toString(i,"_%d");
-      Volume containerLogical(containerLogical_name,ContainerSolid,air);
+      string containerLogical_name  = "containerLogical"+dd4hep::_toString(i,"_%d");
+      dd4hep::Volume containerLogical(containerLogical_name,ContainerSolid,air);
 
 
-      Box PESolid(container_x_dim/2., module_thickness/2., PE_Thickness/2.);
+      dd4hep::Box PESolid(container_x_dim/2., module_thickness/2., PE_Thickness/2.);
  
-      string PELogical_name  = "PELogical"+_toString(i,"_%d");
-      Volume PELogical(PELogical_name,PESolid,polyethylene);
+      string PELogical_name  = "PELogical"+dd4hep::_toString(i,"_%d");
+      dd4hep::Volume PELogical(PELogical_name,PESolid,polyethylene);
 
-      Position  PosPE(0,0,containerThickness/2. - PE_Thickness/2.);
+      dd4hep::Position  PosPE(0,0,containerThickness/2. - PE_Thickness/2.);
       
       pVol = containerLogical.placeVolume(PELogical,PosPE);
       
-      Box Cu_Solid(container_x_dim/2., module_thickness/2., Cu_Thickness/2.); 
+      dd4hep::Box Cu_Solid(container_x_dim/2., module_thickness/2., Cu_Thickness/2.); 
       
-      string Cu_Logical_name  = "Cu_Logical"+_toString(i,"_%d");
-      Volume Cu_Logical(Cu_Logical_name,Cu_Solid,copper);
+      string Cu_Logical_name  = "Cu_Logical"+dd4hep::_toString(i,"_%d");
+      dd4hep::Volume Cu_Logical(Cu_Logical_name,Cu_Solid,copper);
       
-      Position  PosCu(0,0,-containerThickness/2. + Cu_Thickness/2.);
+      dd4hep::Position  PosCu(0,0,-containerThickness/2. + Cu_Thickness/2.);
       
       pVol = containerLogical.placeVolume(Cu_Logical,PosCu);
 
@@ -285,30 +282,30 @@ public:
 	
 	double phirot = (stave_id-1) * M_PI/4;
 	
-	RotationZYX rot;
-	Position stavePosition;
+	dd4hep::RotationZYX rot;
+	dd4hep::Position stavePosition;
 	
         if(z_position > 0) {
-	  RotationZYX rot_P(-phirot,0,0);
+	  dd4hep::RotationZYX rot_P(-phirot,0,0);
 	  rot = rot_P;
-	  Position stavePosition_P((Ecal_outer_radius - module_thickness/2.)*sin(phirot)+(InnerServicesWidth/2. + container_x_dim/2.)*cos(-phirot),
-				   (Ecal_outer_radius - module_thickness/2.)*cos(phirot)+(InnerServicesWidth/2. + container_x_dim/2.)*sin(-phirot), 
-				   z_position);
+	  dd4hep::Position stavePosition_P((Ecal_outer_radius - module_thickness/2.)*sin(phirot)+(InnerServicesWidth/2. + container_x_dim/2.)*cos(-phirot),
+                                           (Ecal_outer_radius - module_thickness/2.)*cos(phirot)+(InnerServicesWidth/2. + container_x_dim/2.)*sin(-phirot), 
+                                           z_position);
 
 	  stavePosition = stavePosition_P;
 	}
 	else
 	  {
-	    RotationZYX rot_M(phirot,M_PI,0);
+	    dd4hep::RotationZYX rot_M(phirot,M_PI,0);
 	    rot = rot_M;
-	    Position stavePosition_M((Ecal_outer_radius - module_thickness/2.)*sin(phirot)+(-InnerServicesWidth/2. - container_x_dim/2.)*cos(-phirot),
-				     (Ecal_outer_radius - module_thickness/2.)*cos(phirot)+(-InnerServicesWidth/2. - container_x_dim/2.)*sin(-phirot),
-				     z_position);
+	    dd4hep::Position stavePosition_M((Ecal_outer_radius - module_thickness/2.)*sin(phirot)+(-InnerServicesWidth/2. - container_x_dim/2.)*cos(-phirot),
+                                             (Ecal_outer_radius - module_thickness/2.)*cos(phirot)+(-InnerServicesWidth/2. - container_x_dim/2.)*sin(-phirot),
+                                             z_position);
 	    
 	    stavePosition = stavePosition_M;
 	  }
 	
-	Transform3D tran3D(rot,stavePosition);
+	dd4hep::Transform3D tran3D(rot,stavePosition);
 	pVol = envelope.placeVolume(containerLogical,tran3D);
 	
       }
@@ -342,9 +339,9 @@ private:
   double ZPlus_PE_Thickness;
   double ZPlus_Cu_Thickness;
 
-  Material air;
-  Material polyethylene;
-  Material copper;
+  dd4hep::Material air;
+  dd4hep::Material polyethylene;
+  dd4hep::Material copper;
 
 
 };

--- a/detector/other/SServices00_v01.cpp
+++ b/detector/other/SServices00_v01.cpp
@@ -20,6 +20,25 @@
 
 #include "SServices00_v01.h"
 
+using dd4hep::Assembly;
+using dd4hep::Box;
+using dd4hep::Detector;
+using dd4hep::IntersectionSolid;
+using dd4hep::Material;
+using dd4hep::PlacedVolume;
+using dd4hep::Polycone;
+using dd4hep::Position;
+using dd4hep::RotationZYX;
+using dd4hep::Solid;
+using dd4hep::SubtractionSolid;
+using dd4hep::Torus;
+using dd4hep::Transform3D;
+using dd4hep::Trapezoid;
+using dd4hep::Tube;
+using dd4hep::UnionSolid;
+using dd4hep::Volume;
+
+
 SServices00_v01::SServices00_v01() 
 {
   std::cout<<"SServices00_v01 is being created "<<std::endl;
@@ -31,58 +50,58 @@ SServices00_v01::~SServices00_v01()
 
 bool SServices00_v01::BuildServices(PlacedVolume &pVol,
 				    Assembly &envelope,
-				    LCDD &lcdd) 
+				    Detector &theDetector) 
 {
 
   std::cout << "\nBuilding SServices00"<< std::endl;
 
   TPC_inner_radius =
-    lcdd.constant<double>("TPC_inner_radius");
+    theDetector.constant<double>("TPC_inner_radius");
 
   Sit_cables_cylinder_thickness =
-    lcdd.constant<double>("SIT12_cable_thickness");
+    theDetector.constant<double>("SIT12_cable_thickness");
 
   TUBE_IPOuterBulge_end_z  =
-    lcdd.constant<double>("TUBE_IPOuterBulge_end_z");
+    theDetector.constant<double>("TUBE_IPOuterBulge_end_z");
 
   TUBE_IPOuterBulge_end_radius  =
-    lcdd.constant<double>("TUBE_IPOuterBulge_end_radius");
+    theDetector.constant<double>("TUBE_IPOuterBulge_end_radius");
 
   Sit_cables_disk_thickness =((1+TUBE_IPOuterBulge_end_radius/TPC_inner_radius)*0.5*
-			      (lcdd.constant<double>("SServices_FTD7_cables_thickness")));
+			      (theDetector.constant<double>("SServices_FTD7_cables_thickness")));
 
-  SIT1_Radius = lcdd.constant<double>("SIT1_Radius");
-  SIT2_Radius = lcdd.constant<double>("SIT2_Radius");
+  SIT1_Radius = theDetector.constant<double>("SIT1_Radius");
+  SIT2_Radius = theDetector.constant<double>("SIT2_Radius");
 
   FTD2_cone_thickness =
-    lcdd.constant<double>("SServices_FTD2_cone_thickness");
+    theDetector.constant<double>("SServices_FTD2_cone_thickness");
 
   FTD3_cone_thickness =
-    lcdd.constant<double>("SServices_FTD3_cone_thickness");
+    theDetector.constant<double>("SServices_FTD3_cone_thickness");
 
   TPC_Ecal_Hcal_barrel_halfZ = 
-    lcdd.constant<double>("TPC_Ecal_Hcal_barrel_halfZ");
+    theDetector.constant<double>("TPC_Ecal_Hcal_barrel_halfZ");
 
   TPC_outer_radius = 
-    lcdd.constant<double>("TPC_outer_radius");
+    theDetector.constant<double>("TPC_outer_radius");
 
   Ecal_cables_gap =
-    lcdd.constant<double>("Ecal_cables_gap");
+    theDetector.constant<double>("Ecal_cables_gap");
 
   InnerServicesWidth = 
-    lcdd.constant<double>("HcalServicesModule_InnerServicesWidth");
+    theDetector.constant<double>("HcalServicesModule_InnerServicesWidth");
 
   RailHeight = 
-    lcdd.constant<double>("EcalBarrelServices_RailHeight");
+    theDetector.constant<double>("EcalBarrelServices_RailHeight");
 
-  if(RailHeight > lcdd.constant<double>("Hcal_Ecal_gap"))
+  if(RailHeight > theDetector.constant<double>("Hcal_Ecal_gap"))
 	throw std::runtime_error("EcalBarrel services: RailHeight exceeds Hcal_Ecal_gap");
 
   double Ecal_inner_radius = TPC_outer_radius +
-    lcdd.constant<double>("Ecal_Tpc_gap");
+    theDetector.constant<double>("Ecal_Tpc_gap");
 
   Ecal_outer_radius =
-    lcdd.constant<double>("Ecal_outer_radius");
+    theDetector.constant<double>("Ecal_outer_radius");
 
   module_thickness = Ecal_outer_radius - Ecal_inner_radius;
 
@@ -96,17 +115,17 @@ bool SServices00_v01::BuildServices(PlacedVolume &pVol,
   G4cout << "top_dim_x = " << top_dim_x << G4endl;
 #endif
 
-  if (!BuildTPCEndplateServices(pVol,envelope,lcdd))  return false;
+  if (!BuildTPCEndplateServices(pVol,envelope,theDetector))  return false;
 
-  if (!BuildEcalBarrelServices(pVol,envelope,lcdd))  return false;
+  if (!BuildEcalBarrelServices(pVol,envelope,theDetector))  return false;
 
-  if (!BuildEcalBarrel_EndCapServices(pVol,envelope,lcdd))  
+  if (!BuildEcalBarrel_EndCapServices(pVol,envelope,theDetector))  
   		return false;
 
-  if (!BuildHcalBarrel_EndCapServices(pVol,envelope,lcdd))  
+  if (!BuildHcalBarrel_EndCapServices(pVol,envelope,theDetector))  
   		return false;
 
-  BuildSitCables(pVol,envelope,lcdd);
+  BuildSitCables(pVol,envelope,theDetector);
 
   return true;
 
@@ -114,13 +133,13 @@ bool SServices00_v01::BuildServices(PlacedVolume &pVol,
 
 void SServices00_v01::BuildSitCables(PlacedVolume &pVol,
 				     Assembly &envelope,
-				     LCDD &lcdd) 
+				     Detector &theDetector) 
 {
 
 //First place the Cylinder
 
   double ftd4to7_tpc_radial_gap  = 
-        lcdd.constant<double>("ftd4to7_tpc_radial_gap");
+        theDetector.constant<double>("ftd4to7_tpc_radial_gap");
 
   if(ftd4to7_tpc_radial_gap < Sit_cables_cylinder_thickness)
 	throw std::runtime_error("SServices_02_v00: the ftd-tpc radial gap is less than Sit cable thickness");
@@ -129,12 +148,12 @@ void SServices00_v01::BuildSitCables(PlacedVolume &pVol,
 	ftd4to7_tpc_radial_gap/2.;
 
   double z_start_3 = TPC_Ecal_Hcal_barrel_halfZ * 
-	lcdd.constant<double>("z_position_ReltoTPCLength");
+	theDetector.constant<double>("z_position_ReltoTPCLength");
 
-  double petalairthickness_half = 0.5 * ( lcdd.constant<double>("petal_cp_support_thickness")
-                                             + 2.0*(lcdd.constant<double>("disk_si_thickness")));
+  double petalairthickness_half = 0.5 * ( theDetector.constant<double>("petal_cp_support_thickness")
+                                             + 2.0*(theDetector.constant<double>("disk_si_thickness")));
 
-  double max_half_thickness_disk_3 = lcdd.constant<double>("petal_support_zoffset") + petalairthickness_half ;
+  double max_half_thickness_disk_3 = theDetector.constant<double>("petal_support_zoffset") + petalairthickness_half ;
 
   double z_half_len = (TPC_Ecal_Hcal_barrel_halfZ -
 	z_start_3) / 2.;
@@ -145,7 +164,7 @@ void SServices00_v01::BuildSitCables(PlacedVolume &pVol,
 		     0., 2 * M_PI);
 
   Volume SitTubeLog("SitTubeLog",SitTubeSolid,
-	       lcdd.material("aluminium"));
+	       theDetector.material("aluminium"));
   
   Position Cylinder_pos1(0, 0, z_start_3 + z_half_len);
   pVol = envelope.placeVolume(SitTubeLog,Cylinder_pos1);
@@ -157,18 +176,18 @@ void SServices00_v01::BuildSitCables(PlacedVolume &pVol,
 //Then place the cone
 
   double z_start_2 = TPC_Ecal_Hcal_barrel_halfZ * 
-	lcdd.constant<double>("z_position_ReltoTPCLength");
+	theDetector.constant<double>("z_position_ReltoTPCLength");
 
-  petalairthickness_half = 0.5 * ( lcdd.constant<double>("petal_cp_support_thickness")
-                                             + 2.0*(lcdd.constant<double>("disk_si_thickness")));
+  petalairthickness_half = 0.5 * ( theDetector.constant<double>("petal_cp_support_thickness")
+                                             + 2.0*(theDetector.constant<double>("disk_si_thickness")));
 
-  double max_half_thickness_disk_2 = lcdd.constant<double>("petal_support_zoffset") + petalairthickness_half ;
+  double max_half_thickness_disk_2 = theDetector.constant<double>("petal_support_zoffset") + petalairthickness_half ;
 
   double FTD2_outer_radius = SIT1_Radius + 
-	lcdd.constant<double>("ftd2_sit1_radial_diff");
+	theDetector.constant<double>("ftd2_sit1_radial_diff");
 
   double FTD3_outer_radius = SIT2_Radius +
-	lcdd.constant<double>("ftd3_sit2_radial_diff");
+	theDetector.constant<double>("ftd3_sit2_radial_diff");
 
   double zPlane[2];
   zPlane[0] = z_start_2 + max_half_thickness_disk_2 + SurfaceTolerance;
@@ -195,7 +214,7 @@ void SServices00_v01::BuildSitCables(PlacedVolume &pVol,
   Polycone SitConeSolid (0., 2.0 * M_PI, rmin, rmax, z);
 		
   Volume SitConeLog("SitConeLog",SitConeSolid,
-		    lcdd.material("aluminium"));
+		    theDetector.material("aluminium"));
   
   Position cone_pos(0, 0, 0);
   pVol = envelope.placeVolume(SitConeLog,cone_pos);
@@ -213,7 +232,7 @@ void SServices00_v01::BuildSitCables(PlacedVolume &pVol,
 		    0., 2 * M_PI);
 
   Volume SitDiskLog("SitDiskLog",SitDiskSolid,
-		    lcdd.material("aluminium"));
+		    theDetector.material("aluminium"));
   
   Position disk_pos1(0, 0, TUBE_IPOuterBulge_end_z + Sit_cables_disk_thickness/2.);
   pVol = envelope.placeVolume(SitDiskLog,disk_pos1);
@@ -233,7 +252,7 @@ void SServices00_v01::BuildSitCables(PlacedVolume &pVol,
 	    <<"\n   - SServices_FTD3_cone_thickness = "
 	    <<FTD3_cone_thickness
 	    <<"\n   - SServices_FTD7_cables_thickness = "
-	    <<lcdd.constant<double>("SServices_FTD7_cables_thickness")
+	    <<theDetector.constant<double>("SServices_FTD7_cables_thickness")
 	    <<std::endl;
 
 }
@@ -242,50 +261,50 @@ bool
 SServices00_v01::
 BuildTPCEndplateServices(PlacedVolume &pVol,
 			 Assembly &envelope,
-			 LCDD &lcdd)
+			 Detector &theDetector)
 {
    double tpcEndplateServices_R[MAX_TPC_RINGS], 
 	tpcEndplateServices_r[MAX_TPC_RINGS];
 
    tpcEndplateServices_R[0] = 
-	lcdd.constant<double>("tpcEndplateServicesRing1_R");
+	theDetector.constant<double>("tpcEndplateServicesRing1_R");
    tpcEndplateServices_r[0] = 
-	lcdd.constant<double>("tpcEndplateServicesRing1_ro");
+	theDetector.constant<double>("tpcEndplateServicesRing1_ro");
 
    tpcEndplateServices_R[1] = 
-	lcdd.constant<double>("tpcEndplateServicesRing2_R");
+	theDetector.constant<double>("tpcEndplateServicesRing2_R");
    tpcEndplateServices_r[1] = 
-	lcdd.constant<double>("tpcEndplateServicesRing2_ro");
+	theDetector.constant<double>("tpcEndplateServicesRing2_ro");
 
    tpcEndplateServices_R[2] = 
-	lcdd.constant<double>("tpcEndplateServicesRing3_R");
+	theDetector.constant<double>("tpcEndplateServicesRing3_R");
    tpcEndplateServices_r[2] = 
-	lcdd.constant<double>("tpcEndplateServicesRing3_ro");
+	theDetector.constant<double>("tpcEndplateServicesRing3_ro");
 
    tpcEndplateServices_R[3] = 
-	lcdd.constant<double>("tpcEndplateServicesRing4_R");
+	theDetector.constant<double>("tpcEndplateServicesRing4_R");
    tpcEndplateServices_r[3] = 
-	lcdd.constant<double>("tpcEndplateServicesRing4_ro");
+	theDetector.constant<double>("tpcEndplateServicesRing4_ro");
 
    tpcEndplateServices_R[4] = 
-	lcdd.constant<double>("tpcEndplateServicesRing5_R");
+	theDetector.constant<double>("tpcEndplateServicesRing5_R");
    tpcEndplateServices_r[4] = 
-	lcdd.constant<double>("tpcEndplateServicesRing5_ro");
+	theDetector.constant<double>("tpcEndplateServicesRing5_ro");
 
    tpcEndplateServices_R[5] = 
-	lcdd.constant<double>("tpcEndplateServicesRing6_R");
+	theDetector.constant<double>("tpcEndplateServicesRing6_R");
    tpcEndplateServices_r[5] = 
-	lcdd.constant<double>("tpcEndplateServicesRing6_ro");
+	theDetector.constant<double>("tpcEndplateServicesRing6_ro");
 
    tpcEndplateServices_R[6] = 
-	lcdd.constant<double>("tpcEndplateServicesRing7_R");
+	theDetector.constant<double>("tpcEndplateServicesRing7_R");
    tpcEndplateServices_r[6] = 
-	lcdd.constant<double>("tpcEndplateServicesRing7_ro");
+	theDetector.constant<double>("tpcEndplateServicesRing7_ro");
 
    tpcEndplateServices_R[7] = 
-	lcdd.constant<double>("tpcEndplateServicesRing8_R");
+	theDetector.constant<double>("tpcEndplateServicesRing8_R");
    tpcEndplateServices_r[7] = 
-	lcdd.constant<double>("tpcEndplateServicesRing8_ro");
+	theDetector.constant<double>("tpcEndplateServicesRing8_ro");
 
    for(int i=0; i<MAX_TPC_RINGS; i++) {
 
@@ -301,7 +320,7 @@ BuildTPCEndplateServices(PlacedVolume &pVol,
 		      0, 2*M_PI);
 
       Volume ringLogical("ringLogical",ringSolid,
-			 lcdd.material("copper"));
+			 theDetector.material("copper"));
 
       double z_position = TPC_Ecal_Hcal_barrel_halfZ + 
 	                  tpcEndplateServices_r[i];
@@ -372,7 +391,7 @@ bool
 SServices00_v01::
 BuildEcalBarrelServices(PlacedVolume &pVol,
 			Assembly &envelope,
-			LCDD &lcdd)
+			Detector &theDetector)
 {
 
   Box ContainerSolid(top_dim_x/2.,
@@ -381,9 +400,9 @@ BuildEcalBarrelServices(PlacedVolume &pVol,
 
   Volume containerLogical("EcalBarrelServicesContainerLogical",
 			  ContainerSolid,
-			  lcdd.material("air"));
+			  theDetector.material("air"));
 
-  if(!FillEcalBarrelServicesContainer(pVol,containerLogical,lcdd))
+  if(!FillEcalBarrelServicesContainer(pVol,containerLogical,theDetector))
 	return false;
 
   for (int stave_id = 1; stave_id < 9 ; stave_id++)
@@ -405,13 +424,13 @@ bool
 SServices00_v01::
 FillEcalBarrelServicesContainer(PlacedVolume &pVol,
 				Volume &pContainerLogical,
-				LCDD &lcdd)
+				Detector &theDetector)
 {
-  double RailDistanceToRight = lcdd.constant<double>("EcalBarrelServices_RailDistanceToRight");
+  double RailDistanceToRight = theDetector.constant<double>("EcalBarrelServices_RailDistanceToRight");
 
-  double RailSeparation = lcdd.constant<double>("EcalBarrelServices_RailSeparation");
+  double RailSeparation = theDetector.constant<double>("EcalBarrelServices_RailSeparation");
 
-  double RailWidth = lcdd.constant<double>("EcalBarrelServices_RailWidth");
+  double RailWidth = theDetector.constant<double>("EcalBarrelServices_RailWidth");
 
   bool RailSeparationChanged = false;
   if(fabs(
@@ -430,7 +449,7 @@ FillEcalBarrelServicesContainer(PlacedVolume &pVol,
 		TPC_Ecal_Hcal_barrel_halfZ); 
 
   Volume railLogical("RailLogical",railSolid,
-		     lcdd.material("aluminium"));
+		     theDetector.material("aluminium"));
  
   double railPosition = top_dim_x/2. - RailDistanceToRight - RailWidth/2.;
 
@@ -445,22 +464,22 @@ FillEcalBarrelServicesContainer(PlacedVolume &pVol,
   }
 
 //-Z thicknesses 
-  double ZMinus_FirstInterrail_PE_Thickness = lcdd.constant<double>("EcalBarrelServices_ZMinus_FirstInterrail_PE_Thickness");
+  double ZMinus_FirstInterrail_PE_Thickness = theDetector.constant<double>("EcalBarrelServices_ZMinus_FirstInterrail_PE_Thickness");
 
-  double ZMinus_FirstInterrail_Cu_Thickness = lcdd.constant<double>("EcalBarrelServices_ZMinus_FirstInterrail_Cu_Thickness");
+  double ZMinus_FirstInterrail_Cu_Thickness = theDetector.constant<double>("EcalBarrelServices_ZMinus_FirstInterrail_Cu_Thickness");
 
-  double ZMinus_SecondInterrail_Cu_Thickness = lcdd.constant<double>("EcalBarrelServices_ZMinus_SecondInterrail_Cu_Thickness");
+  double ZMinus_SecondInterrail_Cu_Thickness = theDetector.constant<double>("EcalBarrelServices_ZMinus_SecondInterrail_Cu_Thickness");
 
 //+Z thicknesses 
-  double ZPlus_FirstInterrail_PE_Thickness = lcdd.constant<double>("EcalBarrelServices_ZPlus_FirstInterrail_PE_Thickness");
+  double ZPlus_FirstInterrail_PE_Thickness = theDetector.constant<double>("EcalBarrelServices_ZPlus_FirstInterrail_PE_Thickness");
 
-  double ZPlus_FirstInterrail_Cu_Thickness = lcdd.constant<double>("EcalBarrelServices_ZPlus_FirstInterrail_Cu_Thickness");
+  double ZPlus_FirstInterrail_Cu_Thickness = theDetector.constant<double>("EcalBarrelServices_ZPlus_FirstInterrail_Cu_Thickness");
 
-  double ZPlus_SecondInterrail_Cu_Thickness = lcdd.constant<double>("EcalBarrelServices_ZPlus_SecondInterrail_Cu_Thickness");
+  double ZPlus_SecondInterrail_Cu_Thickness = theDetector.constant<double>("EcalBarrelServices_ZPlus_SecondInterrail_Cu_Thickness");
 
   if(RailSeparationChanged)
   {
-     double OldRailSeparation = lcdd.constant<double>("EcalBarrelServices_RailSeparation");
+     double OldRailSeparation = theDetector.constant<double>("EcalBarrelServices_RailSeparation");
 
      double fraction = OldRailSeparation / RailSeparation;
      ZMinus_FirstInterrail_PE_Thickness *= fraction;
@@ -483,7 +502,7 @@ FillEcalBarrelServicesContainer(PlacedVolume &pVol,
 		 moduleLength / 2.); 
 
      Volume PELogical("PELogical",PESolid,
-		      lcdd.material("polyethylene"));
+		      theDetector.material("polyethylene"));
 
      Position posPE(top_dim_x/2.-RailDistanceToRight-RailWidth-RailSeparation+x_half_dim,
 		    -RailHeight/2. + ZMinus_FirstInterrail_PE_Thickness/2.,
@@ -496,7 +515,7 @@ FillEcalBarrelServicesContainer(PlacedVolume &pVol,
 		    moduleLength / 2.); 
 
      Volume Cu_1_Logical("Cu_1_Logical",Cu_1_Solid,
-                        lcdd.material("copper"));
+                        theDetector.material("copper"));
 
      Position posCu1(top_dim_x/2.-RailDistanceToRight-RailWidth-RailSeparation+x_half_dim,
 		     -RailHeight/2. + ZMinus_FirstInterrail_PE_Thickness+ZMinus_FirstInterrail_Cu_Thickness/2.,
@@ -509,7 +528,7 @@ FillEcalBarrelServicesContainer(PlacedVolume &pVol,
 		    moduleLength / 2.); 
 
      Volume Cu_2_Logical("Cu_2_Logical",Cu_2_Solid,
-                        lcdd.material("copper"));
+                        theDetector.material("copper"));
 
      Position posCu2(top_dim_x/2.-RailDistanceToRight-2*RailWidth-2*RailSeparation+x_half_dim,
 		     -RailHeight/2. + ZMinus_SecondInterrail_Cu_Thickness/2.,
@@ -527,7 +546,7 @@ FillEcalBarrelServicesContainer(PlacedVolume &pVol,
 		 moduleLength / 2.); 
 
      Volume PELogical("PELogical",PESolid,
-		      lcdd.material("polyethylene"));
+		      theDetector.material("polyethylene"));
 
      Position posPE(top_dim_x/2.-RailDistanceToRight-RailWidth-RailSeparation+x_half_dim,
 		    -RailHeight/2. + ZPlus_FirstInterrail_PE_Thickness/2.,
@@ -541,7 +560,7 @@ FillEcalBarrelServicesContainer(PlacedVolume &pVol,
 		    moduleLength / 2.); 
 
      Volume Cu_1_Logical("Cu_1_Logical",Cu_1_Solid,
-                        lcdd.material("copper"));
+                        theDetector.material("copper"));
 
      Position posCu1(top_dim_x/2.-RailDistanceToRight-RailWidth-RailSeparation+x_half_dim,
 		     -RailHeight/2. + ZPlus_FirstInterrail_PE_Thickness+ZPlus_FirstInterrail_Cu_Thickness/2.,
@@ -555,7 +574,7 @@ FillEcalBarrelServicesContainer(PlacedVolume &pVol,
 		    moduleLength / 2.); 
 
      Volume Cu_2_Logical("Cu_2_Logical",Cu_2_Solid,
-                        lcdd.material("copper"));
+                        theDetector.material("copper"));
 
      Position posCu2(top_dim_x/2.-RailDistanceToRight-2*RailWidth-2*RailSeparation+x_half_dim,
 		     -RailHeight/2. + ZPlus_SecondInterrail_Cu_Thickness/2.,
@@ -596,17 +615,17 @@ bool
 SServices00_v01::
 BuildEcalBarrel_EndCapServices(PlacedVolume &pVol,
 			       Assembly &envelope,
-			       LCDD &lcdd)
+			       Detector &theDetector)
 {
 //-Z thicknesses 
-  double ZMinus_PE_Thickness = lcdd.constant<double>("EcalBarrel_EndCapServices_ZMinus_PE_Thickness");
+  double ZMinus_PE_Thickness = theDetector.constant<double>("EcalBarrel_EndCapServices_ZMinus_PE_Thickness");
 
-  double ZMinus_Cu_Thickness = lcdd.constant<double>("EcalBarrel_EndCapServices_ZMinus_Cu_Thickness");
+  double ZMinus_Cu_Thickness = theDetector.constant<double>("EcalBarrel_EndCapServices_ZMinus_Cu_Thickness");
 
 //+Z thicknesses 
-  double ZPlus_PE_Thickness = lcdd.constant<double>("EcalBarrel_EndCapServices_ZPlus_PE_Thickness");
+  double ZPlus_PE_Thickness = theDetector.constant<double>("EcalBarrel_EndCapServices_ZPlus_PE_Thickness");
 
-  double ZPlus_Cu_Thickness = lcdd.constant<double>("EcalBarrel_EndCapServices_ZPlus_Cu_Thickness");
+  double ZPlus_Cu_Thickness = theDetector.constant<double>("EcalBarrel_EndCapServices_ZPlus_Cu_Thickness");
 
   double containerThickness = ZMinus_PE_Thickness + ZMinus_Cu_Thickness;
   double z_position = -TPC_Ecal_Hcal_barrel_halfZ -containerThickness/2.;
@@ -628,7 +647,7 @@ BuildEcalBarrel_EndCapServices(PlacedVolume &pVol,
 		       containerThickness/2.); 
 
     Volume containerLogical("EcalBarrel_EndCapServicesContainerLogical",ContainerSolid,
-			    lcdd.material("air"));
+			    theDetector.material("air"));
 
 
     Box PESolid(container_x_dim/2.,
@@ -636,7 +655,7 @@ BuildEcalBarrel_EndCapServices(PlacedVolume &pVol,
 		PE_Thickness/2.); 
 
     Volume PELogical("EcalBarrel_EndCap_PELogical",PESolid,
-		     lcdd.material("polyethylene"));
+		     theDetector.material("polyethylene"));
 
     Position  PosPE(0,0,containerThickness/2. - PE_Thickness/2.);
       
@@ -648,7 +667,7 @@ BuildEcalBarrel_EndCapServices(PlacedVolume &pVol,
 		 Cu_Thickness/2.); 
 
     Volume Cu_Logical("EcalBarrel_EndCap_Cu_Logical",Cu_Solid,
-		      lcdd.material("copper"));
+		      theDetector.material("copper"));
 
     Position  PosCu(0,0,-containerThickness/2. + Cu_Thickness/2.);
       
@@ -706,7 +725,7 @@ BuildEcalBarrel_EndCapServices(PlacedVolume &pVol,
 	    <<"\n   - EcalBarrel_EndCapServices_ZPlus_PE_Thickness = "
 	    <<ZPlus_PE_Thickness
 	    <<"\n   - Ecal_Tpc_gap = "
-	    <<lcdd.constant<double>("Ecal_Tpc_gap")
+	    <<theDetector.constant<double>("Ecal_Tpc_gap")
 	    <<"\n   - Ecal_cables_gap = "
 	    <<Ecal_cables_gap
 	    <<"\n   - Ecal_outer_radius = "
@@ -721,14 +740,14 @@ bool
 SServices00_v01::
 BuildHcalBarrel_EndCapServices(PlacedVolume &pVol,
 			       Assembly &envelope,
-			       LCDD &lcdd)
+			       Detector &theDetector)
 {
   double Hcal_stave_gaps = 
-	lcdd.constant<double>("Hcal_stave_gaps");
+	theDetector.constant<double>("Hcal_stave_gaps");
   double Hcal_inner_radius = Ecal_outer_radius + 
-	lcdd.constant<double>("Hcal_Ecal_gap");
+	theDetector.constant<double>("Hcal_Ecal_gap");
   double Hcal_R_max = 
-	lcdd.constant<double>("Hcal_R_max");
+	theDetector.constant<double>("Hcal_R_max");
 
   Hcal_total_dim_y = Hcal_R_max * cos(M_PI/16) - Hcal_inner_radius;
   double Hcal_module_radius = Hcal_inner_radius + Hcal_total_dim_y;
@@ -775,24 +794,24 @@ BuildHcalBarrel_EndCapServices(PlacedVolume &pVol,
 
 
   Volume ModuleLogicalZMinus("ServicesHcalModuleZMinus", ModuleSolid,
-			     lcdd.material("air"));
+			     theDetector.material("air"));
 
 
   Volume  ModuleLogicalZPlus("ServicesHcalModuleZPlus", ModuleSolid,
-			     lcdd.material("air"));
+			     theDetector.material("air"));
 
   //First place layer models of services coming from Ecal and TPC:
   if(!FillHcalServicesModuleWithInnerServices(pVol,
-		      ModuleLogicalZMinus,ModuleLogicalZPlus,lcdd))
+		      ModuleLogicalZMinus,ModuleLogicalZPlus,theDetector))
       return false;
 
   //Then place layer models of HCAL electronics interface:
   int BuildHcalElectronicsInterface = 
-    lcdd.constant<int>("BuildHcalElectronicsInterface");
+    theDetector.constant<int>("BuildHcalElectronicsInterface");
 
   if(!(BuildHcalElectronicsInterface == 0))
     if(!FillHcalServicesModuleWithHcalElectronicsInterface(pVol,
-		        ModuleLogicalZMinus,ModuleLogicalZPlus,lcdd))
+		        ModuleLogicalZMinus,ModuleLogicalZPlus,theDetector))
       return false;
 
   double Y = Hcal_inner_radius + YX1H;
@@ -834,21 +853,21 @@ SServices00_v01::
 FillHcalServicesModuleWithInnerServices(PlacedVolume &pVol,
 					Volume &ModuleLogicalZMinus,
 					Volume &ModuleLogicalZPlus,
-					LCDD &lcdd)
+					Detector &theDetector)
 {
 //-Z thicknesses 
-  double ZMinus_StainlessSteel_Thickness = lcdd.constant<double>("HcalServicesModule_ZMinus_StainlessSteel_Thickness");
+  double ZMinus_StainlessSteel_Thickness = theDetector.constant<double>("HcalServicesModule_ZMinus_StainlessSteel_Thickness");
 
-  double ZMinus_PE_Thickness = lcdd.constant<double>("HcalServicesModule_ZMinus_PE_Thickness");
+  double ZMinus_PE_Thickness = theDetector.constant<double>("HcalServicesModule_ZMinus_PE_Thickness");
 
-  double ZMinus_Cu_Thickness = lcdd.constant<double>("HcalServicesModule_ZMinus_Cu_Thickness");
+  double ZMinus_Cu_Thickness = theDetector.constant<double>("HcalServicesModule_ZMinus_Cu_Thickness");
 
 //+Z thicknesses 
-  double ZPlus_StainlessSteel_Thickness = lcdd.constant<double>("HcalServicesModule_ZPlus_StainlessSteel_Thickness");
+  double ZPlus_StainlessSteel_Thickness = theDetector.constant<double>("HcalServicesModule_ZPlus_StainlessSteel_Thickness");
 
-  double ZPlus_PE_Thickness = lcdd.constant<double>("HcalServicesModule_ZPlus_PE_Thickness");
+  double ZPlus_PE_Thickness = theDetector.constant<double>("HcalServicesModule_ZPlus_PE_Thickness");
 
-  double ZPlus_Cu_Thickness = lcdd.constant<double>("HcalServicesModule_ZPlus_Cu_Thickness");
+  double ZPlus_Cu_Thickness = theDetector.constant<double>("HcalServicesModule_ZPlus_Cu_Thickness");
 
   double StainlessSteel_Thickness = ZMinus_StainlessSteel_Thickness;
   double Cu_Thickness = ZMinus_Cu_Thickness;
@@ -864,7 +883,7 @@ FillHcalServicesModuleWithInnerServices(PlacedVolume &pVol,
 			   Ecal_cables_gap/2. - StainlessSteel_Thickness/2.);
 
     if(!PlaceHcalInnerServicesLayer(pVol,motherLogical,
-		lcdd.material("stainless_steel"),
+		theDetector.material("stainless_steel"),
 		StainlessSteel_Thickness, layerPositionSteel))
 
 	return false;
@@ -873,7 +892,7 @@ FillHcalServicesModuleWithInnerServices(PlacedVolume &pVol,
 			   Ecal_cables_gap/2. -StainlessSteel_Thickness - PE_Thickness/2.);
 
     if(!PlaceHcalInnerServicesLayer(pVol,motherLogical,
-		lcdd.material("polyethylene"),
+		theDetector.material("polyethylene"),
 		PE_Thickness, layerPositionPoly))
 
 	return false;
@@ -883,7 +902,7 @@ FillHcalServicesModuleWithInnerServices(PlacedVolume &pVol,
 		Cu_Thickness/2.);
 
     if(!PlaceHcalInnerServicesLayer(pVol,motherLogical,
-		lcdd.material("copper"),
+		theDetector.material("copper"),
 		Cu_Thickness, layerPositionCopper))
 
 	return false;
@@ -913,23 +932,23 @@ FillHcalServicesModuleWithInnerServices(PlacedVolume &pVol,
 	    <<"\n   - HcalServicesModule_ZPlus_StainlessSteel_Thickness = "
 	    <<ZPlus_StainlessSteel_Thickness
 	    <<"\n   - HcalServices_outer_Cu_thickness = "
-	    <<lcdd.constant<double>("HcalServices_outer_Cu_thickness")
+	    <<theDetector.constant<double>("HcalServices_outer_Cu_thickness")
 	    <<"\n   - HcalServices_outer_FR4_thickness = "
-	    <<lcdd.constant<double>("HcalServices_outer_FR4_thickness")
+	    <<theDetector.constant<double>("HcalServices_outer_FR4_thickness")
 	    <<"\n   - Hcal_Ecal_gap = "
-	    <<lcdd.constant<double>("Hcal_Ecal_gap")
+	    <<theDetector.constant<double>("Hcal_Ecal_gap")
 	    <<"\n   - Hcal_R_max = "
-	    <<lcdd.constant<double>("Hcal_R_max")
+	    <<theDetector.constant<double>("Hcal_R_max")
 	    <<"\n   - Hcal_back_plate_thickness = "
-	    <<lcdd.constant<double>("Hcal_back_plate_thickness")
+	    <<theDetector.constant<double>("Hcal_back_plate_thickness")
 	    <<"\n   - Hcal_nlayers = "
-	    <<lcdd.constant<int>("Hcal_nlayers")
+	    <<theDetector.constant<int>("Hcal_nlayers")
 	    <<"\n   - Hcal_radiator_thickness = "
-	    <<lcdd.constant<double>("Hcal_radiator_thickness")
+	    <<theDetector.constant<double>("Hcal_radiator_thickness")
 	    <<"\n   - Hcal_stave_gaps = "
-	    <<lcdd.constant<int>("Hcal_stave_gaps")
+	    <<theDetector.constant<int>("Hcal_stave_gaps")
 	    <<"\n   - Hcal_steel_cassette_thickness = "
-	    <<lcdd.constant<double>("Hcal_steel_cassette_thickness")
+	    <<theDetector.constant<double>("Hcal_steel_cassette_thickness")
 	    <<std::endl;
 
    return true;
@@ -940,15 +959,15 @@ SServices00_v01::
 FillHcalServicesModuleWithHcalElectronicsInterface(PlacedVolume &pVol,
 						   Volume &ModuleLogicalZMinus,
 						   Volume &ModuleLogicalZPlus,
-						   LCDD &lcdd)
+						   Detector &theDetector)
 {
    std::cout<<"   - BuildHcalElectronicsInterface = true " <<std::endl;
 
-   double Hcal_back_plate_thickness = lcdd.constant<double>("Hcal_back_plate_thickness");
+   double Hcal_back_plate_thickness = theDetector.constant<double>("Hcal_back_plate_thickness");
   
-   double Hcal_nlayers = lcdd.constant<int>("Hcal_nlayers");
+   double Hcal_nlayers = theDetector.constant<int>("Hcal_nlayers");
 
-   double Hcal_radiator_thickness = lcdd.constant<double>("Hcal_radiator_thickness");
+   double Hcal_radiator_thickness = theDetector.constant<double>("Hcal_radiator_thickness");
 
    double Hcal_layer_thickenss = 
 	(Hcal_total_dim_y - Hcal_back_plate_thickness) / Hcal_nlayers;
@@ -985,7 +1004,7 @@ G4cout << "Hcal Barrel-EndCap services: Hcal_chamber_thickness = " <<
 
 	if(!FillHcalElectronicsInterfaceLayer(pVol,
                 ModuleLogicalZMinus, ModuleLogicalZPlus,
-		layer_y_offset, layer_x_dim,lcdd))
+		layer_y_offset, layer_x_dim,theDetector))
 		
 		return false;
  
@@ -1000,10 +1019,10 @@ FillHcalElectronicsInterfaceLayer(PlacedVolume &pVol,
 				  Volume &ModuleLogicalZMinus,
 				  Volume &ModuleLogicalZPlus,
 				  double layer_y_offset, double layer_x_dim,
-				  LCDD &lcdd)
+				  Detector &theDetector)
 {
    double Hcal_y_dim1_for_x  = Hcal_total_dim_y - Hcal_y_dim2_for_x;
-   double Hcal_steel_cassette_thickness = lcdd.constant<double>("Hcal_steel_cassette_thickness");
+   double Hcal_steel_cassette_thickness = theDetector.constant<double>("Hcal_steel_cassette_thickness");
 
    double y_position = -Hcal_y_dim1_for_x/2. + layer_y_offset +
 		Hcal_steel_cassette_thickness/2.;
@@ -1011,12 +1030,12 @@ FillHcalElectronicsInterfaceLayer(PlacedVolume &pVol,
    if(!PlaceHcalElectronicsInterfaceComponent(pVol,
 					      ModuleLogicalZMinus,
 					      ModuleLogicalZPlus,
-					      lcdd.material("S235"),
+					      theDetector.material("S235"),
 					      Hcal_steel_cassette_thickness,y_position,layer_x_dim)
       )
 		return false;
 
-   double FR4_thickness = lcdd.constant<double>("HcalServices_outer_FR4_thickness");
+   double FR4_thickness = theDetector.constant<double>("HcalServices_outer_FR4_thickness");
 
    y_position += (Hcal_steel_cassette_thickness/2. +
 			FR4_thickness/2.);
@@ -1024,19 +1043,19 @@ FillHcalElectronicsInterfaceLayer(PlacedVolume &pVol,
    if(!PlaceHcalElectronicsInterfaceComponent(pVol,
 					      ModuleLogicalZMinus,
 					      ModuleLogicalZPlus,
-					      lcdd.material("PCB"),
+					      theDetector.material("PCB"),
 					      FR4_thickness,y_position,layer_x_dim)
       )
 		return false;
 
-   double Cu_thickness = lcdd.constant<double>("HcalServices_outer_Cu_thickness");
+   double Cu_thickness = theDetector.constant<double>("HcalServices_outer_Cu_thickness");
 
    y_position += (FR4_thickness/2. + Cu_thickness/2.);
 
    if(!PlaceHcalElectronicsInterfaceComponent(pVol,
 					      ModuleLogicalZMinus,
 					      ModuleLogicalZPlus,
-					      lcdd.material("copper"),
+					      theDetector.material("copper"),
 					      Cu_thickness,y_position,layer_x_dim)
       )
 		return false;

--- a/detector/other/SServices00_v01.h
+++ b/detector/other/SServices00_v01.h
@@ -32,23 +32,6 @@
 #include <string>
 
 using namespace std;
-using namespace DD4hep;
-using namespace DD4hep::Geometry;
-using namespace DD4hep::DDRec;
-using namespace DDSurfaces;
-
-using DD4hep::Geometry::Transform3D;
-using DD4hep::Geometry::Position;
-using DD4hep::Geometry::RotationY;
-using DD4hep::Geometry::RotateY;
-using DD4hep::Geometry::ConeSegment;
-using DD4hep::Geometry::SubtractionSolid;
-using DD4hep::Geometry::Material;
-using DD4hep::Geometry::Volume;
-using DD4hep::Geometry::Solid;
-using DD4hep::Geometry::Tube;
-using DD4hep::Geometry::PlacedVolume;
-using DD4hep::Geometry::Assembly;
 
 class SServices00_v01
 {
@@ -58,75 +41,75 @@ class SServices00_v01
   ~SServices00_v01();
 
    bool
-   BuildServices(PlacedVolume &pVol,
-		 Assembly &envelope,
-		 LCDD &lcdd);
+   BuildServices(dd4hep::PlacedVolume &pVol,
+		 dd4hep::Assembly &envelope,
+		 dd4hep::Detector &theDetector);
 private:
 
    bool
-   BuildTPCEndplateServices(PlacedVolume &pVol,
-			    Assembly &envelope,
-			    LCDD &lcdd);
+   BuildTPCEndplateServices(dd4hep::PlacedVolume &pVol,
+			    dd4hep::Assembly &envelope,
+			    dd4hep::Detector &theDetector);
    
    bool
-   BuildEcalBarrelServices(PlacedVolume &pVol,
-			   Assembly &envelope,
-			   LCDD &lcdd);
+   BuildEcalBarrelServices(dd4hep::PlacedVolume &pVol,
+			   dd4hep::Assembly &envelope,
+			   dd4hep::Detector &theDetector);
    
    bool
-   BuildEcalBarrel_EndCapServices(PlacedVolume &pVol,
-				  Assembly &envelope,
-				  LCDD &lcdd);
+   BuildEcalBarrel_EndCapServices(dd4hep::PlacedVolume &pVol,
+				  dd4hep::Assembly &envelope,
+				  dd4hep::Detector &theDetector);
 
    bool
-   BuildHcalBarrel_EndCapServices(PlacedVolume &pVol,
-				  Assembly &envelope,
-				  LCDD &lcdd);
+   BuildHcalBarrel_EndCapServices(dd4hep::PlacedVolume &pVol,
+				  dd4hep::Assembly &envelope,
+				  dd4hep::Detector &theDetector);
 
    bool
-   FillEcalBarrelServicesContainer(PlacedVolume &pVol,
-				   Volume &pContainerLogical,
-				   LCDD &lcdd);
+   FillEcalBarrelServicesContainer(dd4hep::PlacedVolume &pVol,
+				   dd4hep::Volume &pContainerLogical,
+				   dd4hep::Detector &theDetector);
    
    bool
-   FillHcalServicesModuleWithInnerServices(PlacedVolume &pVol,
-					   Volume &ModuleLogicalZMinus,
-					   Volume &ModuleLogicalZPlus,
-					   LCDD &lcdd);
+   FillHcalServicesModuleWithInnerServices(dd4hep::PlacedVolume &pVol,
+					   dd4hep::Volume &ModuleLogicalZMinus,
+					   dd4hep::Volume &ModuleLogicalZPlus,
+					   dd4hep::Detector &theDetector);
 
    
    bool
-   PlaceHcalInnerServicesLayer(PlacedVolume &pVol,Volume &,
-			       Material, double, Position &);
+   PlaceHcalInnerServicesLayer(dd4hep::PlacedVolume &pVol,dd4hep::Volume &,
+			       dd4hep::Material, double, dd4hep::Position &);
    
    bool
-   FillHcalServicesModuleWithHcalElectronicsInterface(PlacedVolume &pVol,
-						      Volume &ModuleLogicalZMinus,
-						      Volume &ModuleLogicalZPlus,
-						      LCDD &lcdd);
+   FillHcalServicesModuleWithHcalElectronicsInterface(dd4hep::PlacedVolume &pVol,
+						      dd4hep::Volume &ModuleLogicalZMinus,
+						      dd4hep::Volume &ModuleLogicalZPlus,
+						      dd4hep::Detector &theDetector);
 
    
 
    bool
-   FillHcalElectronicsInterfaceLayer(PlacedVolume &pVol,
-				     Volume &ModuleLogicalZMinus,
-				     Volume &ModuleLogicalZPlus,
+   FillHcalElectronicsInterfaceLayer(dd4hep::PlacedVolume &pVol,
+				     dd4hep::Volume &ModuleLogicalZMinus,
+				     dd4hep::Volume &ModuleLogicalZPlus,
 				     double, double,
-				     LCDD &lcdd);
+				     dd4hep::Detector &theDetector);
    
    bool
-   PlaceHcalElectronicsInterfaceComponent(PlacedVolume &pVol,
-					  Volume &ModuleLogicalZMinus,
-					  Volume &ModuleLogicalZPlus,
-					  Material layerMaterial,
+   PlaceHcalElectronicsInterfaceComponent(dd4hep::PlacedVolume &pVol,
+					  dd4hep::Volume &ModuleLogicalZMinus,
+					  dd4hep::Volume &ModuleLogicalZPlus,
+					  dd4hep::Material layerMaterial,
 					  double, double, double);
 
-   Solid CutLayer(Solid &, double);
+   dd4hep::Solid CutLayer(dd4hep::Solid &, double);
       
    void
-   BuildSitCables(PlacedVolume &pVol,
-		  Assembly &envelope,
-		  LCDD &lcdd);
+   BuildSitCables(dd4hep::PlacedVolume &pVol,
+		  dd4hep::Assembly &envelope,
+		  dd4hep::Detector &theDetector);
 
    string FTD_db_name;
    double TPC_inner_radius;

--- a/detector/other/Solenoid_o1_v01_gep.cpp
+++ b/detector/other/Solenoid_o1_v01_gep.cpp
@@ -7,10 +7,33 @@
 
 
 using namespace std;
-using namespace DD4hep;
-using namespace DD4hep::Geometry;
 
-static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
+using dd4hep::Assembly;
+using dd4hep::BUILD_ENVELOPE;
+using dd4hep::Box;
+using dd4hep::DetElement;
+using dd4hep::Detector;
+using dd4hep::IntersectionSolid;
+using dd4hep::Material;
+using dd4hep::PlacedVolume;
+using dd4hep::Polycone;
+using dd4hep::Position;
+using dd4hep::Ref_t;
+using dd4hep::RotationZYX;
+using dd4hep::SensitiveDetector;
+using dd4hep::Solid;
+using dd4hep::SubtractionSolid;
+using dd4hep::Torus;
+using dd4hep::Transform3D;
+using dd4hep::Trapezoid;
+using dd4hep::Tube;
+using dd4hep::UnionSolid;
+using dd4hep::Volume;
+using dd4hep::_toString;
+
+using dd4hep::rec::LayeredCalorimeterData;
+
+static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector sens)  {
     xml_det_t     x_det     = e;
     int           det_id    = x_det.id();
     string        det_name  = x_det.nameStr();
@@ -19,23 +42,23 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
     
     // --- create an envelope volume and position it into the world ---------------------
     
-    Volume envelope = XML::createPlacedEnvelope( lcdd,  e , sdet ) ;
-    XML::setDetectorTypeFlag( e, sdet ) ;
+    Volume envelope = dd4hep::xml::createPlacedEnvelope( theDetector,  e , sdet ) ;
+    dd4hep::xml::setDetectorTypeFlag( e, sdet ) ;
 
-    if( lcdd.buildType() == BUILD_ENVELOPE ) return sdet ;
+    if( theDetector.buildType() == BUILD_ENVELOPE ) return sdet ;
     
     //-----------------------------------------------------------------------------------
     
  
-    Material air = lcdd.air();
+    Material air = theDetector.air();
     PlacedVolume pv;
     int n = 0;
 
     //added code by Thorben Quast for event display
-    DDRec::LayeredCalorimeterData* solenoidData = new DDRec::LayeredCalorimeterData;
+    LayeredCalorimeterData* solenoidData = new LayeredCalorimeterData;
     solenoidData->inner_symmetry = 0;
     solenoidData->outer_symmetry = 0;
-    solenoidData->layoutType = DDRec::LayeredCalorimeterData::BarrelLayout ;
+    solenoidData->layoutType = LayeredCalorimeterData::BarrelLayout ;
 
     double inner_radius= std::numeric_limits<double>::max();
     double outer_radius= 0;
@@ -56,13 +79,13 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
 
         for(xml_coll_t j(x_layer,_U(slice)); j; ++j, ++m)  {
             xml_comp_t x_slice = j;
-            Material mat = lcdd.material(x_slice.materialStr());
+            Material mat = theDetector.material(x_slice.materialStr());
             string s_name= l_name+_toString(m,"_slice%d");
             double thickness = x_slice.thickness();
 
             //NN: These probably need to be fixed and ced modified to read the extent, rather than the layer
             //added code by Thorben Quast for event display
-            DDRec::LayeredCalorimeterData::Layer solenoidLayer;
+            LayeredCalorimeterData::Layer solenoidLayer;
             solenoidLayer.distance = r;
 
             solenoidLayer.inner_thickness = thickness/2.;
@@ -81,7 +104,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
                 s_vol.setSensitiveDetector(sens);
             }
             // Set Attributes
-            s_vol.setAttributes(lcdd,x_slice.regionStr(),x_slice.limitsStr(),x_slice.visStr());
+            s_vol.setAttributes(theDetector,x_slice.regionStr(),x_slice.limitsStr(),x_slice.visStr());
             pv = l_vol.placeVolume(s_vol);
             // Slices have no extra id. Take the ID of the layer!
             pv.addPhysVolID("slice",m);
@@ -98,7 +121,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
             outer_radius = r;
         
         //cout << l_name << " " << rmin << " " << r << " " << z << endl;
-        l_vol.setVisAttributes(lcdd,x_layer.visStr());
+        l_vol.setVisAttributes(theDetector,x_layer.visStr());
         
         pv = envelope.placeVolume(l_vol);
         pv.addPhysVolID("layer",n);
@@ -115,7 +138,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
     solenoidData->extent[3] = detZ;
     
     //added code by Thorben Quast for event display
-    sdet.addExtension< DDRec::LayeredCalorimeterData >( solenoidData ) ;
+    sdet.addExtension< LayeredCalorimeterData >( solenoidData ) ;
 
 
     return sdet;

--- a/detector/other/TrackerBarrelSupport_o1_v01.cpp
+++ b/detector/other/TrackerBarrelSupport_o1_v01.cpp
@@ -11,26 +11,37 @@
 #include <string>
 
 using namespace std;
-using namespace DD4hep;
-using namespace DD4hep::Geometry;
-using namespace DD4hep::DDRec ;
-using namespace DDSurfaces ;
 
-using DD4hep::Geometry::Transform3D;
-using DD4hep::Geometry::Position;
-using DD4hep::Geometry::RotationY;
-using DD4hep::Geometry::RotateY;
-using DD4hep::Geometry::ConeSegment;
-using DD4hep::Geometry::SubtractionSolid;
-using DD4hep::Geometry::Material;
-using DD4hep::Geometry::Volume;
-using DD4hep::Geometry::Solid;
-using DD4hep::Geometry::Tube;
-using DD4hep::Geometry::PlacedVolume;
-using DD4hep::Geometry::Assembly;
+using dd4hep::Assembly;
+using dd4hep::BUILD_ENVELOPE;
+using dd4hep::Box;
+using dd4hep::DetElement;
+using dd4hep::Detector;
+using dd4hep::IntersectionSolid;
+using dd4hep::Material;
+using dd4hep::PlacedVolume;
+using dd4hep::Polycone;
+using dd4hep::Position;
+using dd4hep::Ref_t;
+using dd4hep::RotationZYX;
+using dd4hep::SensitiveDetector;
+using dd4hep::Solid;
+using dd4hep::SubtractionSolid;
+using dd4hep::Torus;
+using dd4hep::Transform3D;
+using dd4hep::Trapezoid;
+using dd4hep::Tube;
+using dd4hep::UnionSolid;
+using dd4hep::Volume;
+using dd4hep::_toString;
 
-static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector )
-{
+using dd4hep::rec::LayeredCalorimeterData;
+using dd4hep::rec::Vector3D;
+using dd4hep::rec::VolCylinder;
+using dd4hep::rec::volSurfaceList;
+using dd4hep::rec::SurfaceType;
+
+static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector)  {
   //static double tolerance = 0e0;
 
   xml_det_t     x_det     = e;
@@ -38,11 +49,11 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector )
   string        det_name  = x_det.nameStr();
   DetElement    sdet(det_name, det_id);
 
-  Volume envelope = XML::createPlacedEnvelope(lcdd,  e , sdet) ;
+  Volume envelope = dd4hep::xml::createPlacedEnvelope(theDetector,  e , sdet) ;
 
-  if (lcdd.buildType() == BUILD_ENVELOPE) return sdet ;
+  if (theDetector.buildType() == BUILD_ENVELOPE) return sdet ;
 
-  Material air = lcdd.air();
+  Material air = theDetector.air();
   PlacedVolume pv;
   int n = 0;
 
@@ -59,7 +70,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector )
 
     for (xml_coll_t j(x_layer, _U(slice)); j; ++j, ++m)  {
       xml_comp_t x_slice = j;
-      Material mat = lcdd.material(x_slice.materialStr());
+      Material mat = theDetector.material(x_slice.materialStr());
       string s_name = l_name + _toString(m, "_slice%d");
       double thickness = x_slice.thickness();
 
@@ -77,14 +88,14 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector )
       r += thickness;
 
       // Set Attributes
-      s_vol.setAttributes(lcdd, x_slice.regionStr(), x_slice.limitsStr(), x_slice.visStr());
+      s_vol.setAttributes(theDetector, x_slice.regionStr(), x_slice.limitsStr(), x_slice.visStr());
       pv = l_vol.placeVolume(s_vol);
       // Slices have no extra id. Take the ID of the layer!
       pv.addPhysVolID("slice", m);
     }
     l_tub.setDimensions(rmin, r, z);
     //cout << l_name << " " << rmin << " " << r << " " << z << endl;
-    l_vol.setVisAttributes(lcdd, x_layer.visStr());
+    l_vol.setVisAttributes(theDetector, x_layer.visStr());
 
     pv = envelope.placeVolume(l_vol);
     pv.addPhysVolID("layer", n);

--- a/detector/other/TrackerBarrel_surfaces.cpp
+++ b/detector/other/TrackerBarrel_surfaces.cpp
@@ -22,6 +22,11 @@ namespace {
 #define DD4HEP_USE_SURFACEINSTALL_HELPER TrackerBarrelSurfacePlugin
 #include "DD4hep/SurfaceInstaller.h"
 
+using dd4hep::DetElement;
+using dd4hep::PlacedVolume;
+using dd4hep::Volume;
+using dd4hep::Box;
+
 namespace{
   template <> void Installer<UserData>::handle_arguments(int argc, char** argv)   {
     for(int i=0; i<argc; ++i)  {
@@ -29,7 +34,7 @@ namespace{
       char* ptr = ::strchr(argv[i],'=');
       if ( ptr )  {
         std::string name( argv[i] , ptr ) ;
-        value = DD4hep::_toDouble(++ptr);
+        value = dd4hep::_toDouble(++ptr);
         if( name=="dimension" ) data.dimension = value ; 
         std::cout << "TrackerBarrelSurfacePlugin: argument[" << i << "] = " << name 
                   << " = " << value << std::endl;
@@ -43,7 +48,7 @@ namespace{
     Volume comp_vol = pv.volume();
     if ( comp_vol.isSensitive() )  {  
       Volume mod_vol  = parentVolume(component);
-      DD4hep::Geometry::Box mod_shape(mod_vol.solid()), comp_shape(comp_vol.solid());
+      Box mod_shape(mod_vol.solid()), comp_shape(comp_vol.solid());
       
       if ( !comp_shape.isValid() || !mod_shape.isValid() )   {
         invalidInstaller("Components and/or modules are not boxes -- invalid shapes");

--- a/detector/other/TrackerEndcapSupport_o1_v01.cpp
+++ b/detector/other/TrackerEndcapSupport_o1_v01.cpp
@@ -11,36 +11,44 @@
 #include <string>
 
 using namespace std;
-using namespace DD4hep;
-using namespace DD4hep::Geometry;
-using namespace DD4hep::DDRec ;
-using namespace DDSurfaces ;
 
-using DD4hep::Geometry::Transform3D;
-using DD4hep::Geometry::Position;
-using DD4hep::Geometry::RotationY;
-using DD4hep::Geometry::RotateY;
-using DD4hep::Geometry::ConeSegment;
-using DD4hep::Geometry::SubtractionSolid;
-using DD4hep::Geometry::Material;
-using DD4hep::Geometry::Volume;
-using DD4hep::Geometry::Solid;
-using DD4hep::Geometry::Tube;
-using DD4hep::Geometry::PlacedVolume;
-using DD4hep::Geometry::Assembly;
+using dd4hep::Assembly;
+using dd4hep::ConeSegment;
+using dd4hep::Material;
+using dd4hep::PlacedVolume;
+using dd4hep::Position;
+using dd4hep::Ref_t;
+using dd4hep::RotateY;
+using dd4hep::RotationY;
+using dd4hep::Solid;
+using dd4hep::SubtractionSolid;
+using dd4hep::Transform3D;
+using dd4hep::Tube;
+using dd4hep::Volume;
+using dd4hep::Detector;
+using dd4hep::SensitiveDetector;
+using dd4hep::DetElement;
+using dd4hep::BUILD_ENVELOPE;
+using dd4hep::_toString;
 
-static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector)
+using dd4hep::rec::Vector3D;
+using dd4hep::rec::VolSurfaceHandle;
+using dd4hep::rec::VolPlaneImpl;
+using dd4hep::rec::SurfaceType;
+using dd4hep::rec::volSurfaceList;
+
+static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector)
 {
   xml_det_t     x_det     = e;
   int           det_id    = x_det.id();
   string        det_name  = x_det.nameStr();
   DetElement    sdet(det_name, det_id);
 
-  Volume envelope = XML::createPlacedEnvelope(lcdd,  e , sdet) ;
+  Volume envelope = dd4hep::xml::createPlacedEnvelope(theDetector,  e , sdet) ;
 
-  if (lcdd.buildType() == BUILD_ENVELOPE) return sdet ;
+  if (theDetector.buildType() == BUILD_ENVELOPE) return sdet ;
 
-  Material   air       = lcdd.air();
+  Material   air       = theDetector.air();
   bool       reflect   = x_det.reflect();
 
   PlacedVolume pv;
@@ -61,11 +69,11 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector)
     }
     Tube    l_tub(rmin, rmax, layerWidth, 2 * M_PI);
     Volume  l_vol(l_nam, l_tub, air);
-    l_vol.setVisAttributes(lcdd, x_layer.visStr());
+    l_vol.setVisAttributes(theDetector, x_layer.visStr());
     for (xml_coll_t j(x_layer, _U(slice)); j; ++j, ++s_num)  {
       xml_comp_t x_slice = j;
       double thick = x_slice.thickness();
-      Material mat = lcdd.material(x_slice.materialStr());
+      Material mat = theDetector.material(x_slice.materialStr());
       string s_nam = l_nam + _toString(s_num, "_slice%d");
       Volume s_vol(s_nam, Tube(rmin, rmax, thick/2.), mat); //NN: Tube is a MyConeSeg, takes half thickness
 
@@ -80,7 +88,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector)
 	  volSurfaceList( sdet )->push_back( cylSurf1 );
 	   
 
-      s_vol.setAttributes(lcdd, x_slice.regionStr(), x_slice.limitsStr(), x_slice.visStr());
+      s_vol.setAttributes(theDetector, x_slice.regionStr(), x_slice.limitsStr(), x_slice.visStr());
       pv = l_vol.placeVolume(s_vol, Position(0, 0, z - zmin - layerWidth / 2 + thick / 2));
       pv.addPhysVolID("sensor", s_num);
     }
@@ -94,11 +102,11 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector)
     if (reflect)  {
 	  Tube    l_tub2(rmin, rmax, layerWidth, 2 * M_PI);
       Volume  l_vol2(l_nam, l_tub2, air);
-      l_vol2.setVisAttributes(lcdd, x_layer.visStr());
+      l_vol2.setVisAttributes(theDetector, x_layer.visStr());
       for (xml_coll_t j(x_layer, _U(slice)); j; ++j, ++s_num)  {
         xml_comp_t x_slice = j;
         double thick = x_slice.thickness();
-        Material mat = lcdd.material(x_slice.materialStr());
+        Material mat = theDetector.material(x_slice.materialStr());
         string s_nam = l_nam + _toString(s_num, "_slice%d");
         Volume s_vol2(s_nam, Tube(rmin, rmax, thick), mat);
 
@@ -113,7 +121,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector)
 	    volSurfaceList( sdet )->push_back( cylSurf2 );
 	   
 
-        s_vol2.setAttributes(lcdd, x_slice.regionStr(), x_slice.limitsStr(), x_slice.visStr());
+        s_vol2.setAttributes(theDetector, x_slice.regionStr(), x_slice.limitsStr(), x_slice.visStr());
         pv = l_vol2.placeVolume(s_vol2, Position(0, 0, -1.*(z - zmin - layerWidth / 2 + thick / 2)));
         pv.addPhysVolID("sensor", s_num);
       }

--- a/detector/other/TrackerEndcap_surfaces.cpp
+++ b/detector/other/TrackerEndcap_surfaces.cpp
@@ -16,11 +16,11 @@
 
 /// Install measurement surfaces
 template <typename UserData> 
-void Installer<UserData>::install(DetElement component, PlacedVolume pv)   {
-  Volume comp_vol = pv.volume();
+void Installer<UserData>::install(dd4hep::DetElement component, dd4hep::PlacedVolume pv)   {
+  dd4hep::Volume comp_vol = pv.volume();
   if ( comp_vol.isSensitive() )  {  
-    Volume mod_vol = parentVolume(component);
-    DD4hep::Geometry::Trapezoid comp_shape(comp_vol.solid()), mod_shape(mod_vol.solid());
+    dd4hep::Volume mod_vol = parentVolume(component);
+    dd4hep::Trapezoid comp_shape(comp_vol.solid()), mod_shape(mod_vol.solid());
 
     if ( !comp_shape.isValid() || !mod_shape.isValid() )   {
       invalidInstaller("Components and/or modules are not Trapezoid -- invalid shapes");

--- a/detector/other/createEnvelope.cpp
+++ b/detector/other/createEnvelope.cpp
@@ -9,10 +9,20 @@
 #include "DD4hep/DetFactoryHelper.h"
 
 using namespace std;
-using namespace DD4hep;
-using namespace DD4hep::Geometry;
 
-static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector /*sens*/)  {
+using dd4hep::Box;
+using dd4hep::DetElement;
+using dd4hep::Detector;
+using dd4hep::Material;
+using dd4hep::PlacedVolume;
+using dd4hep::Position;
+using dd4hep::Ref_t;
+using dd4hep::RotationZYX;
+using dd4hep::SensitiveDetector;
+using dd4hep::Transform3D;
+using dd4hep::Volume;
+
+static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector /*sens*/)  {
 
   xml_det_t     x_det     = e;
 
@@ -21,7 +31,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector /*sens*/)  {
 
   xml_comp_t    x_dim     = x_det.dimensions();
 
-  Material      env_mat   = lcdd.material(x_dim.materialStr());
+  Material      env_mat   = theDetector.material(x_dim.materialStr());
 
   xml_comp_t    env_pos     = x_det.position();
   xml_comp_t    env_rot     = x_det.rotation();
@@ -32,7 +42,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector /*sens*/)  {
   Transform3D   tr(rotZYX,pos);
 
   DetElement    sdet      (det_name,det_id);
-  Volume        motherVol = lcdd.pickMotherVolume(sdet);
+  Volume        motherVol = theDetector.pickMotherVolume(sdet);
 
   // https://root.cern.ch/root/html/TGeoShape.html
   // TNamed <- TGeoShape <- TGeoBBox <- TGeoCompositeShape
@@ -45,7 +55,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector /*sens*/)  {
   PlacedVolume  env_phv   =  motherVol.placeVolume(envelope,tr);
   sdet.setPlacement( env_phv ) ;
 
-  envelope.setAttributes(lcdd,x_det.regionStr(),x_det.limitsStr(),x_det.visStr());
+  envelope.setAttributes(theDetector,x_det.regionStr(),x_det.limitsStr(),x_det.visStr());
   return sdet;
 }
 

--- a/detector/tracker/SET_Simple_Planar_geo.cpp
+++ b/detector/tracker/SET_Simple_Planar_geo.cpp
@@ -16,10 +16,7 @@
 //#include "GearWrapper.h"
 
 using namespace std;
-using namespace DD4hep;
-//using namespace dd4hep ;
-using namespace DD4hep::Geometry;
-using namespace DDRec ;
+using namespace dd4hep::rec;
 
 /** helper struct */
 struct SET_Layer {
@@ -54,7 +51,7 @@ struct extended_reconstruction_parameters {
  *
  *  @author: F.Gaede, DESY, Jan 2014
  */
-static Ref_t create_element(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
+static dd4hep::Ref_t create_element(dd4hep::Detector& theDetector, xml_h e, dd4hep::SensitiveDetector sens)  {
 
   //------------------------------------------
   //  See comments starting with '//**' for
@@ -65,15 +62,15 @@ static Ref_t create_element(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
   xml_det_t    x_det = e;
   string       name  = x_det.nameStr();
 
-  DetElement   set(  name, x_det.id()  ) ;
+  dd4hep::DetElement   set(  name, x_det.id()  ) ;
   
   // --- create an envelope volume and position it into the world ---------------------
   
-  Volume envelope = XML::createPlacedEnvelope( lcdd,  e , set ) ;
+  dd4hep::Volume envelope = dd4hep::xml::createPlacedEnvelope( theDetector,  e , set ) ;
   
-  XML::setDetectorTypeFlag( e, set ) ;
+  dd4hep::xml::setDetectorTypeFlag( e, set ) ;
 
-  if( lcdd.buildType() == BUILD_ENVELOPE ) return set ;
+  if( theDetector.buildType() == dd4hep::BUILD_ENVELOPE ) return set ;
   
   //-----------------------------------------------------------------------------------
 
@@ -84,7 +81,7 @@ static Ref_t create_element(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
   sens.setType("tracker");
 
   
-  DDRec::ZPlanarData*  zPlanarData = new ZPlanarData ;
+  dd4hep::rec::ZPlanarData*  zPlanarData = new ZPlanarData ;
 
   //######################################################################################################################################################################
   //  code ported from SET_Simple_Planar::construct() :
@@ -120,9 +117,9 @@ static Ref_t create_element(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
   
   // _e_r_p.sensor_length_mm  =sensor_length;
 
-  Material air = lcdd.air()  ;
-  Material sensitiveMat = lcdd.material(db->fetchString("sensitive_mat"));  
-  Material supportMat   = lcdd.material(db->fetchString("support_mat"));  
+  dd4hep::Material air = theDetector.air()  ;
+  dd4hep::Material sensitiveMat = theDetector.material(db->fetchString("sensitive_mat"));  
+  dd4hep::Material supportMat   = theDetector.material(db->fetchString("support_mat"));  
   
   
   // // // setup the encoder 
@@ -150,8 +147,8 @@ static Ref_t create_element(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
   // // RegisterSensitiveDetector(_theSETSD);
   
 
-  const double TPC_outer_radius = lcdd.constant<double>("TPC_outer_radius");
-  const double TPC_Ecal_Hcal_barrel_halfZ = lcdd.constant<double>("TPC_Ecal_Hcal_barrel_halfZ");
+  const double TPC_outer_radius = theDetector.constant<double>("TPC_outer_radius");
+  const double TPC_Ecal_Hcal_barrel_halfZ = theDetector.constant<double>("TPC_Ecal_Hcal_barrel_halfZ");
 
   for(xml_coll_t c( x_det ,_U(layer)); c; ++c)  {
     
@@ -177,10 +174,10 @@ static Ref_t create_element(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
 
         
     // create assembly and DetElement for the layer
-    std::string layerName = _toString( layer_id , "layer_%d"  );
-    Assembly layer_assembly( layerName ) ;
-    PlacedVolume pv = envelope.placeVolume( layer_assembly ) ;
-    DetElement layerDE( set , layerName  , x_det.id() );
+    std::string layerName = dd4hep::_toString( layer_id , "layer_%d" );
+    dd4hep::Assembly layer_assembly( layerName ) ;
+    dd4hep::PlacedVolume pv = envelope.placeVolume( layer_assembly ) ;
+    dd4hep::DetElement layerDE( set , layerName  , x_det.id() );
     layerDE.setPlacement( pv ) ;
 
 
@@ -216,7 +213,7 @@ static Ref_t create_element(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
     //   (*Control::globalModelParameters)["SET2_Half_Length_Z"] = osshalfz.str();
     // }
     
-    DDRec::ZPlanarData::LayerLayout thisLayer ;
+    dd4hep::rec::ZPlanarData::LayerLayout thisLayer ;
     thisLayer.sensorsPerLadder = number_of_sensors_per_half * 2.0 ;
     thisLayer.lengthSensor     = sensor_length ;
     
@@ -275,28 +272,29 @@ static Ref_t create_element(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
 
     // create an enclosing ladder volume that will be placed in the world volume for every ladder
         
-    Box setLadderSolid( (sensitive_thickness +support_thickness ) / 2.0 ,
-			layer_geom.ladder_width / 2.0,
-			layer_geom.half_z);
+    dd4hep::Box setLadderSolid( (sensitive_thickness +support_thickness ) / 2.0 ,
+                                layer_geom.ladder_width / 2.0,
+                                layer_geom.half_z);
 
-    Volume setLadderLogical (_toString( layer_id,"SET_LadderLogical_%02d"), setLadderSolid, air ) ; 
+    dd4hep::Volume setLadderLogical (dd4hep::_toString( layer_id,"SET_LadderLogical_%02d"), setLadderSolid, air ) ; 
         
     // now create an envelope volume to represent the sensitive area, which will be divided up into individual sensors         
         
-    Box setSenEnvelopeSolid( (sensitive_thickness ) / 2.0 ,
-			     layer_geom.ladder_width  / 2.0,
-			     layer_geom.half_z);
+    dd4hep::Box setSenEnvelopeSolid( (sensitive_thickness ) / 2.0 ,
+                                     layer_geom.ladder_width  / 2.0,
+                                     layer_geom.half_z);
     
     //fixme: material ???    Volume setSenEnvelopeLogical( _toString( layer_id,"SET_SenEnvelopeLogical_%02d"), setSenEnvelopeSolid, sensitiveMat )  ;
-    Volume setSenEnvelopeLogical( _toString( layer_id,"SET_SenEnvelopeLogical_%02d"), setSenEnvelopeSolid, air )  ;
+    dd4hep::Volume setSenEnvelopeLogical( dd4hep::_toString( layer_id,"SET_SenEnvelopeLogical_%02d"),
+                                          setSenEnvelopeSolid, air )  ;
     
     // create the sensor volumes and place them in the senstive envelope volume 
     
-    Box setSenSolid( (sensitive_thickness ) / 2.0 ,
-		     layer_geom.ladder_width  / 2.0,
-		     (layer_geom.sensor_length / 2.0 ) - 1.e-06*dd4hep::mm ); // added tolerance to avoid false overlap detection
+    dd4hep::Box setSenSolid( (sensitive_thickness ) / 2.0 ,
+                             layer_geom.ladder_width  / 2.0,
+                             (layer_geom.sensor_length / 2.0 ) - 1.e-06*dd4hep::mm ); // added tolerance to avoid false overlap detection
     
-    Volume setSenLogical(  _toString( layer_id,"SET_SenLogical_%02d"), setSenSolid,sensitiveMat ) ; 
+    dd4hep::Volume setSenLogical( dd4hep:: _toString( layer_id,"SET_SenLogical_%02d"), setSenSolid,sensitiveMat ) ; 
     
     setSenLogical.setSensitiveDetector(sens);
     
@@ -328,7 +326,7 @@ static Ref_t create_element(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
     VolPlane surf( setSenLogical , SurfaceType(SurfaceType::Sensitive,SurfaceType::Measurement1D) ,inner_thick, outer_thick , u,v,n ) ; //,o ) ;
  
     // vector of sensor placements - needed for DetElements in ladder loop below
-    std::vector<PlacedVolume> pvV(  layer_geom.n_sensors_per_ladder ) ;
+    std::vector<dd4hep::PlacedVolume> pvV(  layer_geom.n_sensors_per_ladder ) ;
 
   //============================================================
 
@@ -343,7 +341,9 @@ static Ref_t create_element(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
       double ypos = 0.0;
       double zpos = -layer_geom.half_z + (0.5*layer_geom.sensor_length) + (isensor*layer_geom.sensor_length) ;
       
-      pv = setSenEnvelopeLogical.placeVolume( setSenLogical, Transform3D( RotationY(0.) , Position( xpos, ypos, zpos)  ) );
+      pv = setSenEnvelopeLogical.placeVolume( setSenLogical,
+                                              dd4hep::Transform3D( dd4hep::RotationY(0.) ,
+                                                                   dd4hep::Position( xpos, ypos, zpos)  ) );
       
       pv.addPhysVolID("sensor",  isensor ) ; 
       //fixme: what is the correct numbering convention ?
@@ -351,10 +351,10 @@ static Ref_t create_element(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
       pvV[isensor] = pv ;
    }					      
     
-    set.setVisAttributes(lcdd, "SeeThrough",  setLadderLogical ) ;
-    set.setVisAttributes(lcdd, "SeeThrough",  setSenEnvelopeLogical ) ;
+    set.setVisAttributes(theDetector, "SeeThrough",  setLadderLogical ) ;
+    set.setVisAttributes(theDetector, "SeeThrough",  setSenEnvelopeLogical ) ;
 
-    set.setVisAttributes(lcdd, "BlueVis",       setSenLogical ) ;
+    set.setVisAttributes(theDetector, "BlueVis",       setSenLogical ) ;
     
     
     // encoder.reset() ;  // reset to 0
@@ -363,8 +363,10 @@ static Ref_t create_element(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
     // cellID0 = encoder.lowWord() ;
         
 
-    pv = setLadderLogical.placeVolume( setSenEnvelopeLogical , Transform3D( RotationY( 0.), 
-									   Position( (-(sensitive_thickness +support_thickness ) / 2.0 + ( sensitive_thickness / 2.0) ), 0.,0.) ) );
+    pv = setLadderLogical.placeVolume( setSenEnvelopeLogical ,
+                                       dd4hep::Transform3D( dd4hep::RotationY( 0.), 
+                                                            dd4hep::Position( (-(sensitive_thickness +support_thickness ) / 2.0
+                                                                               + ( sensitive_thickness / 2.0) ), 0.,0.) ) );
     // pv = setSenEnvelopeLogical.placeVolume( setLadderLogical, Transform3D( RotationY( 0.), 
     // 									   Position( (-(sensitive_thickness +support_thickness ) / 2.0 + ( sensitive_thickness / 2.0) ), 0.,0.) ) );
 
@@ -374,30 +376,32 @@ static Ref_t create_element(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
 
     // create support volume which will be placed in the enclosing ladder volume together with the senstive envelope volume
     
-    Box setSupSolid( (support_thickness ) / 2.0 ,
-		     layer_geom.ladder_width / 2.0,
-		     layer_geom.half_z);
+    dd4hep::Box setSupSolid( (support_thickness ) / 2.0 ,
+                             layer_geom.ladder_width / 2.0,
+                             layer_geom.half_z);
     
-    Volume setSupLogical(   _toString( layer_id,"SET_SupLogical_%02d"),  setSupSolid, supportMat ) ;
-    
-    
-    set.setVisAttributes(lcdd, "RedVis",  setSupLogical ) ;
+    dd4hep::Volume setSupLogical( dd4hep::_toString( layer_id,"SET_SupLogical_%02d"),  setSupSolid, supportMat ) ;
     
     
-    pv = setLadderLogical.placeVolume( setSupLogical, Transform3D( RotationY( 0.), 
-								   Position( (-(sensitive_thickness +support_thickness ) / 2.0 +sensitive_thickness + ( support_thickness / 2.0)   ), 0.,0.) ) );
+    set.setVisAttributes(theDetector, "RedVis",  setSupLogical ) ;
+    
+    
+    pv = setLadderLogical.placeVolume( setSupLogical,
+                                       dd4hep::Transform3D( dd4hep::RotationY( 0.), 
+                                                            dd4hep::Position( (-(sensitive_thickness +support_thickness ) / 2.0
+                                                                               +sensitive_thickness + ( support_thickness / 2.0)   ), 0.,0.) ) );
     
     for( int i = 0 ; i < n_ladders ; ++i ){
       
       std::stringstream ladder_enum; ladder_enum << "set_ladder_" << layer_id << "_" << i;
       
-      DetElement   ladderDE( layerDE ,  ladder_enum.str() , x_det.id() );
+      dd4hep::DetElement ladderDE( layerDE ,  ladder_enum.str() , x_det.id() );
 
       for (int isensor=0; isensor < layer_geom.n_sensors_per_ladder ; ++isensor) {
 
 	std::stringstream sensor_ss ;  sensor_ss << ladder_enum.str() << "_" << isensor ;
 	
-	DetElement sensorDE( ladderDE, sensor_ss.str() ,  x_det.id() );
+	dd4hep::DetElement sensorDE( ladderDE, sensor_ss.str() ,  x_det.id() );
 	sensorDE.setPlacement( pvV[isensor] ) ;
 
 	volSurfaceList( sensorDE )->push_back(  surf ) ;
@@ -427,10 +431,11 @@ static Ref_t create_element(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
 	phi_rot += M_PI ;
       }
 
-      pv = layer_assembly.placeVolume( setLadderLogical, Transform3D( RotationZYX(  phi_rot, 0. , 0. ), 
-								Position( (sensitive_radius+dr) * cos(i * ladder_dphi), 
-									  (sensitive_radius+dr) * sin(i * ladder_dphi), 
-									  0. ) ) ) ;
+      pv = layer_assembly.placeVolume( setLadderLogical,
+                                       dd4hep::Transform3D( dd4hep::RotationZYX(  phi_rot, 0. , 0. ), 
+                                                            dd4hep::Position( (sensitive_radius+dr) * cos(i * ladder_dphi), 
+                                                                              (sensitive_radius+dr) * sin(i * ladder_dphi), 
+                                                                              0. ) ) ) ;
       
       pv.addPhysVolID("layer", layer_id ).addPhysVolID("module", i ) ; 
       //fixme: what is the correct numbering convention ?
@@ -450,7 +455,7 @@ static Ref_t create_element(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
   //--------------------------------------
   
   
-  set.setVisAttributes( lcdd, x_det.visStr(), envelope );
+  set.setVisAttributes( theDetector, x_det.visStr(), envelope );
   
   return set;
 }

--- a/detector/tracker/SiTrackerEndcap_o2_v01_geo.cpp
+++ b/detector/tracker/SiTrackerEndcap_o2_v01_geo.cpp
@@ -15,30 +15,42 @@
 // Specialized generic detector constructor
 // 
 //==========================================================================
+#include <DD4hep/Detector.h>
 #include "DD4hep/DetFactoryHelper.h"
 #include <map>
 
 using namespace std;
-using namespace DD4hep;
-using namespace DD4hep::Geometry;
 
-static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
+using dd4hep::Assembly;
+using dd4hep::DetElement;
+using dd4hep::Detector;
+using dd4hep::Material;
+using dd4hep::PlacedVolume;
+using dd4hep::SensitiveDetector;
+using dd4hep::Volume;
+using dd4hep::Trapezoid;
+using dd4hep::_toString;
+using dd4hep::Position;
+using dd4hep::Transform3D;
+using dd4hep::RotationZYX;
+
+static dd4hep::Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector sens)  {
   typedef vector<PlacedVolume> Placements;
   xml_det_t   x_det     = e;
-  Material    vacuum    = lcdd.vacuum();
+  Material    vacuum    = theDetector.vacuum();
   int         det_id    = x_det.id();
   string      det_name  = x_det.nameStr();
   bool        reflect   = x_det.reflect(false);
   DetElement  sdet        (det_name,det_id);
   Assembly    assembly    (det_name);
   //Volume      assembly    (det_name,Box(10000,10000,10000),vacuum);
-  Volume      motherVol = lcdd.pickMotherVolume(sdet);
+  Volume      motherVol = theDetector.pickMotherVolume(sdet);
   int         m_id=0, c_id=0, n_sensor=0;
   map<string,Volume> modules;
   map<string, Placements>  sensitives;
   PlacedVolume pv;
 
-  assembly.setVisAttributes(lcdd.invisible());
+  assembly.setVisAttributes(theDetector.invisible());
   sens.setType("tracker");
 
   for(xml_coll_t mi(x_det,_U(module)); mi; ++mi, ++m_id)  {
@@ -56,16 +68,16 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
       
     y1 = y2 = total_thickness / 2;
     Volume  m_volume(m_nam, Trapezoid(x1, x2, y1, y2, z), vacuum);      
-    m_volume.setVisAttributes(lcdd.visAttributes(x_mod.visStr()));
+    m_volume.setVisAttributes(theDetector.visAttributes(x_mod.visStr()));
 
     for(ci.reset(), n_sensor=1, c_id=0, posY=-y1; ci; ++ci, ++c_id)  {
       xml_comp_t c       = ci;
       double     c_thick = c.thickness();
-      Material   c_mat   = lcdd.material(c.materialStr());
+      Material   c_mat   = theDetector.material(c.materialStr());
       string     c_name  = _toString(c_id,"component%d");
       Volume     c_vol(c_name, Trapezoid(x1,x2,c_thick/2e0,c_thick/2e0,z), c_mat);
 
-      c_vol.setVisAttributes(lcdd.visAttributes(c.visStr()));
+      c_vol.setVisAttributes(theDetector.visAttributes(c.visStr()));
       pv = m_volume.placeVolume(c_vol,Position(0,posY+c_thick/2,0));
       if ( c.isSensitive() ) {
         sdet.check(n_sensor > 2,"SiTrackerEndcap2::fromCompact: "+c_name+" Max of 2 modules allowed!");

--- a/detector/tracker/SiTrackerEndcap_o2_v03_geo.cpp
+++ b/detector/tracker/SiTrackerEndcap_o2_v03_geo.cpp
@@ -21,13 +21,27 @@
 #include "DDRec/DetectorData.h"
 
 using namespace std;
-using namespace DD4hep;
-using namespace DD4hep::Geometry;
 
-static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
+using dd4hep::BUILD_ENVELOPE;
+using dd4hep::Box;
+using dd4hep::DetElement;
+using dd4hep::Detector;
+using dd4hep::Material;
+using dd4hep::PlacedVolume;
+using dd4hep::Position;
+using dd4hep::Ref_t;
+using dd4hep::RotationZYX;
+using dd4hep::SensitiveDetector;
+using dd4hep::Transform3D;
+using dd4hep::Trapezoid;
+using dd4hep::Volume;
+using dd4hep::_toString;
+
+
+static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector sens)  {
   typedef vector<PlacedVolume> Placements;
   xml_det_t   x_det     = e;
-  Material    vacuum    = lcdd.vacuum();
+  Material    vacuum    = theDetector.vacuum();
   int         det_id    = x_det.id();
   string      det_name  = x_det.nameStr();
   bool        reflect   = x_det.reflect(false);
@@ -39,14 +53,14 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
 
   // --- create an envelope volume and position it into the world ---------------------
 
-  Volume envelope = XML::createPlacedEnvelope(lcdd, e, sdet);
-  XML::setDetectorTypeFlag(e, sdet);
+  Volume envelope = dd4hep::xml::createPlacedEnvelope(theDetector, e, sdet);
+  dd4hep::xml::setDetectorTypeFlag(e, sdet);
 
-  if( lcdd.buildType() == BUILD_ENVELOPE ) return sdet;
+  if( theDetector.buildType() == BUILD_ENVELOPE ) return sdet;
 
   //-----------------------------------------------------------------------------------
 
-  envelope.setVisAttributes(lcdd.invisible());
+  envelope.setVisAttributes(theDetector.invisible());
   sens.setType("tracker");
 
   // Build the sensor units
@@ -66,7 +80,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
       
     y1 = y2 = total_thickness / 2;
     Volume m_volume(m_nam, Trapezoid(x1, x2, y1, y2, z), vacuum);      
-    m_volume.setVisAttributes(lcdd.visAttributes(x_mod.visStr()));
+    m_volume.setVisAttributes(theDetector.visAttributes(x_mod.visStr()));
 
     std::cout << m_nam << ", thickness=" << total_thickness << std::endl;
 
@@ -75,13 +89,13 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
     for(ci.reset(), n_sensor=1, c_id=0, posY=-y1; ci; ++ci, ++c_id) {
       xml_comp_t c       = ci;
       double     c_thick = c.thickness();
-      Material   c_mat   = lcdd.material(c.materialStr());
+      Material   c_mat   = theDetector.material(c.materialStr());
       string     c_name  = _toString(c_id, "component%d");
       Volume     c_vol(c_name, Trapezoid(x1,x2,c_thick/2e0,c_thick/2e0,z), c_mat);
 
       std::cout << " + sensor " << n_sensor << " " << c_name;
 
-      c_vol.setVisAttributes(lcdd.visAttributes(c.visStr()));
+      c_vol.setVisAttributes(theDetector.visAttributes(c.visStr()));
       pv = m_volume.placeVolume(c_vol, Position(0, posY + c_thick/2, 0));
       if ( c.isSensitive() ) {
         sdet.check(n_sensor > 2, "SiTrackerEndcap::fromCompact: " + c_name + " Max of 2 modules allowed!");

--- a/detector/tracker/TrackerBarrel_o1_v01_geo.cpp
+++ b/detector/tracker/TrackerBarrel_o1_v01_geo.cpp
@@ -11,13 +11,27 @@
 #include "DDRec/DetectorData.h"
 
 using namespace std;
-using namespace DD4hep;
-using namespace DD4hep::Geometry;
 
-static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
+using dd4hep::Ref_t;
+using dd4hep::Detector;
+using dd4hep::SensitiveDetector;
+using dd4hep::Material;
+using dd4hep::DetElement;
+using dd4hep::Volume;
+using dd4hep::PlacedVolume;
+using dd4hep::Position;
+using dd4hep::RotationZYX;
+using dd4hep::BUILD_ENVELOPE;
+using dd4hep::Box;
+using dd4hep::Tube;
+using dd4hep::ERROR;
+using dd4hep::_toString;
+using dd4hep::Transform3D;
+
+static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector sens)  {
     typedef vector<PlacedVolume> Placements;
     xml_det_t   x_det     = e;
-    Material    air       = lcdd.air();
+    Material    air       = theDetector.air();
     int         det_id    = x_det.id();
     string      det_name  = x_det.nameStr();
     DetElement  sdet       (det_name,det_id);
@@ -30,13 +44,13 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
     
     // --- create an envelope volume and position it into the world ---------------------
     
-    Volume envelope = XML::createPlacedEnvelope( lcdd,  e , sdet ) ;
-    XML::setDetectorTypeFlag( e, sdet ) ;
+    Volume envelope = dd4hep::xml::createPlacedEnvelope( theDetector,  e , sdet ) ;
+    dd4hep::xml::setDetectorTypeFlag( e, sdet ) ;
     
-    if( lcdd.buildType() == BUILD_ENVELOPE ) return sdet ;
+    if( theDetector.buildType() == BUILD_ENVELOPE ) return sdet ;
     
     //-----------------------------------------------------------------------------------
-    DDRec::ZPlanarData*  zPlanarData = new DDRec::ZPlanarData() ;
+    dd4hep::rec::ZPlanarData*  zPlanarData = new dd4hep::rec::ZPlanarData() ;
     
     sens.setType("tracker");
     
@@ -54,14 +68,14 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
             throw runtime_error("Logic error in building modules.");
         }
         volumes[m_nam] = m_vol;
-        m_vol.setVisAttributes(lcdd.visAttributes(x_mod.visStr()));
+        m_vol.setVisAttributes(theDetector.visAttributes(x_mod.visStr()));
         for(xml_coll_t ci(x_mod,_U(module_component)); ci; ++ci, ++ncomponents)  {
             xml_comp_t x_comp = ci;
             xml_comp_t x_pos  = x_comp.position(false);
             xml_comp_t x_rot  = x_comp.rotation(false);
             string     c_nam  = _toString(ncomponents,"component%d");
             Box        c_box(x_comp.width()/2,x_comp.length()/2,x_comp.thickness()/2);
-            Volume     c_vol(c_nam,c_box,lcdd.material(x_comp.materialStr()));
+            Volume     c_vol(c_nam,c_box,theDetector.material(x_comp.materialStr()));
             
             if ( x_pos && x_rot ) {
                 Position    c_pos(x_pos.x(0),x_pos.y(0),x_pos.z(0));
@@ -77,9 +91,9 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
             else {
                 pv = m_vol.placeVolume(c_vol);
             }
-            c_vol.setRegion(lcdd, x_comp.regionStr());
-            c_vol.setLimitSet(lcdd, x_comp.limitsStr());
-            c_vol.setVisAttributes(lcdd, x_comp.visStr());
+            c_vol.setRegion(theDetector, x_comp.regionStr());
+            c_vol.setLimitSet(theDetector, x_comp.limitsStr());
+            c_vol.setVisAttributes(theDetector, x_comp.visStr());
             if ( x_comp.isSensitive() ) {
                 //         pv.addPhysVolID("wafer",wafer_number++);
                 c_vol.setSensitiveDetector(sens);
@@ -121,7 +135,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
         int module_idx =0;
         
         
-        DDRec::ZPlanarData::LayerLayout thisLayer ;
+        dd4hep::rec::ZPlanarData::LayerLayout thisLayer ;
         
        
         // Loop over the number of sensors in phi.
@@ -164,7 +178,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
                     ///NOTE WORKS ONLY FOR ONE WAFER
                     if (ii==0 && j==0 && ic==0){
                       
-                      DD4hep::Geometry::Box mod_shape(m_env.solid()), comp_shape(wafer_pv.volume().solid());
+                      Box mod_shape(m_env.solid()), comp_shape(wafer_pv.volume().solid());
                       
                       const double* trans = comp_elt.placement()->GetMatrix()->GetTranslation();
                       double half_module_thickness = mod_shape->GetDZ();
@@ -216,17 +230,17 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
         // Create the PhysicalVolume for the layer.
         pv = envelope.placeVolume(lay_vol); // Place layer in mother
         pv.addPhysVolID("layer", lay_id);       // Set the layer ID.
-        lay_elt.setAttributes(lcdd,lay_vol,x_layer.regionStr(),x_layer.limitsStr(),x_layer.visStr());
+        lay_elt.setAttributes(theDetector,lay_vol,x_layer.regionStr(),x_layer.limitsStr(),x_layer.visStr());
         lay_elt.setPlacement(pv);
         
         zPlanarData->layers.push_back( thisLayer ) ;
         
     }
-    sdet.setAttributes(lcdd,envelope,x_det.regionStr(),x_det.limitsStr(),x_det.visStr());
-    sdet.addExtension< DDRec::ZPlanarData >( zPlanarData ) ;
+    sdet.setAttributes(theDetector,envelope,x_det.regionStr(),x_det.limitsStr(),x_det.visStr());
+    sdet.addExtension< dd4hep::rec::ZPlanarData >( zPlanarData ) ;
     
-    //envelope.setVisAttributes(lcdd.invisible());
-    /*pv = lcdd.pickMotherVolume(sdet).placeVolume(assembly);
+    //envelope.setVisAttributes(theDetector.invisible());
+    /*pv = theDetector.pickMotherVolume(sdet).placeVolume(assembly);
      pv.addPhysVolID("system", det_id);      // Set the subdetector system ID.
      pv.addPhysVolID("barrel", 0);           // Flag this as a barrel subdetector.
      sdet.setPlacement(pv);*/

--- a/detector/tracker/TrackerBarrel_o1_v02_geo.cpp
+++ b/detector/tracker/TrackerBarrel_o1_v02_geo.cpp
@@ -11,13 +11,30 @@
 #include "DDRec/DetectorData.h"
 
 using namespace std;
-using namespace DD4hep;
-using namespace DD4hep::Geometry;
 
-static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
+using dd4hep::Assembly;
+using dd4hep::Ref_t;
+using dd4hep::Detector;
+using dd4hep::SensitiveDetector;
+using dd4hep::Material;
+using dd4hep::DetElement;
+using dd4hep::Volume;
+using dd4hep::PlacedVolume;
+using dd4hep::Position;
+using dd4hep::RotationZYX;
+using dd4hep::BUILD_ENVELOPE;
+using dd4hep::Box;
+using dd4hep::Tube;
+using dd4hep::ERROR;
+using dd4hep::_toString;
+using dd4hep::Transform3D;
+using dd4hep::rec::ZPlanarData;
+
+
+static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector sens)  {
     typedef vector<PlacedVolume> Placements;
     xml_det_t   x_det     = e;
-    Material    air       = lcdd.air();
+    Material    air       = theDetector.air();
     int         det_id    = x_det.id();
     string      det_name  = x_det.nameStr();
     DetElement  sdet       (det_name,det_id);
@@ -29,13 +46,13 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
     
     // --- create an envelope volume and position it into the world ---------------------
     
-    Volume envelope = XML::createPlacedEnvelope( lcdd,  e , sdet ) ;
-    XML::setDetectorTypeFlag( e, sdet ) ;
+    Volume envelope = dd4hep::xml::createPlacedEnvelope( theDetector,  e , sdet ) ;
+    dd4hep::xml::setDetectorTypeFlag( e, sdet ) ;
     
-    if( lcdd.buildType() == BUILD_ENVELOPE ) return sdet ;
+    if( theDetector.buildType() == BUILD_ENVELOPE ) return sdet ;
     
     //-----------------------------------------------------------------------------------
-    DDRec::ZPlanarData*  zPlanarData = new DDRec::ZPlanarData() ;
+    ZPlanarData*  zPlanarData = new ZPlanarData() ;
     
     sens.setType("tracker");
     
@@ -60,7 +77,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
 
         Volume     m_vol(m_nam,Box(m_env.width()/2,m_env.length()/2,module_thickness),air);
         volumes[m_nam] = m_vol;
-        m_vol.setVisAttributes(lcdd.visAttributes(x_mod.visStr()));
+        m_vol.setVisAttributes(theDetector.visAttributes(x_mod.visStr()));
         
         
         
@@ -68,16 +85,16 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
             xml_comp_t x_comp = ci;
             string     c_nam  = _toString(ncomponents,"component%d");
             Box        c_box(x_comp.width()/2.0,x_comp.length()/2.0,x_comp.thickness()/2.0);
-            Volume     c_vol(c_nam,c_box,lcdd.material(x_comp.materialStr()));
+            Volume     c_vol(c_nam,c_box,theDetector.material(x_comp.materialStr()));
             
 
             pv = m_vol.placeVolume(c_vol,Position(0,0,module_thickness-x_comp.thickness()/2.0));
 
             module_thickness-=x_comp.thickness();
 
-            c_vol.setRegion(lcdd, x_comp.regionStr());
-            c_vol.setLimitSet(lcdd, x_comp.limitsStr());
-            c_vol.setVisAttributes(lcdd, x_comp.visStr());
+            c_vol.setRegion(theDetector, x_comp.regionStr());
+            c_vol.setLimitSet(theDetector, x_comp.limitsStr());
+            c_vol.setVisAttributes(theDetector, x_comp.visStr());
             if ( x_comp.isSensitive() ) {
                 //         pv.addPhysVolID("wafer",wafer_number++);
                 c_vol.setSensitiveDetector(sens);
@@ -117,7 +134,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
         int module_idx =0;
         
         
-        DDRec::ZPlanarData::LayerLayout thisLayer ;
+        ZPlanarData::LayerLayout thisLayer ;
         
        
         // Loop over the number of sensors in phi.
@@ -160,7 +177,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
                     ///NOTE WORKS ONLY FOR ONE WAFER
                     if (ii==0 && j==0 && ic==0){
                       
-                      DD4hep::Geometry::Box mod_shape(m_env.solid()), comp_shape(wafer_pv.volume().solid());
+                      Box mod_shape(m_env.solid()), comp_shape(wafer_pv.volume().solid());
                       
                       const double* trans = comp_elt.placement()->GetMatrix()->GetTranslation();
                       double half_module_thickness = mod_shape->GetDZ();
@@ -211,17 +228,17 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
         // Create the PhysicalVolume for the layer.
         pv = envelope.placeVolume(lay_vol); // Place layer in mother
         pv.addPhysVolID("layer", lay_id);       // Set the layer ID.
-        lay_elt.setAttributes(lcdd,lay_vol,x_layer.regionStr(),x_layer.limitsStr(),x_layer.visStr());
+        lay_elt.setAttributes(theDetector,lay_vol,x_layer.regionStr(),x_layer.limitsStr(),x_layer.visStr());
         lay_elt.setPlacement(pv);
         
         zPlanarData->layers.push_back( thisLayer ) ;
         
     }
-    sdet.setAttributes(lcdd,envelope,x_det.regionStr(),x_det.limitsStr(),x_det.visStr());
-    sdet.addExtension< DDRec::ZPlanarData >( zPlanarData ) ;
+    sdet.setAttributes(theDetector,envelope,x_det.regionStr(),x_det.limitsStr(),x_det.visStr());
+    sdet.addExtension< ZPlanarData >( zPlanarData ) ;
     
-    //envelope.setVisAttributes(lcdd.invisible());
-    /*pv = lcdd.pickMotherVolume(sdet).placeVolume(assembly);
+    //envelope.setVisAttributes(theDetector.invisible());
+    /*pv = theDetector.pickMotherVolume(sdet).placeVolume(assembly);
      pv.addPhysVolID("system", det_id);      // Set the subdetector system ID.
      pv.addPhysVolID("barrel", 0);           // Flag this as a barrel subdetector.
      sdet.setPlacement(pv);*/

--- a/detector/tracker/TrackerBarrel_o1_v03_geo.cpp
+++ b/detector/tracker/TrackerBarrel_o1_v03_geo.cpp
@@ -19,13 +19,30 @@
 #include <UTIL/ILDConf.h>
 
 using namespace std;
-using namespace DD4hep;
-using namespace DD4hep::Geometry;
 
-static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
+using dd4hep::Assembly;
+using dd4hep::Ref_t;
+using dd4hep::Detector;
+using dd4hep::SensitiveDetector;
+using dd4hep::Material;
+using dd4hep::DetElement;
+using dd4hep::Volume;
+using dd4hep::PlacedVolume;
+using dd4hep::Position;
+using dd4hep::RotationZYX;
+using dd4hep::BUILD_ENVELOPE;
+using dd4hep::Box;
+using dd4hep::Tube;
+using dd4hep::ERROR;
+using dd4hep::_toString;
+using dd4hep::Transform3D;
+using dd4hep::rec::ZPlanarData;
+using dd4hep::rec::NeighbourSurfacesData;
+
+static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector sens)  {
     typedef vector<PlacedVolume> Placements;
     xml_det_t   x_det     = e;
-    Material    air       = lcdd.air();
+    Material    air       = theDetector.air();
     int         det_id    = x_det.id();
     string      det_name  = x_det.nameStr();
     DetElement  sdet       (det_name,det_id);
@@ -45,14 +62,14 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
     
     // --- create an envelope volume and position it into the world ---------------------
     
-    Volume envelope = XML::createPlacedEnvelope( lcdd,  e , sdet ) ;
-    XML::setDetectorTypeFlag( e, sdet ) ;
+    Volume envelope = dd4hep::xml::createPlacedEnvelope( theDetector,  e , sdet ) ;
+    dd4hep::xml::setDetectorTypeFlag( e, sdet ) ;
     
-    if( lcdd.buildType() == BUILD_ENVELOPE ) return sdet ;
+    if( theDetector.buildType() == BUILD_ENVELOPE ) return sdet ;
     
     //-----------------------------------------------------------------------------------
-    DDRec::ZPlanarData*  zPlanarData = new DDRec::ZPlanarData() ;
-    DDRec::NeighbourSurfacesData*  neighbourSurfacesData = new DDRec::NeighbourSurfacesData() ;
+    ZPlanarData*  zPlanarData = new ZPlanarData() ;
+    NeighbourSurfacesData*  neighbourSurfacesData = new NeighbourSurfacesData() ;
     
     sens.setType("tracker");
     
@@ -76,7 +93,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
 
         Volume     m_vol(m_nam,Box(m_env.width()/2.,m_env.length()/2.,module_thickness/2.),air);
         volumes[m_nam] = m_vol;
-        m_vol.setVisAttributes(lcdd.visAttributes(x_mod.visStr()));
+        m_vol.setVisAttributes(theDetector.visAttributes(x_mod.visStr()));
         
         
         int        ncomponents = 0; 
@@ -87,14 +104,14 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
             xml_comp_t x_comp = ci;
             string     c_nam  = _toString(ncomponents,"component%d");
             Box        c_box(x_comp.width()/2.0,x_comp.length()/2.0,x_comp.thickness()/2.0);
-            Volume     c_vol(c_nam,c_box,lcdd.material(x_comp.materialStr()));
+            Volume     c_vol(c_nam,c_box,theDetector.material(x_comp.materialStr()));
             
 
             pv = m_vol.placeVolume(c_vol,Position(0,0,position_z+x_comp.thickness()/2.0));
 
-            c_vol.setRegion(lcdd, x_comp.regionStr());
-            c_vol.setLimitSet(lcdd, x_comp.limitsStr());
-            c_vol.setVisAttributes(lcdd, x_comp.visStr());
+            c_vol.setRegion(theDetector, x_comp.regionStr());
+            c_vol.setLimitSet(theDetector, x_comp.limitsStr());
+            c_vol.setVisAttributes(theDetector, x_comp.visStr());
             if ( x_comp.isSensitive() ) {
                 //         pv.addPhysVolID("wafer",wafer_number++);
                 c_vol.setSensitiveDetector(sens);
@@ -136,7 +153,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
         int module_idx =0;
         
         
-        DDRec::ZPlanarData::LayerLayout thisLayer ;
+        ZPlanarData::LayerLayout thisLayer ;
         
        
         // Loop over the number of sensors in phi.
@@ -165,7 +182,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
 		encoder[lcio::LCTrackerCellID::module()] = module_idx;
 		encoder[lcio::LCTrackerCellID::sensor()] = sensor_idx;
 
-		DD4hep::long64 cellID = encoder.lowWord(); // 32 bits
+		dd4hep::long64 cellID = encoder.lowWord(); // 32 bits
 
 		//compute neighbours 
 
@@ -223,7 +240,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
                     ///NOTE WORKS ONLY FOR ONE WAFER
                     if (ii==0 && j==0 && ic==0){
                       
-                      DD4hep::Geometry::Box mod_shape(m_env.solid()), comp_shape(wafer_pv.volume().solid());
+                      Box mod_shape(m_env.solid()), comp_shape(wafer_pv.volume().solid());
                       
                       const double* trans = comp_elt.placement()->GetMatrix()->GetTranslation();
                       double half_module_thickness = mod_shape->GetDZ();
@@ -274,18 +291,18 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
         // Create the PhysicalVolume for the layer.
         pv = envelope.placeVolume(lay_vol); // Place layer in mother
         pv.addPhysVolID("layer", lay_id);       // Set the layer ID.
-        lay_elt.setAttributes(lcdd,lay_vol,x_layer.regionStr(),x_layer.limitsStr(),x_layer.visStr());
+        lay_elt.setAttributes(theDetector,lay_vol,x_layer.regionStr(),x_layer.limitsStr(),x_layer.visStr());
         lay_elt.setPlacement(pv);
         
         zPlanarData->layers.push_back( thisLayer ) ;
         
     }
-    sdet.setAttributes(lcdd,envelope,x_det.regionStr(),x_det.limitsStr(),x_det.visStr());
-    sdet.addExtension< DDRec::ZPlanarData >( zPlanarData ) ;
-    sdet.addExtension< DDRec::NeighbourSurfacesData >( neighbourSurfacesData ) ;
+    sdet.setAttributes(theDetector,envelope,x_det.regionStr(),x_det.limitsStr(),x_det.visStr());
+    sdet.addExtension< ZPlanarData >( zPlanarData ) ;
+    sdet.addExtension< NeighbourSurfacesData >( neighbourSurfacesData ) ;
     
-    //envelope.setVisAttributes(lcdd.invisible());
-    /*pv = lcdd.pickMotherVolume(sdet).placeVolume(assembly);
+    //envelope.setVisAttributes(theDetector.invisible());
+    /*pv = theDetector.pickMotherVolume(sdet).placeVolume(assembly);
      pv.addPhysVolID("system", det_id);      // Set the subdetector system ID.
      pv.addPhysVolID("barrel", 0);           // Flag this as a barrel subdetector.
      sdet.setPlacement(pv);*/

--- a/detector/tracker/TrackerBarrel_o1_v05_geo.cpp
+++ b/detector/tracker/TrackerBarrel_o1_v05_geo.cpp
@@ -22,13 +22,31 @@
 #include <UTIL/ILDConf.h>
 
 using namespace std;
-using namespace DD4hep;
-using namespace DD4hep::Geometry;
 
-static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
+using dd4hep::Assembly;
+using dd4hep::BUILD_ENVELOPE;
+using dd4hep::Box;
+using dd4hep::DetElement;
+using dd4hep::Detector;
+using dd4hep::ERROR;
+using dd4hep::Material;
+using dd4hep::PlacedVolume;
+using dd4hep::Position;
+using dd4hep::Ref_t;
+using dd4hep::RotationZYX;
+using dd4hep::SensitiveDetector;
+using dd4hep::Transform3D;
+using dd4hep::Tube;
+using dd4hep::Volume;
+using dd4hep::_toString;
+using dd4hep::rec::NeighbourSurfacesData;
+using dd4hep::rec::ZPlanarData;
+
+
+static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector sens)  {
     typedef vector<PlacedVolume> Placements;
     xml_det_t   x_det     = e;
-    Material    air       = lcdd.air();
+    Material    air       = theDetector.air();
     int         det_id    = x_det.id();
     string      det_name  = x_det.nameStr();
     DetElement  sdet       (det_name,det_id);
@@ -48,14 +66,14 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
 
     // --- create an envelope volume and position it into the world ---------------------
     
-    Volume envelope = XML::createPlacedEnvelope( lcdd,  e , sdet ) ;
-    XML::setDetectorTypeFlag( e, sdet ) ;
+    Volume envelope = dd4hep::xml::createPlacedEnvelope( theDetector,  e , sdet ) ;
+    dd4hep::xml::setDetectorTypeFlag( e, sdet ) ;
     
-    if( lcdd.buildType() == BUILD_ENVELOPE ) return sdet ;
+    if( theDetector.buildType() == BUILD_ENVELOPE ) return sdet ;
     
     //-----------------------------------------------------------------------------------
-    DDRec::ZPlanarData*  zPlanarData = new DDRec::ZPlanarData() ;
-    DDRec::NeighbourSurfacesData*  neighbourSurfacesData = new DDRec::NeighbourSurfacesData() ;
+    ZPlanarData*  zPlanarData = new ZPlanarData() ;
+    NeighbourSurfacesData*  neighbourSurfacesData = new NeighbourSurfacesData() ;
     
     sens.setType("tracker");
     
@@ -73,7 +91,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
 
         double module_thickness = 0;
         for(xml_coll_t incl(x_mod,_U(include)); incl; ++incl) {
-            XML::DocumentHolder doc(XML::DocumentHandler().load(incl, incl.attr_value(_U(ref))));
+            dd4hep::xml::DocumentHolder doc(dd4hep::xml::DocumentHandler().load(incl, incl.attr_value(_U(ref))));
             xml_h includes = doc.root();
             xml_det_t incl_stack = includes;
             for (xml_coll_t ci(incl_stack, _U(module_component)); ci; ++ci) {
@@ -84,7 +102,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
 
         Volume     m_vol(m_nam,Box(m_env.width()/2.,m_env.length()/2.,module_thickness/2.),air);
         volumes[m_nam] = m_vol;
-        m_vol.setVisAttributes(lcdd.visAttributes(x_mod.visStr()));
+        m_vol.setVisAttributes(theDetector.visAttributes(x_mod.visStr()));
         
         
         int        ncomponents = 0; 
@@ -92,21 +110,21 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
         //First component on top of the list is the innermost one. 
         double position_z= -module_thickness/2.;
         for(xml_coll_t incl(x_mod,_U(include)); incl; ++incl) {
-            XML::DocumentHolder doc(XML::DocumentHandler().load(incl, incl.attr_value(_U(ref))));
+            dd4hep::xml::DocumentHolder doc(dd4hep::xml::DocumentHandler().load(incl, incl.attr_value(_U(ref))));
             xml_h includes = doc.root();
             xml_det_t incl_stack = includes;
             for (xml_coll_t ci(incl_stack, _U(module_component)); ci; ++ci, ++ncomponents) {
                 xml_comp_t x_comp = ci;
                 string c_nam = _toString(ncomponents, "component%d");
                 Box c_box(m_env.width() / 2.0, m_env.length() / 2.0, x_comp.thickness() / 2.0);
-                Volume c_vol(c_nam, c_box, lcdd.material(x_comp.materialStr()));
+                Volume c_vol(c_nam, c_box, theDetector.material(x_comp.materialStr()));
 
 
                 pv = m_vol.placeVolume(c_vol, Position(0, 0, position_z + x_comp.thickness() / 2.0));
 
-                c_vol.setRegion(lcdd, x_comp.regionStr());
-                c_vol.setLimitSet(lcdd, x_comp.limitsStr());
-                c_vol.setVisAttributes(lcdd, x_comp.visStr());
+                c_vol.setRegion(theDetector, x_comp.regionStr());
+                c_vol.setLimitSet(theDetector, x_comp.limitsStr());
+                c_vol.setVisAttributes(theDetector, x_comp.visStr());
                 if (x_comp.isSensitive()) {
                     //         pv.addPhysVolID("wafer",wafer_number++);
                     c_vol.setSensitiveDetector(sens);
@@ -150,7 +168,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
         int module_idx =0;
         
         
-        DDRec::ZPlanarData::LayerLayout thisLayer ;
+        ZPlanarData::LayerLayout thisLayer ;
         
        
         // Loop over the number of sensors in phi.
@@ -179,7 +197,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
 		encoder[lcio::LCTrackerCellID::module()] = module_idx;
 		encoder[lcio::LCTrackerCellID::sensor()] = sensor_idx;
 
-		DD4hep::long64 cellID = encoder.lowWord(); // 32 bits
+		dd4hep::long64 cellID = encoder.lowWord(); // 32 bits
 
 		//compute neighbours 
 
@@ -237,7 +255,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
                     ///NOTE WORKS ONLY FOR ONE WAFER
                     if (ii==0 && j==0 && ic==0){
                       
-                      DD4hep::Geometry::Box mod_shape(m_env.solid()), comp_shape(wafer_pv.volume().solid());
+                      Box mod_shape(m_env.solid()), comp_shape(wafer_pv.volume().solid());
                       
                       const double* trans = comp_elt.placement()->GetMatrix()->GetTranslation();
                       double half_module_thickness = mod_shape->GetDZ();
@@ -288,18 +306,18 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
         // Create the PhysicalVolume for the layer.
         pv = envelope.placeVolume(lay_vol); // Place layer in mother
         pv.addPhysVolID("layer", lay_id);       // Set the layer ID.
-        lay_elt.setAttributes(lcdd,lay_vol,x_layer.regionStr(),x_layer.limitsStr(),x_layer.visStr());
+        lay_elt.setAttributes(theDetector,lay_vol,x_layer.regionStr(),x_layer.limitsStr(),x_layer.visStr());
         lay_elt.setPlacement(pv);
         
         zPlanarData->layers.push_back( thisLayer ) ;
         
     }
-    sdet.setAttributes(lcdd,envelope,x_det.regionStr(),x_det.limitsStr(),x_det.visStr());
-    sdet.addExtension< DDRec::ZPlanarData >( zPlanarData ) ;
-    sdet.addExtension< DDRec::NeighbourSurfacesData >( neighbourSurfacesData ) ;
+    sdet.setAttributes(theDetector,envelope,x_det.regionStr(),x_det.limitsStr(),x_det.visStr());
+    sdet.addExtension< ZPlanarData >( zPlanarData ) ;
+    sdet.addExtension< NeighbourSurfacesData >( neighbourSurfacesData ) ;
     
-    //envelope.setVisAttributes(lcdd.invisible());
-    /*pv = lcdd.pickMotherVolume(sdet).placeVolume(assembly);
+    //envelope.setVisAttributes(theDetector.invisible());
+    /*pv = theDetector.pickMotherVolume(sdet).placeVolume(assembly);
      pv.addPhysVolID("system", det_id);      // Set the subdetector system ID.
      pv.addPhysVolID("barrel", 0);           // Flag this as a barrel subdetector.
      sdet.setPlacement(pv);*/

--- a/detector/tracker/TrackerEndcap_o1_v01_geo.cpp
+++ b/detector/tracker/TrackerEndcap_o1_v01_geo.cpp
@@ -14,13 +14,30 @@
 
 
 using namespace std;
-using namespace DD4hep;
-using namespace DD4hep::Geometry;
 
-static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
+using dd4hep::Assembly;
+using dd4hep::BUILD_ENVELOPE;
+using dd4hep::Box;
+using dd4hep::DetElement;
+using dd4hep::Detector;
+using dd4hep::Material;
+using dd4hep::PlacedVolume;
+using dd4hep::Position;
+using dd4hep::Ref_t;
+using dd4hep::RotationZYX;
+using dd4hep::SensitiveDetector;
+using dd4hep::Transform3D;
+using dd4hep::Trapezoid;
+using dd4hep::Tube;
+using dd4hep::Volume;
+using dd4hep::_toString;
+using dd4hep::rec::ZDiskPetalsData;
+
+
+static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector sens)  {
     typedef vector<PlacedVolume> Placements;
     xml_det_t   x_det     = e;
-    Material    vacuum    = lcdd.vacuum();
+    Material    vacuum    = theDetector.vacuum();
     int         det_id    = x_det.id();
     string      det_name  = x_det.nameStr();
     bool        reflect   = x_det.reflect(false);
@@ -32,17 +49,17 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
     
     // --- create an envelope volume and position it into the world ---------------------
     
-    Volume envelope = XML::createPlacedEnvelope( lcdd,  e , sdet ) ;
-    XML::setDetectorTypeFlag( e, sdet ) ;
+    Volume envelope = dd4hep::xml::createPlacedEnvelope( theDetector,  e , sdet ) ;
+    dd4hep::xml::setDetectorTypeFlag( e, sdet ) ;
     
-    if( lcdd.buildType() == BUILD_ENVELOPE ) return sdet ;
+    if( theDetector.buildType() == BUILD_ENVELOPE ) return sdet ;
     
     //-----------------------------------------------------------------------------------
     
-    DDRec::ZDiskPetalsData*  zDiskPetalsData = new DDRec::ZDiskPetalsData ;
+    ZDiskPetalsData*  zDiskPetalsData = new ZDiskPetalsData ;
     
     
-    envelope.setVisAttributes(lcdd.invisible());
+    envelope.setVisAttributes(theDetector.invisible());
     sens.setType("tracker");
     
     for(xml_coll_t mi(x_det,_U(module)); mi; ++mi, ++m_id)  {
@@ -60,16 +77,16 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
         
         y1 = y2 = total_thickness / 2;
         Volume  m_volume(m_nam, Trapezoid(x1, x2, y1, y2, z), vacuum);
-        m_volume.setVisAttributes(lcdd.visAttributes(x_mod.visStr()));
+        m_volume.setVisAttributes(theDetector.visAttributes(x_mod.visStr()));
         
         for(ci.reset(), n_sensor=1, c_id=0, posY=-y1; ci; ++ci, ++c_id)  {
             xml_comp_t c       = ci;
             double     c_thick = c.thickness();
-            Material   c_mat   = lcdd.material(c.materialStr());
+            Material   c_mat   = theDetector.material(c.materialStr());
             string     c_name  = _toString(c_id,"component%d");
             Volume     c_vol(c_name, Trapezoid(x1,x2,c_thick/2e0,c_thick/2e0,z), c_mat);
             
-            c_vol.setVisAttributes(lcdd.visAttributes(c.visStr()));
+            c_vol.setVisAttributes(theDetector.visAttributes(c.visStr()));
             pv = m_volume.placeVolume(c_vol,Position(0,posY+c_thick/2,0));
             if ( c.isSensitive() ) {
                 sdet.check(n_sensor > 2,"SiTrackerEndcap2::fromCompact: "+c_name+" Max of 2 modules allowed!");
@@ -100,13 +117,13 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
             double phi      = phi0;
             Placements& sensVols = sensitives[m_nam];
             
-            DDRec::ZDiskPetalsData::LayerLayout thisLayer ;
+            ZDiskPetalsData::LayerLayout thisLayer ;
             
             ///FIXME! ALL THIS NEEDS TO BE CHECKED and actually are not needed for CED
-            thisLayer.typeFlags[ DDRec::ZDiskPetalsData::SensorType::DoubleSided ] = false ; ///CHECK FIXME
-            thisLayer.typeFlags[ DDRec::ZDiskPetalsData::SensorType::Pixel ]     = false ;  ///CHECK
+            thisLayer.typeFlags[ ZDiskPetalsData::SensorType::DoubleSided ] = false ; ///CHECK FIXME
+            thisLayer.typeFlags[ ZDiskPetalsData::SensorType::Pixel ]     = false ;  ///CHECK
             
-            DD4hep::Geometry::Trapezoid mod_shape(m_vol.solid());
+            Trapezoid mod_shape(m_vol.solid());
             
             
             thisLayer.petalHalfAngle   = 0;
@@ -170,7 +187,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
     
     
     
-    sdet.addExtension< DDRec::ZDiskPetalsData >( zDiskPetalsData ) ;
+    sdet.addExtension< ZDiskPetalsData >( zDiskPetalsData ) ;
     
     
     return sdet;

--- a/detector/tracker/TrackerEndcap_o1_v02_geo.cpp
+++ b/detector/tracker/TrackerEndcap_o1_v02_geo.cpp
@@ -13,13 +13,29 @@
 
 
 using namespace std;
-using namespace DD4hep;
-using namespace DD4hep::Geometry;
 
-static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
+using dd4hep::Assembly;
+using dd4hep::BUILD_ENVELOPE;
+using dd4hep::Box;
+using dd4hep::DetElement;
+using dd4hep::Detector;
+using dd4hep::Material;
+using dd4hep::PlacedVolume;
+using dd4hep::Position;
+using dd4hep::Ref_t;
+using dd4hep::RotationZYX;
+using dd4hep::SensitiveDetector;
+using dd4hep::Transform3D;
+using dd4hep::Trapezoid;
+using dd4hep::Tube;
+using dd4hep::Volume;
+using dd4hep::_toString;
+using dd4hep::rec::ZDiskPetalsData;
+
+static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector sens)  {
     typedef vector<PlacedVolume> Placements;
     xml_det_t   x_det     = e;
-    Material    vacuum    = lcdd.vacuum();
+    Material    vacuum    = theDetector.vacuum();
     int         det_id    = x_det.id();
     string      det_name  = x_det.nameStr();
     bool        reflect   = x_det.reflect(false);
@@ -31,17 +47,17 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
     
     // --- create an envelope volume and position it into the world ---------------------
     
-    Volume envelope = XML::createPlacedEnvelope( lcdd,  e , sdet ) ;
-    XML::setDetectorTypeFlag( e, sdet ) ;
+    Volume envelope = dd4hep::xml::createPlacedEnvelope( theDetector,  e , sdet ) ;
+    dd4hep::xml::setDetectorTypeFlag( e, sdet ) ;
     
-    if( lcdd.buildType() == BUILD_ENVELOPE ) return sdet ;
+    if( theDetector.buildType() == BUILD_ENVELOPE ) return sdet ;
     
     //-----------------------------------------------------------------------------------
     
-    DDRec::ZDiskPetalsData*  zDiskPetalsData = new DDRec::ZDiskPetalsData ;
+    ZDiskPetalsData*  zDiskPetalsData = new ZDiskPetalsData ;
     
     
-    envelope.setVisAttributes(lcdd.invisible());
+    envelope.setVisAttributes(theDetector.invisible());
     sens.setType("tracker");
     
     for(xml_coll_t mi(x_det,_U(module)); mi; ++mi, ++m_id)  {
@@ -59,16 +75,16 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
         
         y1 = y2 = total_thickness / 2;
         Volume  m_volume(m_nam, Trapezoid(x1, x2, y1, y2, z), vacuum);
-        m_volume.setVisAttributes(lcdd.visAttributes(x_mod.visStr()));
+        m_volume.setVisAttributes(theDetector.visAttributes(x_mod.visStr()));
         
         for(ci.reset(), n_sensor=1, c_id=0, posY=-y1; ci; ++ci, ++c_id)  {
             xml_comp_t c       = ci;
             double     c_thick = c.thickness();
-            Material   c_mat   = lcdd.material(c.materialStr());
+            Material   c_mat   = theDetector.material(c.materialStr());
             string     c_name  = _toString(c_id,"component%d");
             Volume     c_vol(c_name, Trapezoid(x1,x2,c_thick/2e0,c_thick/2e0,z), c_mat);
             
-            c_vol.setVisAttributes(lcdd.visAttributes(c.visStr()));
+            c_vol.setVisAttributes(theDetector.visAttributes(c.visStr()));
             pv = m_volume.placeVolume(c_vol,Position(0,posY+c_thick/2,0));
             if ( c.isSensitive() ) {
 //                 sdet.check(n_sensor > 1,"TrackerEndcap:fromCompact: "+c_name+" Max of 1 sensitive elemets allowed!");
@@ -99,13 +115,13 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
             double phi      = phi0;
             Placements& sensVols = sensitives[m_nam];
             
-            DDRec::ZDiskPetalsData::LayerLayout thisLayer ;
+            ZDiskPetalsData::LayerLayout thisLayer ;
             
             ///FIXME! ALL THIS NEEDS TO BE CHECKED and actually are not needed for CED
-            thisLayer.typeFlags[ DDRec::ZDiskPetalsData::SensorType::DoubleSided ] = false ; ///CHECK FIXME
-            thisLayer.typeFlags[ DDRec::ZDiskPetalsData::SensorType::Pixel ]     = false ;  ///CHECK
+            thisLayer.typeFlags[ ZDiskPetalsData::SensorType::DoubleSided ] = false ; ///CHECK FIXME
+            thisLayer.typeFlags[ ZDiskPetalsData::SensorType::Pixel ]     = false ;  ///CHECK
             
-            DD4hep::Geometry::Trapezoid mod_shape(m_vol.solid());
+            Trapezoid mod_shape(m_vol.solid());
             
             
             thisLayer.petalHalfAngle   = 0;
@@ -178,7 +194,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
     
     
     
-    sdet.addExtension< DDRec::ZDiskPetalsData >( zDiskPetalsData ) ;
+    sdet.addExtension< ZDiskPetalsData >( zDiskPetalsData ) ;
     
     
     return sdet;

--- a/detector/tracker/TrackerEndcap_o1_v03_geo.cpp
+++ b/detector/tracker/TrackerEndcap_o1_v03_geo.cpp
@@ -20,13 +20,29 @@
 
 
 using namespace std;
-using namespace DD4hep;
-using namespace DD4hep::Geometry;
 
-static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
+using dd4hep::Assembly;
+using dd4hep::BUILD_ENVELOPE;
+using dd4hep::Box;
+using dd4hep::DetElement;
+using dd4hep::Detector;
+using dd4hep::Material;
+using dd4hep::PlacedVolume;
+using dd4hep::Position;
+using dd4hep::Ref_t;
+using dd4hep::RotationZYX;
+using dd4hep::SensitiveDetector;
+using dd4hep::Transform3D;
+using dd4hep::Trapezoid;
+using dd4hep::Tube;
+using dd4hep::Volume;
+using dd4hep::_toString;
+using dd4hep::rec::ZDiskPetalsData;
+
+static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector sens)  {
     typedef vector<PlacedVolume> Placements;
     xml_det_t   x_det     = e;
-    Material    vacuum    = lcdd.vacuum();
+    Material    vacuum    = theDetector.vacuum();
     int         det_id    = x_det.id();
     string      det_name  = x_det.nameStr();
     bool        reflect   = x_det.reflect(false);
@@ -38,17 +54,17 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
     
     // --- create an envelope volume and position it into the world ---------------------
     
-    Volume envelope = XML::createPlacedEnvelope( lcdd,  e , sdet ) ;
-    XML::setDetectorTypeFlag( e, sdet ) ;
+    Volume envelope = dd4hep::xml::createPlacedEnvelope( theDetector,  e , sdet ) ;
+    dd4hep::xml::setDetectorTypeFlag( e, sdet ) ;
     
-    if( lcdd.buildType() == BUILD_ENVELOPE ) return sdet ;
+    if( theDetector.buildType() == BUILD_ENVELOPE ) return sdet ;
     
     //-----------------------------------------------------------------------------------
     
-    DDRec::ZDiskPetalsData*  zDiskPetalsData = new DDRec::ZDiskPetalsData ;
+    ZDiskPetalsData*  zDiskPetalsData = new ZDiskPetalsData ;
     
     
-    envelope.setVisAttributes(lcdd.invisible());
+    envelope.setVisAttributes(theDetector.invisible());
     sens.setType("tracker");
     
     for(xml_coll_t mi(x_det,_U(module)); mi; ++mi, ++m_id)  {
@@ -66,7 +82,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
         
         y1 = y2 = total_thickness / 2;
         Volume  m_volume(m_nam, Trapezoid(x1, x2, y1, y2, z), vacuum);
-        m_volume.setVisAttributes(lcdd.visAttributes(x_mod.visStr()));
+        m_volume.setVisAttributes(theDetector.visAttributes(x_mod.visStr()));
         
         
         //Iterate through slices. The first slice (top in the xml) is placed at the "bottom" of the module
@@ -74,11 +90,11 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
         for(ci.reset(), n_sensor=1, c_id=0, posY=-y1; ci; ++ci, ++c_id)  {
             xml_comp_t c       = ci;
             double     c_thick = c.thickness();
-            Material   c_mat   = lcdd.material(c.materialStr());
+            Material   c_mat   = theDetector.material(c.materialStr());
             string     c_name  = _toString(c_id,"component%d");
             Volume     c_vol(c_name, Trapezoid(x1,x2,c_thick/2e0,c_thick/2e0,z), c_mat);
             
-            c_vol.setVisAttributes(lcdd.visAttributes(c.visStr()));
+            c_vol.setVisAttributes(theDetector.visAttributes(c.visStr()));
             pv = m_volume.placeVolume(c_vol,Position(0,posY+c_thick/2,0));
             if ( c.isSensitive() ) {
 //                 sdet.check(n_sensor > 1,"TrackerEndcap:fromCompact: "+c_name+" Max of 1 sensitive elemets allowed!");
@@ -109,13 +125,13 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
             double phi      = phi0;
             Placements& sensVols = sensitives[m_nam];
             
-            DDRec::ZDiskPetalsData::LayerLayout thisLayer ;
+            ZDiskPetalsData::LayerLayout thisLayer ;
             
             ///FIXME! ALL THIS NEEDS TO BE CHECKED and actually are not needed for CED
-            thisLayer.typeFlags[ DDRec::ZDiskPetalsData::SensorType::DoubleSided ] = false ; ///CHECK FIXME
-            thisLayer.typeFlags[ DDRec::ZDiskPetalsData::SensorType::Pixel ]     = false ;  ///CHECK
+            thisLayer.typeFlags[ ZDiskPetalsData::SensorType::DoubleSided ] = false ; ///CHECK FIXME
+            thisLayer.typeFlags[ ZDiskPetalsData::SensorType::Pixel ]     = false ;  ///CHECK
             
-            DD4hep::Geometry::Trapezoid mod_shape(m_vol.solid());
+            Trapezoid mod_shape(m_vol.solid());
             
             
             thisLayer.petalHalfAngle   = 0;
@@ -188,7 +204,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
     
     
     
-    sdet.addExtension< DDRec::ZDiskPetalsData >( zDiskPetalsData ) ;
+    sdet.addExtension< ZDiskPetalsData >( zDiskPetalsData ) ;
     
     
     return sdet;

--- a/detector/tracker/TrackerEndcap_o1_v04_geo.cpp
+++ b/detector/tracker/TrackerEndcap_o1_v04_geo.cpp
@@ -27,13 +27,29 @@
 
 
 using namespace std;
-using namespace DD4hep;
-using namespace DD4hep::Geometry;
 
-static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
+using dd4hep::Assembly;
+using dd4hep::BUILD_ENVELOPE;
+using dd4hep::Box;
+using dd4hep::DetElement;
+using dd4hep::Detector;
+using dd4hep::Material;
+using dd4hep::PlacedVolume;
+using dd4hep::Position;
+using dd4hep::Ref_t;
+using dd4hep::RotationZYX;
+using dd4hep::SensitiveDetector;
+using dd4hep::Transform3D;
+using dd4hep::Trapezoid;
+using dd4hep::Tube;
+using dd4hep::Volume;
+using dd4hep::_toString;
+using dd4hep::rec::ZDiskPetalsData;
+
+static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector sens)  {
     typedef vector<PlacedVolume> Placements;
     xml_det_t   x_det     = e;
-    Material    vacuum    = lcdd.vacuum();
+    Material    vacuum    = theDetector.vacuum();
     int         det_id    = x_det.id();
     string      det_name  = x_det.nameStr();
     bool        reflect   = x_det.reflect(false);
@@ -45,18 +61,18 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
     
     // --- create an envelope volume and position it into the world ---------------------
     
-    Volume envelope = XML::createPlacedEnvelope( lcdd,  e , sdet ) ;
-    XML::setDetectorTypeFlag( e, sdet ) ;
+    Volume envelope = dd4hep::xml::createPlacedEnvelope( theDetector,  e , sdet ) ;
+    dd4hep::xml::setDetectorTypeFlag( e, sdet ) ;
     
-    if( lcdd.buildType() == BUILD_ENVELOPE ) return sdet ;
+    if( theDetector.buildType() == BUILD_ENVELOPE ) return sdet ;
     
     //-----------------------------------------------------------------------------------
     
-    DDRec::ZDiskPetalsData*  zDiskPetalsData = new DDRec::ZDiskPetalsData ;
+    ZDiskPetalsData*  zDiskPetalsData = new ZDiskPetalsData ;
     std::map< std::string, double > moduleSensThickness;
     
     
-    envelope.setVisAttributes(lcdd.invisible());
+    envelope.setVisAttributes(theDetector.invisible());
     sens.setType("tracker");
     
     for(xml_coll_t mi(x_det,_U(module)); mi; ++mi, ++m_id)  {
@@ -74,7 +90,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
         
         y1 = y2 = total_thickness / 2;
         Volume  m_volume(m_nam, Trapezoid(x1, x2, y1, y2, z), vacuum);
-        m_volume.setVisAttributes(lcdd.visAttributes(x_mod.visStr()));
+        m_volume.setVisAttributes(theDetector.visAttributes(x_mod.visStr()));
         
         
         //Iterate through slices. The first slice (top in the xml) is placed at the "bottom" of the module
@@ -82,11 +98,11 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
         for(ci.reset(), n_sensor=1, c_id=0, posY=-y1; ci; ++ci, ++c_id)  {
             xml_comp_t c       = ci;
             double     c_thick = c.thickness();
-            Material   c_mat   = lcdd.material(c.materialStr());
+            Material   c_mat   = theDetector.material(c.materialStr());
             string     c_name  = _toString(c_id,"component%d");
             Volume     c_vol(c_name, Trapezoid(x1,x2,c_thick/2e0,c_thick/2e0,z), c_mat);
             
-            c_vol.setVisAttributes(lcdd.visAttributes(c.visStr()));
+            c_vol.setVisAttributes(theDetector.visAttributes(c.visStr()));
             pv = m_volume.placeVolume(c_vol,Position(0,posY+c_thick/2,0));
             if ( c.isSensitive() ) {
 //                 sdet.check(n_sensor > 1,"TrackerEndcap:fromCompact: "+c_name+" Max of 1 sensitive elemets allowed!");
@@ -126,7 +142,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
             Placements& sensVols = sensitives[m_nam];
             sensitiveThickness = moduleSensThickness[m_nam];
             
-            DD4hep::Geometry::Trapezoid mod_shape(m_vol.solid());
+            Trapezoid mod_shape(m_vol.solid());
             
              if(r - mod_shape->GetDZ()<innerR)
                  innerR= r- mod_shape->GetDZ();
@@ -177,7 +193,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
             ++ring_no;
         }
         
-            DDRec::ZDiskPetalsData::LayerLayout thisLayer ;
+            ZDiskPetalsData::LayerLayout thisLayer ;
             
             ///NOTE: Only filling what needed for CED/DDMarlinPandora
             thisLayer.zPosition= sumZ/ring_no; //calc average z
@@ -192,7 +208,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
             zDiskPetalsData->layers.push_back( thisLayer ) ;
     }
 
-    sdet.addExtension< DDRec::ZDiskPetalsData >( zDiskPetalsData ) ;
+    sdet.addExtension< ZDiskPetalsData >( zDiskPetalsData ) ;
     
     
     return sdet;

--- a/detector/tracker/TrackerEndcap_o1_v05_geo.cpp
+++ b/detector/tracker/TrackerEndcap_o1_v05_geo.cpp
@@ -32,13 +32,30 @@
 
 
 using namespace std;
-using namespace DD4hep;
-using namespace DD4hep::Geometry;
 
-static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
+using dd4hep::Assembly;
+using dd4hep::BUILD_ENVELOPE;
+using dd4hep::Box;
+using dd4hep::DetElement;
+using dd4hep::Detector;
+using dd4hep::Material;
+using dd4hep::PlacedVolume;
+using dd4hep::Position;
+using dd4hep::Ref_t;
+using dd4hep::RotationZYX;
+using dd4hep::SensitiveDetector;
+using dd4hep::Transform3D;
+using dd4hep::Trapezoid;
+using dd4hep::Tube;
+using dd4hep::Volume;
+using dd4hep::_toString;
+using dd4hep::rec::ZDiskPetalsData;
+using dd4hep::rec::NeighbourSurfacesData;
+
+static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector sens)  {
     typedef vector<PlacedVolume> Placements;
     xml_det_t   x_det     = e;
-    Material    vacuum    = lcdd.vacuum();
+    Material    vacuum    = theDetector.vacuum();
     int         det_id    = x_det.id();
     string      det_name  = x_det.nameStr();
     bool        reflect   = x_det.reflect(false);
@@ -58,19 +75,19 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
 
     // --- create an envelope volume and position it into the world ---------------------
     
-    Volume envelope = XML::createPlacedEnvelope( lcdd,  e , sdet ) ;
-    XML::setDetectorTypeFlag( e, sdet ) ;
+    Volume envelope = dd4hep::xml::createPlacedEnvelope( theDetector,  e , sdet ) ;
+    dd4hep::xml::setDetectorTypeFlag( e, sdet ) ;
     
-    if( lcdd.buildType() == BUILD_ENVELOPE ) return sdet ;
+    if( theDetector.buildType() == BUILD_ENVELOPE ) return sdet ;
     
     //-----------------------------------------------------------------------------------
     
-    DDRec::ZDiskPetalsData*  zDiskPetalsData = new DDRec::ZDiskPetalsData ;
-    DDRec::NeighbourSurfacesData*  neighbourSurfacesData = new DDRec::NeighbourSurfacesData() ;
+    ZDiskPetalsData*  zDiskPetalsData = new ZDiskPetalsData ;
+    NeighbourSurfacesData*  neighbourSurfacesData = new NeighbourSurfacesData() ;
     std::map< std::string, double > moduleSensThickness;
     
     
-    envelope.setVisAttributes(lcdd.invisible());
+    envelope.setVisAttributes(theDetector.invisible());
     sens.setType("tracker");
     
     for(xml_coll_t mi(x_det,_U(module)); mi; ++mi, ++m_id)  {
@@ -88,7 +105,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
         
         y1 = y2 = total_thickness / 2;
         Volume  m_volume(m_nam, Trapezoid(x1, x2, y1, y2, z), vacuum);
-        m_volume.setVisAttributes(lcdd.visAttributes(x_mod.visStr()));
+        m_volume.setVisAttributes(theDetector.visAttributes(x_mod.visStr()));
         
         
         //Iterate through slices. The first slice (top in the xml) is placed at the "bottom" of the module
@@ -96,11 +113,11 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
         for(ci.reset(), n_sensor=1, c_id=0, posY=-y1; ci; ++ci, ++c_id)  {
             xml_comp_t c       = ci;
             double     c_thick = c.thickness();
-            Material   c_mat   = lcdd.material(c.materialStr());
+            Material   c_mat   = theDetector.material(c.materialStr());
             string     c_name  = _toString(c_id,"component%d");
             Volume     c_vol(c_name, Trapezoid(x1,x2,c_thick/2e0,c_thick/2e0,z), c_mat);
             
-            c_vol.setVisAttributes(lcdd.visAttributes(c.visStr()));
+            c_vol.setVisAttributes(theDetector.visAttributes(c.visStr()));
             pv = m_volume.placeVolume(c_vol,Position(0,posY+c_thick/2,0));
             if ( c.isSensitive() ) {
 //                 sdet.check(n_sensor > 1,"TrackerEndcap:fromCompact: "+c_name+" Max of 1 sensitive elemets allowed!");
@@ -146,7 +163,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
             Placements& sensVols = sensitives[m_nam];
             sensitiveThickness = moduleSensThickness[m_nam];
             
-            DD4hep::Geometry::Trapezoid mod_shape(m_vol.solid());
+            Trapezoid mod_shape(m_vol.solid());
             
              if(r - mod_shape->GetDZ()<innerR)
                  innerR= r- mod_shape->GetDZ();
@@ -196,7 +213,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
 
 		//encoding
 
-		DD4hep::long64 cellID_reflect;
+		dd4hep::long64 cellID_reflect;
 		if (reflect) {
 		  encoder[lcio::LCTrackerCellID::side()] = lcio::ILDDetID::bwd;
 		  encoder[lcio::LCTrackerCellID::layer()] = l_id;
@@ -211,7 +228,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
 		encoder[lcio::LCTrackerCellID::module()] = mod_num;
 		encoder[lcio::LCTrackerCellID::sensor()] = k;
 
-		DD4hep::long64 cellID = encoder.lowWord(); // 32 bits
+		dd4hep::long64 cellID = encoder.lowWord(); // 32 bits
 
 		//compute neighbours 
 
@@ -265,7 +282,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
             ++ring_no;
         }
         
-            DDRec::ZDiskPetalsData::LayerLayout thisLayer ;
+            ZDiskPetalsData::LayerLayout thisLayer ;
             
             ///NOTE: Only filling what needed for CED/DDMarlinPandora
             thisLayer.zPosition= sumZ/ring_no; //calc average z
@@ -280,8 +297,8 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
             zDiskPetalsData->layers.push_back( thisLayer ) ;
     }
 
-    sdet.addExtension< DDRec::ZDiskPetalsData >( zDiskPetalsData ) ;
-    sdet.addExtension< DDRec::NeighbourSurfacesData >( neighbourSurfacesData ) ;
+    sdet.addExtension< ZDiskPetalsData >( zDiskPetalsData ) ;
+    sdet.addExtension< NeighbourSurfacesData >( neighbourSurfacesData ) ;
 
     
     return sdet;

--- a/detector/tracker/TrackerEndcap_o2_v05_geo.cpp
+++ b/detector/tracker/TrackerEndcap_o2_v05_geo.cpp
@@ -32,13 +32,32 @@
 
 
 using namespace std;
-using namespace DD4hep;
-using namespace DD4hep::Geometry;
 
-static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
+using dd4hep::Assembly;
+using dd4hep::BUILD_ENVELOPE;
+using dd4hep::Box;
+using dd4hep::DetElement;
+using dd4hep::Detector;
+using dd4hep::Material;
+using dd4hep::PlacedVolume;
+using dd4hep::Position;
+using dd4hep::Ref_t;
+using dd4hep::RotationX;
+using dd4hep::RotationZ;
+using dd4hep::RotationZYX;
+using dd4hep::SensitiveDetector;
+using dd4hep::Transform3D;
+using dd4hep::Trapezoid;
+using dd4hep::Tube;
+using dd4hep::Volume;
+using dd4hep::_toString;
+using dd4hep::rec::ZDiskPetalsData;
+using dd4hep::rec::NeighbourSurfacesData;
+
+static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector sens)  {
     typedef vector<PlacedVolume> Placements;
     xml_det_t   x_det     = e;
-    Material    vacuum    = lcdd.vacuum();
+    Material    vacuum    = theDetector.vacuum();
     int         det_id    = x_det.id();
     string      det_name  = x_det.nameStr();
     bool        reflect   = x_det.reflect(false);
@@ -59,19 +78,19 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
 
     // --- create an envelope volume and position it into the world ---------------------
     
-    Volume envelope = XML::createPlacedEnvelope( lcdd,  e , sdet ) ;
-    XML::setDetectorTypeFlag( e, sdet ) ;
+    Volume envelope = dd4hep::xml::createPlacedEnvelope( theDetector,  e , sdet ) ;
+    dd4hep::xml::setDetectorTypeFlag( e, sdet ) ;
     
-    if( lcdd.buildType() == BUILD_ENVELOPE ) return sdet ;
+    if( theDetector.buildType() == BUILD_ENVELOPE ) return sdet ;
     
     //-----------------------------------------------------------------------------------
     
-    DDRec::ZDiskPetalsData*  zDiskPetalsData = new DDRec::ZDiskPetalsData ;
-    DDRec::NeighbourSurfacesData*  neighbourSurfacesData = new DDRec::NeighbourSurfacesData() ;
+    ZDiskPetalsData*  zDiskPetalsData = new ZDiskPetalsData ;
+    NeighbourSurfacesData*  neighbourSurfacesData = new NeighbourSurfacesData() ;
     std::map< std::string, double > moduleSensThickness;
     
     
-    envelope.setVisAttributes(lcdd.invisible());
+    envelope.setVisAttributes(theDetector.invisible());
     sens.setType("tracker");
     
     for(xml_coll_t mi(x_det,_U(module)); mi; ++mi, ++m_id)  {
@@ -88,7 +107,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
         
         double dz = total_thickness / 2.;
         Volume  m_volume(m_nam, Box(dx, dy, dz), vacuum);
-        m_volume.setVisAttributes(lcdd.visAttributes(x_mod.visStr()));
+        m_volume.setVisAttributes(theDetector.visAttributes(x_mod.visStr()));
         
         
         //Iterate through slices. The first slice (top in the xml) is placed at the "bottom" of the module
@@ -96,11 +115,11 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
         for(ci.reset(), n_sensor=1, c_id=0, posZ=-dz; ci; ++ci, ++c_id)  {
             xml_comp_t c       = ci;
             double     c_thick = c.thickness();
-            Material   c_mat   = lcdd.material(c.materialStr());
+            Material   c_mat   = theDetector.material(c.materialStr());
             string     c_name  = _toString(c_id,"component%d");
             Volume     c_vol(c_name, Box(dx,dy,c_thick/2.0), c_mat);
             
-            c_vol.setVisAttributes(lcdd.visAttributes(c.visStr()));
+            c_vol.setVisAttributes(theDetector.visAttributes(c.visStr()));
             pv = m_volume.placeVolume(c_vol,Position(0,0,posZ+c_thick/2.0));
             if ( c.isSensitive() ) {
 //                 sdet.check(n_sensor > 1,"TrackerEndcap:fromCompact: "+c_name+" Max of 1 sensitive elemets allowed!");
@@ -146,7 +165,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
             sensitiveThickness = moduleSensThickness[m_nam];
             
             
-            DD4hep::Geometry::Box mod_shape(m_vol.solid());
+            Box mod_shape(m_vol.solid());
             
              if(r - mod_shape->GetDZ()<innerR)
                  innerR= r- mod_shape->GetDZ();
@@ -198,7 +217,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
 
 		//encoding
 
-		DD4hep::long64 cellID_reflect;
+		dd4hep::long64 cellID_reflect;
 		if (reflect) {
 		  encoder[lcio::LCTrackerCellID::side()] = lcio::ILDDetID::bwd;
 		  encoder[lcio::LCTrackerCellID::layer()] = l_id;
@@ -213,7 +232,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
 		encoder[lcio::LCTrackerCellID::module()] = mod_num;
 		encoder[lcio::LCTrackerCellID::sensor()] = k;
 
-		DD4hep::long64 cellID = encoder.lowWord(); // 32 bits
+		dd4hep::long64 cellID = encoder.lowWord(); // 32 bits
 
 		//compute neighbours 
 
@@ -267,7 +286,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
             ++ring_no;
         }
         
-            DDRec::ZDiskPetalsData::LayerLayout thisLayer ;
+            ZDiskPetalsData::LayerLayout thisLayer ;
             
             ///NOTE: Only filling what needed for CED/DDMarlinPandora
             thisLayer.zPosition= sumZ/ring_no; //calc average z
@@ -282,8 +301,8 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
             zDiskPetalsData->layers.push_back( thisLayer ) ;
     }
 
-    sdet.addExtension< DDRec::ZDiskPetalsData >( zDiskPetalsData ) ;
-    sdet.addExtension< DDRec::NeighbourSurfacesData >( neighbourSurfacesData ) ;
+    sdet.addExtension< ZDiskPetalsData >( zDiskPetalsData ) ;
+    sdet.addExtension< NeighbourSurfacesData >( neighbourSurfacesData ) ;
 
     
     return sdet;

--- a/detector/tracker/VXD04_geo.cpp
+++ b/detector/tracker/VXD04_geo.cpp
@@ -19,13 +19,31 @@
 #include <cmath>
 
 using namespace std;
-using namespace DD4hep;
-using namespace dd4hep ;
-using namespace DD4hep::Geometry;
-using namespace DDRec;
 
-
-
+using dd4hep::Assembly;
+using dd4hep::BUILD_ENVELOPE;
+using dd4hep::Box;
+using dd4hep::ConeSegment;
+using dd4hep::DetElement;
+using dd4hep::Detector;
+using dd4hep::Material;
+using dd4hep::PlacedVolume;
+using dd4hep::Position;
+using dd4hep::Ref_t;
+using dd4hep::RotationZYX;
+using dd4hep::SensitiveDetector;
+using dd4hep::Torus;
+using dd4hep::Transform3D;
+using dd4hep::Tube;
+using dd4hep::Volume;
+using dd4hep::_toString;
+using dd4hep::rec::SurfaceType;
+using dd4hep::rec::Vector3D;
+using dd4hep::rec::VolCone;
+using dd4hep::rec::VolPlane;
+using dd4hep::rec::VolCylinder;
+using dd4hep::rec::ZPlanarData;
+using dd4hep::rec::volSurfaceList;
 
 /** Construction of VTX detector, ported from Mokka driver VXD04.cc
  *
@@ -39,7 +57,7 @@ using namespace DDRec;
  *  @author: F.Gaede, DESY, Nov 2013
  *
  */
-static Ref_t create_element(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
+static Ref_t create_element(Detector& theDetector, xml_h e, SensitiveDetector sens)  {
   
   xml_det_t    x_det = e;
   string       name  = x_det.nameStr();
@@ -48,11 +66,11 @@ static Ref_t create_element(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
   
   // --- create an envelope volume and position it into the world ---------------------
   
-  Volume envelope = XML::createPlacedEnvelope( lcdd,  e , vxd ) ;
+  Volume envelope = dd4hep::xml::createPlacedEnvelope( theDetector,  e , vxd ) ;
   
-  XML::setDetectorTypeFlag( e, vxd ) ;
+  dd4hep::xml::setDetectorTypeFlag( e, vxd ) ;
 
-  if( lcdd.buildType() == BUILD_ENVELOPE ) return vxd ;
+  if( theDetector.buildType() == BUILD_ENVELOPE ) return vxd ;
 
   //-----------------------------------------------------------------------------------
 
@@ -179,10 +197,10 @@ static Ref_t create_element(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
   //   encoder[LCTrackerCellID::sensor()] = 0 ;
   //   int cellID0 = encoder.lowWord() ;
 
-  Material activeMaterial =  lcdd.material("G4_Si"); //silicon_2.33gccm"); 
+  Material activeMaterial =  theDetector.material("G4_Si"); //silicon_2.33gccm"); 
   
 
-  DDRec::ZPlanarData*  zPlanarData = new ZPlanarData ;
+  ZPlanarData*  zPlanarData = new ZPlanarData ;
 
 // #ifdef MOKKA_GEAR
 //   // some variables for storing information for MOKKA_GEAR
@@ -242,7 +260,7 @@ static Ref_t create_element(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
     // **********************   flex  cable *****************************************
     // ****************************************************************************************
     
-    Material flexCableMaterial =  lcdd.material( flex_cable_material ); 
+    Material flexCableMaterial =  theDetector.material( flex_cable_material ); 
     
     Box FlexCableSolid( ladder_width+(side_band_electronics_option*side_band_electronics_width/2.),
 			ladder_length+(end_ladd_electronics_option*(2*end_electronics_half_z)) + beryllium_ladder_block_length*2.,
@@ -269,7 +287,7 @@ static Ref_t create_element(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
     //  			0,
     //  			0);
     
-    vxd.setVisAttributes(lcdd,  "RedVis" , FlexCableLogical);
+    vxd.setVisAttributes(theDetector,  "RedVis" , FlexCableLogical);
     //** ----- Original Mokke/Geant4 code: -----
     //    FlexCableLogical->SetVisAttributes(flex_cableVisAtt);
     
@@ -277,7 +295,7 @@ static Ref_t create_element(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
     // **********************   metal traces  *****************************************
     // ****************************************************************************************
     
-    Material metalTracesMaterial = lcdd.material( metal_traces_material); 
+    Material metalTracesMaterial = theDetector.material( metal_traces_material); 
     
     Box MetalTracesSolid( ladder_width+(side_band_electronics_option*side_band_electronics_width/2.),
 			  ladder_length+(end_ladd_electronics_option*(2*end_electronics_half_z)) + beryllium_ladder_block_length*2.,
@@ -285,13 +303,13 @@ static Ref_t create_element(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
     
     Volume MetalTracesLogical( _toString(LayerId,"MetalTraces_%02d") , MetalTracesSolid,metalTracesMaterial ) ;
     
-    vxd.setVisAttributes(lcdd,  "GrayVis" , MetalTracesLogical) ;
+    vxd.setVisAttributes(theDetector,  "GrayVis" , MetalTracesLogical) ;
     
     // ****************************************************************************************
     // **********************   foam spacer n support  *****************************************
     // ****************************************************************************************
     
-    Material foamSpacerMaterial = lcdd.material( foam_spacer_material);
+    Material foamSpacerMaterial = theDetector.material( foam_spacer_material);
     
     Box FoamSpacerSolid( support_width+(side_band_electronics_option*side_band_electronics_width/2.),
 			 ladder_length+(end_ladd_electronics_option*(2*end_electronics_half_z)) + beryllium_ladder_block_length*2. ,
@@ -299,11 +317,11 @@ static Ref_t create_element(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
     
     Volume FoamSpacerLogical( _toString(LayerId,"FoamSpacer_%02d"), FoamSpacerSolid, foamSpacerMaterial) ;
       
-    vxd.setVisAttributes(lcdd, "YellowVis", FoamSpacerLogical ) ;
+    vxd.setVisAttributes(theDetector, "YellowVis", FoamSpacerLogical ) ;
 
     //here we place the physical volumes of both the flex cable (kapton & metal traces) and the foam spacer
     
-    phirot = (2*pi)/nb_ladder;
+    phirot = (2*M_PI)/nb_ladder;
     
     double ladder_clothest_approch = beryllium_ladder_block_thickness*2 +0.1;
 
@@ -327,9 +345,9 @@ static Ref_t create_element(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
 	double phirot2 = ladder_loop*phirot;
 
 	// RotationMatrix *rot = new RotationMatrix();
-	// rot->rotateX(pi*0.5);
+	// rot->rotateX(M_PI*0.5);
 	// rot->rotateY(phirot2);
-	RotationZYX rot( 0, phirot2 , (pi*0.5) ) ;
+	RotationZYX rot( 0, phirot2 , (M_PI*0.5) ) ;
 	
 	supp_assembly.placeVolume( FlexCableLogical,
 				   Transform3D( rot, Position(( layer_radius + metal_traces_thickness + (flex_cable_thickness/2.))*sin(phirot2)+offset_phi*cos(phirot2),
@@ -362,7 +380,7 @@ static Ref_t create_element(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
 	
 	double phirot2 = ladder_loop*phirot;
 	
-	RotationZYX rot( 0, phirot2 , (pi*0.5) ) ;
+	RotationZYX rot( 0, phirot2 , (M_PI*0.5) ) ;
 	
 	supp_assembly.placeVolume( FlexCableLogical,
 				   Transform3D( rot, Position((layer_radius-(metal_traces_thickness + flex_cable_thickness/2.)+layer_gap)*sin(phirot2)+offset_phi*cos(phirot2),
@@ -488,7 +506,7 @@ static Ref_t create_element(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
 
 // #endif
 
-    DDRec::ZPlanarData::LayerLayout thisLayer ;
+    ZPlanarData::LayerLayout thisLayer ;
     
     if (LayerId==1||LayerId==3||LayerId==5) { 
       
@@ -518,9 +536,9 @@ static Ref_t create_element(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
       
       Box BerylliumAnnulusBlockSolid( ladder_width, beryllium_ladder_block_length, beryllium_ladder_block_thickness);
       
-      Volume BerylliumAnnulusBlockLogical( _toString(LayerId,"BerylliumAnnulusBlock_%02d"), BerylliumAnnulusBlockSolid, lcdd.material("G4_Be")) ; //"beryllium") ) ;
+      Volume BerylliumAnnulusBlockLogical( _toString(LayerId,"BerylliumAnnulusBlock_%02d"), BerylliumAnnulusBlockSolid, theDetector.material("G4_Be")) ; //"beryllium") ) ;
       
-      vxd.setVisAttributes(lcdd,  "CyanVis" , BerylliumAnnulusBlockLogical) ;
+      vxd.setVisAttributes(theDetector,  "CyanVis" , BerylliumAnnulusBlockLogical) ;
 
 
       //====== create the meassurement surface for Be annulus block ===================
@@ -539,7 +557,7 @@ static Ref_t create_element(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
 	
 	double phirot2 = phirot*AnnulusBlock_loop;
 
-	RotationZYX rot( 0, phirot2 ,  pi*0.5 ) ;
+	RotationZYX rot( 0, phirot2 ,  M_PI*0.5 ) ;
 	
 	double ZAnnulusBlock = ladder_length + end_electronics_half_z + (beryllium_ladder_block_length*2.);
 	    
@@ -570,7 +588,7 @@ static Ref_t create_element(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
 	std::string volName = _toString(LayerId,"BerylliumAnnulusBlock_%02d") ;
 	volName +=  _toString( int(AnnulusBlock_loop), "_%02d");
 
-	Volume BerylliumAnnulusBlockLogical( volName , BerylliumAnnulusBlockSolid, lcdd.material("G4_Be")) ; //"beryllium") ) ;
+	Volume BerylliumAnnulusBlockLogical( volName , BerylliumAnnulusBlockSolid, theDetector.material("G4_Be")) ; //"beryllium") ) ;
 
 	//====== create the meassurement surface for Be annulus block ===================
 	Vector3D u( 1. , 0. , 0. ) ;
@@ -583,11 +601,11 @@ static Ref_t create_element(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
 	std::string annBlockNameP =  _toString( LayerId , "BerylliumAnnulusBlock_%02d_posZ") + _toString( (int)AnnulusBlock_loop, "_%02d" ) ;
 	std::string annBlockNameN =  _toString( LayerId , "BerylliumAnnulusBlock_%02d_negZ") + _toString( (int)AnnulusBlock_loop, "_%02d" ) ;
 	
-	vxd.setVisAttributes(lcdd,  "CyanVis" , BerylliumAnnulusBlockLogical) ;
+	vxd.setVisAttributes(theDetector,  "CyanVis" , BerylliumAnnulusBlockLogical) ;
 	
 	double phirot2 = phirot*AnnulusBlock_loop;
 	
-	RotationZYX rot( 0, phirot2 , (pi*0.5) ) ;
+	RotationZYX rot( 0, phirot2 , (M_PI*0.5) ) ;
 	
 	double ZAnnulusBlock2=shell_half_z -(beryllium_ladder_block_length2/2.);// - (shell_thickess/2.); 
 	
@@ -621,7 +639,7 @@ static Ref_t create_element(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
       
       Volume ElectronicsEndLogical(_toString(LayerId,"ElectronicsEnd_%02d"),ElectronicsEndSolid, activeMaterial ); //("silicon_2.33gccm")
       
-      vxd.setVisAttributes(lcdd,  "GreenVis" , ElectronicsEndLogical );
+      vxd.setVisAttributes(theDetector,  "GreenVis" , ElectronicsEndLogical );
       
       double end_ladd_electronic_offset_phi = offset_phi +(side_band_electronics_option * side_band_electronics_width/2.);
       
@@ -643,7 +661,7 @@ static Ref_t create_element(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
 	  std::string elecEndLadNameN =  _toString( LayerId , "ElectronicsEnd_%02d_negZ") + _toString( (int)elec_loop, "_%02d" ) ;
 	  
 	  double phirot2 = phirot*elec_loop;
-	  RotationZYX rot( 0, phirot2 , (pi*0.5) ) ;    
+	  RotationZYX rot( 0, phirot2 , (M_PI*0.5) ) ;    
 	  
 	  double Z = ladder_length +end_electronics_half_z + (ladder_gap/2.);
 	  
@@ -674,7 +692,7 @@ static Ref_t create_element(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
 	  std::string elecEndLadNameN =  _toString( LayerId , "ElectronicsEnd_%02d_negZ") + _toString( (int)elec_loop, "_%02d" ) ;
 	  
 	  double phirot2 = phirot*elec_loop;
-	  RotationZYX rot( 0, phirot2 , (pi*0.5) ) ;    
+	  RotationZYX rot( 0, phirot2 , (M_PI*0.5) ) ;    
 	  
 	  double Z = ladder_length +end_electronics_half_z + (ladder_gap/2.);
 	  
@@ -707,7 +725,7 @@ static Ref_t create_element(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
       
       Volume ElectronicsBandLogical(_toString(LayerId,"ElectronicsBand_%02d"), ElectronicsBandSolid, activeMaterial ) ;
       
-      vxd.setVisAttributes(lcdd,  "GreenVis" , ElectronicsBandLogical ) ;
+      vxd.setVisAttributes(theDetector,  "GreenVis" , ElectronicsBandLogical ) ;
       
       //fixme: turn off sensitive sidebands for now - not sure they cause problems in the volume manager ....
       // active_side_band_electronics_option = 0 ;
@@ -722,7 +740,7 @@ static Ref_t create_element(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
 	for (double elec_loop=0; elec_loop<nb_ladder;elec_loop++) {   
 	  
 	  double phirot2 = phirot*elec_loop;
-	  RotationZYX rot( 0, phirot2 , (pi*0.5) ) ;   
+	  RotationZYX rot( 0, phirot2 , (M_PI*0.5) ) ;   
 	  
 	  double Z = (ladder_length* (1-side_band_electronics_option/2.)) + ladder_gap/2.;
 	  
@@ -754,7 +772,7 @@ static Ref_t create_element(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
 	for (double elec_loop=0; elec_loop<nb_ladder;elec_loop++) { 
 	  
 	  double phirot2 = phirot*elec_loop;
-	  RotationZYX rot( 0, phirot2 , (pi*0.5) ) ;   
+	  RotationZYX rot( 0, phirot2 , (M_PI*0.5) ) ;   
 
 	  double Z = (ladder_length* (1-side_band_electronics_option/2.)) + ladder_gap/2.;
 	      
@@ -822,7 +840,7 @@ static Ref_t create_element(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
       
       Volume KaptonLinesLogical( _toString(LayerId,"KaptonLines_%02d"), KaptonLinesSolid, flexCableMaterial ) ;
       
-      vxd.setVisAttributes(lcdd,  "WhiteVis" , KaptonLinesLogical );
+      vxd.setVisAttributes(theDetector,  "WhiteVis" , KaptonLinesLogical );
       
       //Here we define the solid and logical volumes of the metal traces of the strip lines
       ConeSegment MetalLinesSolid( strip_line_half_z,
@@ -834,7 +852,7 @@ static Ref_t create_element(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
       
       Volume MetalLinesLogical( _toString(LayerId,"MetalLines_%02d"), MetalLinesSolid, metalTracesMaterial );
       
-      vxd.setVisAttributes(lcdd,  "GrayVis" , MetalLinesLogical) ;
+      vxd.setVisAttributes(theDetector,  "GrayVis" , MetalLinesLogical) ;
       
       //here we place both the kapton and copper part of the strip lines
       double Z = strip_line_start_z + strip_line_half_z;
@@ -884,7 +902,7 @@ static Ref_t create_element(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
 	//volSurfaceList( suppPosMetallinesDE )->push_back( conSurf2 );
 
 	
-	RotationZYX rot( 0, 0 , pi ) ;   // the same but other side
+	RotationZYX rot( 0, 0 , M_PI ) ;   // the same but other side
 
 	PlacedVolume pv_kap_neg = supp_assembly.placeVolume( KaptonLinesLogical,  Transform3D( rot , Position(0., 0., -Z) ) );
 
@@ -936,7 +954,7 @@ static Ref_t create_element(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
 	volSurfaceList( suppPosMetallinesDE )->push_back( conSurf2 );
 	
       
-	RotationZYX rot( 0, 0 , pi ) ;   // the same but other side
+	RotationZYX rot( 0, 0 , M_PI ) ;   // the same but other side
 	
 	PlacedVolume pv_kap_neg = supp_assembly.placeVolume( KaptonLinesLogical,  Transform3D( rot , Position(0., 0., -Z) ) );
 
@@ -980,9 +998,9 @@ static Ref_t create_element(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
     Torus CoolPipeSolid(layer_radius + layer_gap + cool_pipe_outer_radius/2., cool_pipe_inner_radius,
 			cool_pipe_outer_radius, sPhi, dPhi);
     
-    Volume CoolPipeLogical(_toString(LayerId,"CoolPipe_%02d"), CoolPipeSolid, lcdd.material("G4_Ti")) ; //titanium") ) ;
+    Volume CoolPipeLogical(_toString(LayerId,"CoolPipe_%02d"), CoolPipeSolid, theDetector.material("G4_Ti")) ; //titanium") ) ;
     
-    vxd.setVisAttributes(lcdd,  "MagentaVis" , CoolPipeLogical );
+    vxd.setVisAttributes(theDetector,  "MagentaVis" , CoolPipeLogical );
 
     //one cooling pipe for each double layer
  
@@ -1011,9 +1029,9 @@ static Ref_t create_element(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
       
       Tube CoolPipeTubeSolid( cool_pipe_inner_radius, cool_pipe_outer_radius, CoolPipeLength/2., sPhi, sPhi+dPhi );
       
-      Volume CoolPipeTubeLogical( _toString(LayerId,"CoolPipeTube_%02d"), CoolPipeTubeSolid, lcdd.material("G4_Ti")) ; //titanium") ) ; 
+      Volume CoolPipeTubeLogical( _toString(LayerId,"CoolPipeTube_%02d"), CoolPipeTubeSolid, theDetector.material("G4_Ti")) ; //titanium") ) ; 
       
-      vxd.setVisAttributes(lcdd,  "MagentaVis" , CoolPipeTubeLogical );
+      vxd.setVisAttributes(theDetector,  "MagentaVis" , CoolPipeTubeLogical );
       
       //**fg: reversed sign compared to original VXD04.cc as this created obvious overlaps in TGeo (also in Mokka ???)
       RotationZYX rm( 0., 0., -thetaTube);
@@ -1045,7 +1063,7 @@ static Ref_t create_element(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
       
     Volume SiActiveLayerLogical( _toString( LayerId , "SiActiveLayer_%02d"),SiActiveLayerSolid, activeMaterial ) ;
 
-    vxd.setVisAttributes(lcdd,  "BlueVis" , SiActiveLayerLogical ) ;
+    vxd.setVisAttributes(theDetector,  "BlueVis" , SiActiveLayerLogical ) ;
 
     SiActiveLayerLogical.setSensitiveDetector(sens);
    
@@ -1068,7 +1086,7 @@ static Ref_t create_element(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
     for (double active_loop=0;active_loop<nb_ladder;active_loop++){
 	
       double phirot2 =  phirot*active_loop;
-      RotationZYX rot( 0. , phirot2, (pi*0.5) ) ;
+      RotationZYX rot( 0. , phirot2, (M_PI*0.5) ) ;
 	
       double Z = ladder_length/2.+ ladder_gap;
 	
@@ -1170,7 +1188,7 @@ static Ref_t create_element(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
     // #endif
 
 
-    //--- fill DDRec::ZPlanarData
+    //--- fill ZPlanarData
 
     if (LayerId==1||LayerId==3||LayerId==5)  { 
 
@@ -1196,7 +1214,7 @@ static Ref_t create_element(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
     }
 
     thisLayer.ladderNumber = (int) nb_ladder  ;
-    thisLayer.phi0 =  -pi/2.  ;
+    thisLayer.phi0 =  -M_PI/2.  ;
     
     zPlanarData->layers.push_back( thisLayer ) ;
 
@@ -1227,16 +1245,16 @@ static Ref_t create_element(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
     Tube ExternalKaptonCablesSolid(cryostat_apperture, cryostat_apperture + 3*external_kapton_thickness/2.,  external_cable_length, sPhi, sPhi+dPhi);
     //The reason for the factor three is that the thickness refer to the thickness of each single cable, and we have three cables in total, one per layer
 
-    Volume ExternalKaptonCablesLogical("ExternalKaptonCables", ExternalKaptonCablesSolid, lcdd.material("G4_KAPTON") );
+    Volume ExternalKaptonCablesLogical("ExternalKaptonCables", ExternalKaptonCablesSolid, theDetector.material("G4_KAPTON") );
  
-    vxd.setVisAttributes(lcdd,  "WhiteVis" , ExternalKaptonCablesLogical );
+    vxd.setVisAttributes(theDetector,  "WhiteVis" , ExternalKaptonCablesLogical );
 
     //metal part
     Tube ExternalMetalCablesSolid(cryostat_apperture - 3*external_metal_thickness/2., cryostat_apperture, external_cable_length,  sPhi, sPhi+dPhi);
 
-    Volume ExternalMetalCablesLogical("ExternalMetalCables", ExternalMetalCablesSolid ,  lcdd.material("G4_Cu") ) ;
+    Volume ExternalMetalCablesLogical("ExternalMetalCables", ExternalMetalCablesSolid ,  theDetector.material("G4_Cu") ) ;
  
-    vxd.setVisAttributes(lcdd,  "GrayVis" , ExternalMetalCablesLogical );
+    vxd.setVisAttributes(theDetector,  "GrayVis" , ExternalMetalCablesLogical );
 
     
     //====== YV: create a material surface for the cabling outside the VXD  ===================
@@ -1280,9 +1298,9 @@ static Ref_t create_element(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
   
   Tube SupportShellSolid( shell_inner_radious, shell_inner_radious+shell_thickess, shell_half_z, sPhi, sPhi+dPhi );
 
-  Volume SupportShellLogical("SupportShell", SupportShellSolid,  lcdd.material("G4_Be")) ; //"beryllium") ) ;
+  Volume SupportShellLogical("SupportShell", SupportShellSolid,  theDetector.material("G4_Be")) ; //"beryllium") ) ;
 
-  vxd.setVisAttributes(lcdd,  "CyanVis" , SupportShellLogical ) ;
+  vxd.setVisAttributes(theDetector,  "CyanVis" , SupportShellLogical ) ;
   
 
   //====== create a material surface for the support shell ===================
@@ -1306,9 +1324,9 @@ static Ref_t create_element(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
   
   Tube EndPlateShellSolid( support_endplate_inner_radious,  shell_inner_radious+shell_thickess, support_endplate_half_z, sPhi, sPhi+dPhi ) ;
 
-  Volume EndPlateShellLogical("EndPlateShell_outer", EndPlateShellSolid,  lcdd.material("G4_Be")) ; //"beryllium") ) ;
+  Volume EndPlateShellLogical("EndPlateShell_outer", EndPlateShellSolid,  theDetector.material("G4_Be")) ; //"beryllium") ) ;
 
-  vxd.setVisAttributes(lcdd,  "CyanVis" , EndPlateShellLogical ) ;
+  vxd.setVisAttributes(theDetector,  "CyanVis" , EndPlateShellLogical ) ;
   
   double ZEndPlateShell = shell_half_z + shell_endplate_thickness/2.;// + (beryllium_ladder_block_length*2);
 
@@ -1346,9 +1364,9 @@ static Ref_t create_element(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
   
   Tube EndPlateShellSolidL1( support_endplate_inner_radious_L1, support_endplate_outer_radious_L1, support_endplate_half_z_L1, sPhi, sPhi+dPhi ) ;
   
-  Volume EndPlateShellLogicalL1("EndPlateShell_inner", EndPlateShellSolidL1,  lcdd.material("G4_Be")) ; //"beryllium") ) ;
+  Volume EndPlateShellLogicalL1("EndPlateShell_inner", EndPlateShellSolidL1,  theDetector.material("G4_Be")) ; //"beryllium") ) ;
   
-  vxd.setVisAttributes(lcdd,  "CyanVis" , EndPlateShellLogicalL1 ) ;
+  vxd.setVisAttributes(theDetector,  "CyanVis" , EndPlateShellLogicalL1 ) ;
   
   double ZEndPlateShell2 = ladder_length +  ((end_electronics_half_z*end_ladd_electronics_option) * 2) + shell_thickess/2. + (beryllium_ladder_block_length*2) ;
   
@@ -1368,9 +1386,9 @@ static Ref_t create_element(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
   //**fg, NB:  TGeoConeSeg( dz,rmin0,rmax0,rmin1,rmax1, phi0, phi1 )  -  G4Cons( rmin0,rmin1,rmax0,rmax1, dz, phi0, delta_phi ) !!!!!!!!!!!!!!!!!!!!
   //!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!      
       
-  Volume SupportConeLogical("SupportCone", SupportShellCone,  lcdd.material("G4_Be")) ; //"beryllium") ) ;
+  Volume SupportConeLogical("SupportCone", SupportShellCone,  theDetector.material("G4_Be")) ; //"beryllium") ) ;
   
-  vxd.setVisAttributes(lcdd,  "CyanVis" , SupportConeLogical ) ;
+  vxd.setVisAttributes(theDetector,  "CyanVis" , SupportConeLogical ) ;
   
   double ZCone = ladder_length +  ((end_electronics_half_z*end_ladd_electronics_option) * 2) + shell_thickess + (beryllium_ladder_block_length*2) + support_cone_half_z;
 
@@ -1388,7 +1406,7 @@ static Ref_t create_element(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
   suppShellConePosDE.setPlacement( pv_supp_pos );
   volSurfaceList( suppShellConePosDE )->push_back( suppShellCone );
 
-  PlacedVolume pv_supp_neg = supp_assembly.placeVolume( SupportConeLogical, Transform3D( RotationZYX( 0, 0, pi ), Position(0., 0., -ZCone ) ) ) ;
+  PlacedVolume pv_supp_neg = supp_assembly.placeVolume( SupportConeLogical, Transform3D( RotationZYX( 0, 0, M_PI ), Position(0., 0., -ZCone ) ) ) ;
   DetElement suppShellConeNegDE ( suppDE , "negShellCone" , x_det.id() )  ;
   suppShellConeNegDE.setPlacement( pv_supp_neg );
   volSurfaceList( suppShellConeNegDE )->push_back( suppShellCone );
@@ -1399,12 +1417,12 @@ static Ref_t create_element(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
   
   Tube SupportForSolid( support_endplate_inner_radious, support_endplate_inner_radious + shell_endplate_thickness, forward_shell_half_z,  sPhi, sPhi+dPhi ) ;
 
-  Volume SupportForLogical("SupportFor", SupportForSolid,  lcdd.material("G4_Be")) ; //"beryllium") ) ;
+  Volume SupportForLogical("SupportFor", SupportForSolid,  theDetector.material("G4_Be")) ; //"beryllium") ) ;
 
-  vxd.setVisAttributes(lcdd,  "CyanVis" , SupportForLogical ) ;
+  vxd.setVisAttributes(theDetector,  "CyanVis" , SupportForLogical ) ;
 
   supp_assembly.placeVolume( SupportForLogical, Transform3D( RotationZYX( 0, 0, 0  ), Position(0., 0.,  supportForZ ) ) ) ;
-  supp_assembly.placeVolume( SupportForLogical, Transform3D( RotationZYX( 0, 0, pi ), Position(0., 0., -supportForZ ) ) ) ;
+  supp_assembly.placeVolume( SupportForLogical, Transform3D( RotationZYX( 0, 0, M_PI ), Position(0., 0., -supportForZ ) ) ) ;
 
   
   //*** Cryostat ***************************************************************
@@ -1416,21 +1434,21 @@ static Ref_t create_element(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
   double aluHalfZ = dzSty + drSty;
   
   if (useCryo) {
-    Material aluMaterial = lcdd.material( "G4_Al" ) ;
+    Material aluMaterial = theDetector.material( "G4_Al" ) ;
     //          VisAttributes *aluVisAttributes = new VisAttributes(Colour(0.5, 0.5, 0.5)); 
     
-    Material styMaterial = lcdd.material("styropor");
+    Material styMaterial = theDetector.material("styropor");
     
 
 
     Tube aluBarrelSolid( rAlu, rAlu + drAlu, aluHalfZ, sPhi, sPhi+dPhi);
     Volume aluBarrelLog( "CryostatAluSkinBarrel", aluBarrelSolid, aluMaterial );
-    vxd.setVisAttributes(lcdd,  "GrayVis" , aluBarrelLog ) ;
+    vxd.setVisAttributes(theDetector,  "GrayVis" , aluBarrelLog ) ;
     supp_assembly.placeVolume( aluBarrelLog ) ;
     
     Tube styBarrelSolid(  rSty, rSty + drSty, dzSty, sPhi, sPhi+dPhi);
     Volume styBarrelLog( "CryostatFoamBarrel", styBarrelSolid, styMaterial );
-    vxd.setVisAttributes(lcdd,  "LightGrayVis", styBarrelLog ) ;
+    vxd.setVisAttributes(theDetector,  "LightGrayVis", styBarrelLog ) ;
     supp_assembly.placeVolume( styBarrelLog ) ;
 
     //====== create a material surface for the cryostat barrel ===================
@@ -1460,7 +1478,7 @@ static Ref_t create_element(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
 
     Tube aluEndcapSolidInner(  rInner, cryostat_apperture - cryostat_apperture_radius, drAlu / 2, sPhi, sPhi+dPhi);
     Volume aluEndcapInnerLog( "CryostatAluSkinEndPlateInner", aluEndcapSolidInner, aluMaterial );
-    vxd.setVisAttributes(lcdd,  "GrayVis" , aluEndcapInnerLog ) ;
+    vxd.setVisAttributes(theDetector,  "GrayVis" , aluEndcapInnerLog ) ;
     PlacedVolume pv_alu_end_pos = supp_assembly.placeVolume( aluEndcapInnerLog , Transform3D( RotationZYX( 0, 0, 0  ), Position(0., 0.,   aluEndcapZ ) ) ) ;
     suppFwdInDE.setPlacement( pv_alu_end_pos ) ;
     PlacedVolume pv_alu_end_neg = supp_assembly.placeVolume( aluEndcapInnerLog , Transform3D( RotationZYX( 0, 0, 0  ), Position(0., 0.,  -aluEndcapZ ) ) ) ;
@@ -1468,7 +1486,7 @@ static Ref_t create_element(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
 
     Tube aluEndcapSolidOuter(   cryostat_apperture + cryostat_apperture_radius, rAlu + drAlu, drAlu / 2, sPhi, sPhi+dPhi);
     Volume aluEndcapOuterLog( "CryostatAluSkinEndPlateOuter", aluEndcapSolidOuter, aluMaterial );
-    vxd.setVisAttributes(lcdd,  "GrayVis" , aluEndcapOuterLog ) ;
+    vxd.setVisAttributes(theDetector,  "GrayVis" , aluEndcapOuterLog ) ;
     PlacedVolume pv_alu_end_out_pos = supp_assembly.placeVolume( aluEndcapOuterLog , Transform3D( RotationZYX( 0, 0, 0  ), Position(0., 0.,   aluEndcapZ ) ) ) ;
     suppFwdOutDE.setPlacement( pv_alu_end_out_pos ) ;
     PlacedVolume pv_alu_end_out_neg = supp_assembly.placeVolume( aluEndcapOuterLog , Transform3D( RotationZYX( 0, 0, 0  ), Position(0., 0.,  -aluEndcapZ ) ) ) ;
@@ -1476,13 +1494,13 @@ static Ref_t create_element(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
     
     Tube styEndcapSolidInner(  rInner, cryostat_apperture - cryostat_apperture_radius, drSty / 2, sPhi, sPhi+dPhi);
     Volume styEndcapInnerLog( "CryostatFoamEndPlateInner", styEndcapSolidInner, styMaterial );
-    vxd.setVisAttributes(lcdd,  "WhiteVis" , styEndcapInnerLog ) ;
+    vxd.setVisAttributes(theDetector,  "WhiteVis" , styEndcapInnerLog ) ;
     supp_assembly.placeVolume( styEndcapInnerLog , Transform3D( RotationZYX( 0, 0, 0  ), Position(0., 0.,   styEndcapZ ) ) ) ;
     supp_assembly.placeVolume( styEndcapInnerLog , Transform3D( RotationZYX( 0, 0, 0  ), Position(0., 0.,  -styEndcapZ ) ) ) ;
 
     Tube styEndcapSolidOuter(  cryostat_apperture + cryostat_apperture_radius, rSty + drSty, drSty / 2, sPhi, sPhi+dPhi);
     Volume styEndcapOuterLog( "CryostatFoamEndPlateOuter", styEndcapSolidOuter, styMaterial );
-    vxd.setVisAttributes(lcdd,  "WhiteVis" , styEndcapOuterLog ) ;
+    vxd.setVisAttributes(theDetector,  "WhiteVis" , styEndcapOuterLog ) ;
     supp_assembly.placeVolume( styEndcapOuterLog , Transform3D( RotationZYX( 0, 0, 0  ), Position(0., 0.,   styEndcapZ ) ) ) ;
     supp_assembly.placeVolume( styEndcapOuterLog , Transform3D( RotationZYX( 0, 0, 0  ), Position(0., 0.,  -styEndcapZ ) ) ) ;
 
@@ -1559,7 +1577,7 @@ static Ref_t create_element(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
   //--------------------------------------
   
   
-  vxd.setVisAttributes( lcdd, x_det.visStr(), envelope );
+  vxd.setVisAttributes( theDetector, x_det.visStr(), envelope );
 
   return vxd;
 }

--- a/detector/tracker/VertexEndcap_o1_v01_geo.cpp
+++ b/detector/tracker/VertexEndcap_o1_v01_geo.cpp
@@ -12,20 +12,36 @@
 #include "XML/Utilities.h"
 
 using namespace std;
-using namespace DD4hep;
-using namespace DD4hep::Geometry;
 
-static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
+using dd4hep::Assembly;
+using dd4hep::BUILD_ENVELOPE;
+using dd4hep::Box;
+using dd4hep::ConeSegment;
+using dd4hep::DetElement;
+using dd4hep::Detector;
+using dd4hep::Material;
+using dd4hep::PlacedVolume;
+using dd4hep::Position;
+using dd4hep::Ref_t;
+using dd4hep::RotationZYX;
+using dd4hep::SensitiveDetector;
+using dd4hep::Trapezoid;
+using dd4hep::Transform3D;
+using dd4hep::Tube;
+using dd4hep::Volume;
+using dd4hep::_toString;
+
+static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector sens)  {
     typedef vector<PlacedVolume> Placements;
     xml_det_t   x_det     = e;
-    Material    vacuum    = lcdd.vacuum();
+    Material    vacuum    = theDetector.vacuum();
     int         det_id    = x_det.id();
     string      det_name  = x_det.nameStr();
     bool        reflect   = x_det.reflect(false);
     DetElement  sdet        (det_name,det_id);
     // Assembly    envelope    (det_name);
     //Volume      envelope    (det_name,Box(10000,10000,10000),vacuum);
-    //unused: Volume      motherVol = lcdd.pickMotherVolume(sdet);
+    //unused: Volume      motherVol = theDetector.pickMotherVolume(sdet);
     int         m_id=0, c_id=0, n_sensor=0;
     map<string,Volume> modules;
     map<string, Placements>  sensitives;
@@ -33,15 +49,15 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
     
     // --- create an envelope volume and position it into the world ---------------------
     
-    Volume envelope = XML::createPlacedEnvelope( lcdd,  e , sdet ) ;
-    XML::setDetectorTypeFlag( e, sdet ) ;
+    Volume envelope = dd4hep::xml::createPlacedEnvelope( theDetector,  e , sdet ) ;
+    dd4hep::xml::setDetectorTypeFlag( e, sdet ) ;
   
-    if( lcdd.buildType() == BUILD_ENVELOPE ) return sdet ;
+    if( theDetector.buildType() == BUILD_ENVELOPE ) return sdet ;
     
     //-----------------------------------------------------------------------------------
     
     
-    envelope.setVisAttributes(lcdd.invisible());
+    envelope.setVisAttributes(theDetector.invisible());
     sens.setType("tracker");
     
     for(xml_coll_t mi(x_det,_U(module)); mi; ++mi, ++m_id)  {
@@ -59,16 +75,16 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
         
         y1 = y2 = total_thickness / 2;
         Volume  m_volume(m_nam, Trapezoid(x1, x2, y1, y2, z), vacuum);
-        m_volume.setVisAttributes(lcdd.visAttributes(x_mod.visStr()));
+        m_volume.setVisAttributes(theDetector.visAttributes(x_mod.visStr()));
         
         for(ci.reset(), n_sensor=1, c_id=0, posY=-y1; ci; ++ci, ++c_id)  {
             xml_comp_t c       = ci;
             double     c_thick = c.thickness();
-            Material   c_mat   = lcdd.material(c.materialStr());
+            Material   c_mat   = theDetector.material(c.materialStr());
             string     c_name  = _toString(c_id,"component%d");
             Volume     c_vol(c_name, Trapezoid(x1,x2,c_thick/2e0,c_thick/2e0,z), c_mat);
             
-            c_vol.setVisAttributes(lcdd.visAttributes(c.visStr()));
+            c_vol.setVisAttributes(theDetector.visAttributes(c.visStr()));
             pv = m_volume.placeVolume(c_vol,Position(0,posY+c_thick/2,0));
             if ( c.isSensitive() ) {
                 sdet.check(n_sensor > 2,"SiTrackerEndcap2::fromCompact: "+c_name+" Max of 2 modules allowed!");

--- a/detector/tracker/VertexEndcap_o1_v02_geo.cpp
+++ b/detector/tracker/VertexEndcap_o1_v02_geo.cpp
@@ -12,20 +12,36 @@
 #include "XML/Utilities.h"
 
 using namespace std;
-using namespace DD4hep;
-using namespace DD4hep::Geometry;
 
-static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
+using dd4hep::Assembly;
+using dd4hep::BUILD_ENVELOPE;
+using dd4hep::Box;
+using dd4hep::ConeSegment;
+using dd4hep::DetElement;
+using dd4hep::Detector;
+using dd4hep::Material;
+using dd4hep::PlacedVolume;
+using dd4hep::Position;
+using dd4hep::Ref_t;
+using dd4hep::RotationZYX;
+using dd4hep::SensitiveDetector;
+using dd4hep::Trapezoid;
+using dd4hep::Transform3D;
+using dd4hep::Tube;
+using dd4hep::Volume;
+using dd4hep::_toString;
+
+static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector sens)  {
     typedef vector<PlacedVolume> Placements;
     xml_det_t   x_det     = e;
-    Material    vacuum    = lcdd.vacuum();
+    Material    vacuum    = theDetector.vacuum();
     int         det_id    = x_det.id();
     string      det_name  = x_det.nameStr();
     bool        reflect   = x_det.reflect(false);
     DetElement  sdet        (det_name,det_id);
     // Assembly    envelope    (det_name);
     //Volume      envelope    (det_name,Box(10000,10000,10000),vacuum);
-    //unused: Volume      motherVol = lcdd.pickMotherVolume(sdet);
+    //unused: Volume      motherVol = theDetector.pickMotherVolume(sdet);
     int         m_id=0, c_id=0, n_sensor=0;
     map<string,Volume> modules;
     map<string, Placements>  sensitives;
@@ -33,15 +49,15 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
     
     // --- create an envelope volume and position it into the world ---------------------
     
-    Volume envelope = XML::createPlacedEnvelope( lcdd,  e , sdet ) ;
-    XML::setDetectorTypeFlag( e, sdet ) ;
+    Volume envelope = dd4hep::xml::createPlacedEnvelope( theDetector,  e , sdet ) ;
+    dd4hep::xml::setDetectorTypeFlag( e, sdet ) ;
    
-    if( lcdd.buildType() == BUILD_ENVELOPE ) return sdet ;
+    if( theDetector.buildType() == BUILD_ENVELOPE ) return sdet ;
     
     //-----------------------------------------------------------------------------------
     
     
-    envelope.setVisAttributes(lcdd.invisible());
+    envelope.setVisAttributes(theDetector.invisible());
     sens.setType("tracker");
     
     for(xml_coll_t mi(x_det,_U(module)); mi; ++mi, ++m_id)  {
@@ -59,16 +75,16 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
         
         y1 = y2 = total_thickness / 2;
         Volume  m_volume(m_nam, Trapezoid(x1, x2, y1, y2, z), vacuum);
-        m_volume.setVisAttributes(lcdd.visAttributes(x_mod.visStr()));
+        m_volume.setVisAttributes(theDetector.visAttributes(x_mod.visStr()));
         
         for(ci.reset(), n_sensor=1, c_id=0, posY=-y1; ci; ++ci, ++c_id)  {
             xml_comp_t c       = ci;
             double     c_thick = c.thickness();
-            Material   c_mat   = lcdd.material(c.materialStr());
+            Material   c_mat   = theDetector.material(c.materialStr());
             string     c_name  = _toString(c_id,"component%d");
             Volume     c_vol(c_name, Trapezoid(x1,x2,c_thick/2e0,c_thick/2e0,z), c_mat);
             
-            c_vol.setVisAttributes(lcdd.visAttributes(c.visStr()));
+            c_vol.setVisAttributes(theDetector.visAttributes(c.visStr()));
             pv = m_volume.placeVolume(c_vol,Position(0,posY+c_thick/2,0));
             if ( c.isSensitive() ) {
                 sdet.check(n_sensor > 1,"VertexEndcap::fromCompact: "+c_name+" Max of 1 modules allowed!");

--- a/detector/tracker/VertexEndcap_o1_v03_geo.cpp
+++ b/detector/tracker/VertexEndcap_o1_v03_geo.cpp
@@ -18,13 +18,29 @@
 #include "XML/Utilities.h"
 
 using namespace std;
-using namespace DD4hep;
-using namespace DD4hep::Geometry;
 
-static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
+using dd4hep::Assembly;
+using dd4hep::BUILD_ENVELOPE;
+using dd4hep::Box;
+using dd4hep::ConeSegment;
+using dd4hep::DetElement;
+using dd4hep::Detector;
+using dd4hep::Material;
+using dd4hep::PlacedVolume;
+using dd4hep::Position;
+using dd4hep::Ref_t;
+using dd4hep::RotationZYX;
+using dd4hep::SensitiveDetector;
+using dd4hep::Trapezoid;
+using dd4hep::Transform3D;
+using dd4hep::Tube;
+using dd4hep::Volume;
+using dd4hep::_toString;
+
+static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector sens)  {
     typedef vector<PlacedVolume> Placements;
     xml_det_t   x_det     = e;
-    Material    vacuum    = lcdd.vacuum();
+    Material    vacuum    = theDetector.vacuum();
     int         det_id    = x_det.id();
     string      det_name  = x_det.nameStr();
     bool        reflect   = x_det.reflect(false);
@@ -36,15 +52,15 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
     
     // --- create an envelope volume and position it into the world ---------------------
     
-    Volume envelope = XML::createPlacedEnvelope( lcdd,  e , sdet ) ;
-    XML::setDetectorTypeFlag( e, sdet ) ;
+    Volume envelope = dd4hep::xml::createPlacedEnvelope( theDetector,  e , sdet ) ;
+    dd4hep::xml::setDetectorTypeFlag( e, sdet ) ;
 
-    if( lcdd.buildType() == BUILD_ENVELOPE ) return sdet ;
+    if( theDetector.buildType() == BUILD_ENVELOPE ) return sdet ;
     
     //-----------------------------------------------------------------------------------
     
     
-    envelope.setVisAttributes(lcdd.invisible());
+    envelope.setVisAttributes(theDetector.invisible());
     sens.setType("tracker");
     
     for(xml_coll_t mi(x_det,_U(module)); mi; ++mi, ++m_id)  {
@@ -62,7 +78,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
         
         y1 = y2 = total_thickness / 2;
         Volume  m_volume(m_nam, Trapezoid(x1, x2, y1, y2, z), vacuum);
-        m_volume.setVisAttributes(lcdd.visAttributes(x_mod.visStr()));
+        m_volume.setVisAttributes(theDetector.visAttributes(x_mod.visStr()));
         
         
         //Iterate through slices. The first slice (top in the xml) is placed at the "bottom" of the module
@@ -70,11 +86,11 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
         for(ci.reset(), n_sensor=1, c_id=0, posY=-y1; ci; ++ci, ++c_id)  {
             xml_comp_t c       = ci;
             double     c_thick = c.thickness();
-            Material   c_mat   = lcdd.material(c.materialStr());
+            Material   c_mat   = theDetector.material(c.materialStr());
             string     c_name  = _toString(c_id,"component%d");
             Volume     c_vol(c_name, Trapezoid(x1,x2,c_thick/2e0,c_thick/2e0,z), c_mat);
             
-            c_vol.setVisAttributes(lcdd.visAttributes(c.visStr()));
+            c_vol.setVisAttributes(theDetector.visAttributes(c.visStr()));
             pv = m_volume.placeVolume(c_vol,Position(0,posY+c_thick/2,0));
             if ( c.isSensitive() ) {
                 sdet.check(n_sensor > 1,"VertexEndcap::fromCompact: "+c_name+" Max of 1 modules allowed!");

--- a/detector/tracker/VertexEndcap_o1_v04_geo.cpp
+++ b/detector/tracker/VertexEndcap_o1_v04_geo.cpp
@@ -20,13 +20,27 @@
 #include "DDRec/DetectorData.h"
 
 using namespace std;
-using namespace DD4hep;
-using namespace DD4hep::Geometry;
 
-static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
+using dd4hep::BUILD_ENVELOPE;
+using dd4hep::DetElement;
+using dd4hep::Detector;
+using dd4hep::ERROR;
+using dd4hep::Material;
+using dd4hep::PlacedVolume;
+using dd4hep::Position;
+using dd4hep::Ref_t;
+using dd4hep::RotationZYX;
+using dd4hep::SensitiveDetector;
+using dd4hep::Transform3D;
+using dd4hep::Trapezoid;
+using dd4hep::Volume;
+using dd4hep::_toString;
+using dd4hep::rec::ZDiskPetalsData;
+
+static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector sens)  {
     typedef vector<PlacedVolume> Placements;
     xml_det_t   x_det     = e;
-    Material    vacuum    = lcdd.vacuum();
+    Material    vacuum    = theDetector.vacuum();
     int         det_id    = x_det.id();
     string      det_name  = x_det.nameStr();
     bool        reflect   = x_det.reflect(false);
@@ -38,19 +52,19 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
     
     // --- create an envelope volume and position it into the world ---------------------
     
-    Volume envelope = XML::createPlacedEnvelope( lcdd,  e , sdet ) ;
-    XML::setDetectorTypeFlag( e, sdet ) ;
+    Volume envelope = dd4hep::xml::createPlacedEnvelope( theDetector,  e , sdet ) ;
+    dd4hep::xml::setDetectorTypeFlag( e, sdet ) ;
 
-    if( lcdd.buildType() == BUILD_ENVELOPE ) return sdet ;
+    if( theDetector.buildType() == BUILD_ENVELOPE ) return sdet ;
     
     //-----------------------------------------------------------------------------------
     
     
-    envelope.setVisAttributes(lcdd.invisible());
+    envelope.setVisAttributes(theDetector.invisible());
     sens.setType("tracker");
 
     // -------- reconstruction parameters  ----------------
-    DDRec::ZDiskPetalsData*  zDiskPetalsData = new DDRec::ZDiskPetalsData ;
+    ZDiskPetalsData*  zDiskPetalsData = new ZDiskPetalsData ;
     std::map< std::string, double > moduleSensThickness;
 
     for(xml_coll_t mi(x_det,_U(module)); mi; ++mi, ++m_id)  {
@@ -68,7 +82,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
         
         y1 = y2 = total_thickness / 2;
         Volume  m_volume(m_nam, Trapezoid(x1, x2, y1, y2, z), vacuum);
-        m_volume.setVisAttributes(lcdd.visAttributes(x_mod.visStr()));
+        m_volume.setVisAttributes(theDetector.visAttributes(x_mod.visStr()));
         
         
         //Iterate through slices. The first slice (top in the xml) is placed at the "bottom" of the module
@@ -76,11 +90,11 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
         for(ci.reset(), n_sensor=1, c_id=0, posY=-y1; ci; ++ci, ++c_id)  {
             xml_comp_t c       = ci;
             double     c_thick = c.thickness();
-            Material   c_mat   = lcdd.material(c.materialStr());
+            Material   c_mat   = theDetector.material(c.materialStr());
             string     c_name  = _toString(c_id,"component%d");
             Volume     c_vol(c_name, Trapezoid(x1,x2,c_thick/2e0,c_thick/2e0,z), c_mat);
             
-            c_vol.setVisAttributes(lcdd.visAttributes(c.visStr()));
+            c_vol.setVisAttributes(theDetector.visAttributes(c.visStr()));
             pv = m_volume.placeVolume(c_vol,Position(0,posY+c_thick/2,0));
             if ( c.isSensitive() ) {
                 sdet.check(n_sensor > 1,"VertexEndcap::fromCompact: "+c_name+" Max of 1 modules allowed!");
@@ -105,7 +119,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
         //NOTE: Mostly Dummy information for event display/DDMarlinPandora
         //FIXME: have to see how to properly accommodate spirals and the fact that there's only
         //one ring
-        DDRec::ZDiskPetalsData::LayerLayout thisLayer ;
+        ZDiskPetalsData::LayerLayout thisLayer ;
         
         int numberOfRings=0; //check that only one ring is used
         for(xml_coll_t ri(x_layer,_U(ring)); ri; ++ri)  {
@@ -127,7 +141,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
             double phi      = phi0;
             Placements& sensVols = sensitives[m_nam];
             
-            DD4hep::Geometry::Trapezoid mod_shape(m_vol.solid());
+            Trapezoid mod_shape(m_vol.solid());
 
             thisLayer.petalHalfAngle   = 0;
             thisLayer.alphaPetal    = 0. ;  // petals are othogonal to z-axis
@@ -186,7 +200,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
     }
     
     //attach data to detector
-    sdet.addExtension< DDRec::ZDiskPetalsData >( zDiskPetalsData ) ;
+    sdet.addExtension< ZDiskPetalsData >( zDiskPetalsData ) ;
     
     std::cout<<"XXX Vertex endcap layers: "<<zDiskPetalsData->layers.size()<<std::endl;
 

--- a/detector/tracker/VertexEndcap_o1_v05_geo.cpp
+++ b/detector/tracker/VertexEndcap_o1_v05_geo.cpp
@@ -25,13 +25,28 @@
 #include <UTIL/ILDConf.h>
 
 using namespace std;
-using namespace DD4hep;
-using namespace DD4hep::Geometry;
 
-static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
+using dd4hep::BUILD_ENVELOPE;
+using dd4hep::DetElement;
+using dd4hep::Detector;
+using dd4hep::ERROR;
+using dd4hep::Material;
+using dd4hep::PlacedVolume;
+using dd4hep::Position;
+using dd4hep::Ref_t;
+using dd4hep::RotationZYX;
+using dd4hep::SensitiveDetector;
+using dd4hep::Transform3D;
+using dd4hep::Trapezoid;
+using dd4hep::Volume;
+using dd4hep::_toString;
+using dd4hep::rec::ZDiskPetalsData;
+using dd4hep::rec::NeighbourSurfacesData;
+
+static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector sens)  {
     typedef vector<PlacedVolume> Placements;
     xml_det_t   x_det     = e;
-    Material    vacuum    = lcdd.vacuum();
+    Material    vacuum    = theDetector.vacuum();
     int         det_id    = x_det.id();
     string      det_name  = x_det.nameStr();
     bool        reflect   = x_det.reflect(false);
@@ -51,20 +66,20 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
 
     // --- create an envelope volume and position it into the world ---------------------
     
-    Volume envelope = XML::createPlacedEnvelope( lcdd,  e , sdet ) ;
-    XML::setDetectorTypeFlag( e, sdet ) ;
+    Volume envelope = dd4hep::xml::createPlacedEnvelope( theDetector,  e , sdet ) ;
+    dd4hep::xml::setDetectorTypeFlag( e, sdet ) ;
 
-    if( lcdd.buildType() == BUILD_ENVELOPE ) return sdet ;
+    if( theDetector.buildType() == BUILD_ENVELOPE ) return sdet ;
     
     //-----------------------------------------------------------------------------------
     
     
-    envelope.setVisAttributes(lcdd.invisible());
+    envelope.setVisAttributes(theDetector.invisible());
     sens.setType("tracker");
 
     // -------- reconstruction parameters  ----------------
-    DDRec::ZDiskPetalsData*  zDiskPetalsData = new DDRec::ZDiskPetalsData ;
-    DDRec::NeighbourSurfacesData*  neighbourSurfacesData = new DDRec::NeighbourSurfacesData() ;
+    ZDiskPetalsData*  zDiskPetalsData = new ZDiskPetalsData ;
+    NeighbourSurfacesData*  neighbourSurfacesData = new NeighbourSurfacesData() ;
     std::map< std::string, double > moduleSensThickness;
 
     for(xml_coll_t mi(x_det,_U(module)); mi; ++mi, ++m_id)  {
@@ -82,7 +97,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
         
         y1 = y2 = total_thickness / 2;
         Volume  m_volume(m_nam, Trapezoid(x1, x2, y1, y2, z), vacuum);
-        m_volume.setVisAttributes(lcdd.visAttributes(x_mod.visStr()));
+        m_volume.setVisAttributes(theDetector.visAttributes(x_mod.visStr()));
         
         
         //Iterate through slices. The first slice (top in the xml) is placed at the "bottom" of the module
@@ -90,11 +105,11 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
         for(ci.reset(), n_sensor=1, c_id=0, posY=-y1; ci; ++ci, ++c_id)  {
             xml_comp_t c       = ci;
             double     c_thick = c.thickness();
-            Material   c_mat   = lcdd.material(c.materialStr());
+            Material   c_mat   = theDetector.material(c.materialStr());
             string     c_name  = _toString(c_id,"component%d");
             Volume     c_vol(c_name, Trapezoid(x1,x2,c_thick/2e0,c_thick/2e0,z), c_mat);
             
-            c_vol.setVisAttributes(lcdd.visAttributes(c.visStr()));
+            c_vol.setVisAttributes(theDetector.visAttributes(c.visStr()));
             pv = m_volume.placeVolume(c_vol,Position(0,posY+c_thick/2,0));
             if ( c.isSensitive() ) {
                 sdet.check(n_sensor > 1,"VertexEndcap::fromCompact: "+c_name+" Max of 1 modules allowed!");
@@ -119,7 +134,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
         //NOTE: Mostly Dummy information for event display/DDMarlinPandora
         //FIXME: have to see how to properly accommodate spirals and the fact that there's only
         //one ring
-        DDRec::ZDiskPetalsData::LayerLayout thisLayer ;
+        ZDiskPetalsData::LayerLayout thisLayer ;
         
         int numberOfRings=0; //check that only one ring is used
         for(xml_coll_t ri(x_layer,_U(ring)); ri; ++ri)  {
@@ -141,7 +156,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
             double phi      = phi0;
             Placements& sensVols = sensitives[m_nam];
             
-            DD4hep::Geometry::Trapezoid mod_shape(m_vol.solid());
+            Trapezoid mod_shape(m_vol.solid());
 
             thisLayer.petalHalfAngle   = 0;
             thisLayer.alphaPetal    = 0. ;  // petals are othogonal to z-axis
@@ -196,7 +211,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
 
 		//encoding
 
-		DD4hep::long64 cellID_reflect;
+		dd4hep::long64 cellID_reflect;
 		if (reflect) {
 		  encoder[lcio::LCTrackerCellID::side()] = lcio::ILDDetID::bwd;
 		  encoder[lcio::LCTrackerCellID::layer()] = l_id;
@@ -211,7 +226,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
 		encoder[lcio::LCTrackerCellID::module()] = 0; // only 1 ring so always 0 
 		encoder[lcio::LCTrackerCellID::sensor()] = k;
 
-		DD4hep::long64 cellID = encoder.lowWord(); // 32 bits
+		dd4hep::long64 cellID = encoder.lowWord(); // 32 bits
 
 		//compute neighbours 
 
@@ -262,8 +277,8 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
     }
     
     //attach data to detector
-    sdet.addExtension< DDRec::ZDiskPetalsData >( zDiskPetalsData ) ;
-    sdet.addExtension< DDRec::NeighbourSurfacesData >( neighbourSurfacesData ) ;
+    sdet.addExtension< ZDiskPetalsData >( zDiskPetalsData ) ;
+    sdet.addExtension< NeighbourSurfacesData >( neighbourSurfacesData ) ;
 
     std::cout<<"XXX Vertex endcap layers: "<<zDiskPetalsData->layers.size()<<std::endl;
 

--- a/detector/tracker/VertexEndcap_o1_v06_geo.cpp
+++ b/detector/tracker/VertexEndcap_o1_v06_geo.cpp
@@ -20,13 +20,27 @@
 #include "DDRec/DetectorData.h"
 
 using namespace std;
-using namespace DD4hep;
-using namespace DD4hep::Geometry;
 
-static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
+using dd4hep::BUILD_ENVELOPE;
+using dd4hep::DetElement;
+using dd4hep::Detector;
+using dd4hep::ERROR;
+using dd4hep::Material;
+using dd4hep::PlacedVolume;
+using dd4hep::Position;
+using dd4hep::Ref_t;
+using dd4hep::RotationZYX;
+using dd4hep::SensitiveDetector;
+using dd4hep::Transform3D;
+using dd4hep::Trapezoid;
+using dd4hep::Volume;
+using dd4hep::_toString;
+using dd4hep::rec::ZDiskPetalsData;
+
+static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector sens)  {
     typedef vector<PlacedVolume> Placements;
     xml_det_t   x_det     = e;
-    Material    vacuum    = lcdd.vacuum();
+    Material    vacuum    = theDetector.vacuum();
     int         det_id    = x_det.id();
     string      det_name  = x_det.nameStr();
     bool        reflect   = x_det.reflect(false);
@@ -38,19 +52,19 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
     
     // --- create an envelope volume and position it into the world ---------------------
     
-    Volume envelope = XML::createPlacedEnvelope( lcdd,  e , sdet ) ;
-    XML::setDetectorTypeFlag( e, sdet ) ;
+    Volume envelope = dd4hep::xml::createPlacedEnvelope( theDetector,  e , sdet ) ;
+    dd4hep::xml::setDetectorTypeFlag( e, sdet ) ;
 
-    if( lcdd.buildType() == BUILD_ENVELOPE ) return sdet ;
+    if( theDetector.buildType() == BUILD_ENVELOPE ) return sdet ;
     
     //-----------------------------------------------------------------------------------
     
     
-    envelope.setVisAttributes(lcdd.invisible());
+    envelope.setVisAttributes(theDetector.invisible());
     sens.setType("tracker");
 
     // -------- reconstruction parameters  ----------------
-    DDRec::ZDiskPetalsData*  zDiskPetalsData = new DDRec::ZDiskPetalsData ;
+    ZDiskPetalsData*  zDiskPetalsData = new ZDiskPetalsData ;
     std::map< std::string, double > moduleSensThickness;
 
     for(xml_coll_t mi(x_det,_U(module)); mi; ++mi, ++m_id)  {
@@ -68,7 +82,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
         
         y1 = y2 = total_thickness / 2;
         Volume  m_volume(m_nam, Trapezoid(x1, x2, y1, y2, z), vacuum);
-        m_volume.setVisAttributes(lcdd.visAttributes(x_mod.visStr()));
+        m_volume.setVisAttributes(theDetector.visAttributes(x_mod.visStr()));
         
         
         //Iterate through slices. The first slice (top in the xml) is placed at the "bottom" of the module
@@ -76,11 +90,11 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
         for(ci.reset(), n_sensor=1, c_id=0, posY=-y1; ci; ++ci, ++c_id)  {
             xml_comp_t c       = ci;
             double     c_thick = c.thickness();
-            Material   c_mat   = lcdd.material(c.materialStr());
+            Material   c_mat   = theDetector.material(c.materialStr());
             string     c_name  = _toString(c_id,"component%d");
             Volume     c_vol(c_name, Trapezoid(x1,x2,c_thick/2e0,c_thick/2e0,z), c_mat);
             
-            c_vol.setVisAttributes(lcdd.visAttributes(c.visStr()));
+            c_vol.setVisAttributes(theDetector.visAttributes(c.visStr()));
             pv = m_volume.placeVolume(c_vol,Position(0,posY+c_thick/2,0));
             if ( c.isSensitive() ) {
                 sdet.check(n_sensor > 1,"VertexEndcap::fromCompact: "+c_name+" Max of 1 modules allowed!");
@@ -105,7 +119,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
         //NOTE: Mostly Dummy information for event display/DDMarlinPandora
         //FIXME: have to see how to properly accommodate spirals and the fact that there's only
         //one ring
-        DDRec::ZDiskPetalsData::LayerLayout thisLayer ;
+        ZDiskPetalsData::LayerLayout thisLayer ;
         
         int numberOfRings=0; //check that only one ring is used
         for(xml_coll_t ri(x_layer,_U(ring)); ri; ++ri)  {
@@ -127,7 +141,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
             double phi      = phi0;
             Placements& sensVols = sensitives[m_nam];
             
-            DD4hep::Geometry::Trapezoid mod_shape(m_vol.solid());
+            Trapezoid mod_shape(m_vol.solid());
 
             thisLayer.petalHalfAngle   = 0;
             thisLayer.alphaPetal    = 0. ;  // petals are othogonal to z-axis
@@ -186,7 +200,7 @@ static Ref_t create_detector(LCDD& lcdd, xml_h e, SensitiveDetector sens)  {
     }
     
     //attach data to detector
-    sdet.addExtension< DDRec::ZDiskPetalsData >( zDiskPetalsData ) ;
+    sdet.addExtension< ZDiskPetalsData >( zDiskPetalsData ) ;
     
     std::cout<<"XXX Vertex endcap layers: "<<zDiskPetalsData->layers.size()<<std::endl;
 

--- a/lcgeoTests/src/BeamCalZtest.cpp
+++ b/lcgeoTests/src/BeamCalZtest.cpp
@@ -1,4 +1,4 @@
-#include <DD4hep/LCDD.h>
+#include <DD4hep/Detector.h>
 #include <DDRec/DetectorData.h>
 #include "DD4hep/DD4hepUnits.h"
 
@@ -13,12 +13,12 @@ int main (int argc, char **args) {
   }
   std::string compactFile = std::string(args[1]);
 
-  DD4hep::Geometry::LCDD& lcdd = DD4hep::Geometry::LCDD::getInstance();
-  lcdd.fromXML( compactFile );
+  dd4hep::Detector& theDetector = dd4hep::Detector::getInstance();
+  theDetector.fromXML( compactFile );
 
-  const std::string lcddname(lcdd.header().name());
+  const std::string detectorName(theDetector.header().name());
 
-  const std::vector< DD4hep::Geometry::DetElement > &detElements = lcdd.detectors("calorimeter", true);
+  const std::vector< dd4hep::DetElement > &detElements = theDetector.detectors("calorimeter", true);
 
   const std::string beamCalName("BeamCal");
 
@@ -29,7 +29,7 @@ int main (int argc, char **args) {
     std::string detName(detElements.at(i).name());
     if ( detName.compare(beamCalName) == 0 ) {
       foundBeamCal = true;
-      DD4hep::DDRec::LayeredCalorimeterData* bcData = detElements.at(i).extension<DD4hep::DDRec::LayeredCalorimeterData>() ;
+      dd4hep::rec::LayeredCalorimeterData* bcData = detElements.at(i).extension<dd4hep::rec::LayeredCalorimeterData>() ;
       bcalOuterZ = bcData->extent[3];
     }
   }
@@ -37,7 +37,7 @@ int main (int argc, char **args) {
 
   if (foundBeamCal) {
     std::cout << "\n" << beamCalName << " Z_outer = " << bcalOuterZ/dd4hep::mm << " mm\n\n";
-    if ( lcddname.find("ILD") != std::string::npos ) {
+    if ( detectorName.find("ILD") != std::string::npos ) {
 
       if (bcalOuterZ/dd4hep::mm > 3420) {
         std::cout << "ERROR: " << beamCalName << " is too far out in the z-direction.\n";
@@ -48,7 +48,7 @@ int main (int argc, char **args) {
       }
     }
     else {
-      std::cout << "No specific requirements are set on " << beamCalName << " z-position for " << lcddname << "\n\n";
+      std::cout << "No specific requirements are set on " << beamCalName << " z-position for " << detectorName << "\n\n";
     }
   }
   else {

--- a/lcgeoTests/src/TestSensThickness.cpp
+++ b/lcgeoTests/src/TestSensThickness.cpp
@@ -3,7 +3,7 @@
 #include <DD4hep/DD4hepUnits.h>
 #include <DD4hep/DDTest.h>
 #include <DD4hep/Detector.h>
-#include <DD4hep/LCDD.h>
+#include <DD4hep/Detector.h>
 #include <DDRec/API/IDDecoder.h>
 #include <DDRec/DetectorData.h>
 
@@ -14,9 +14,9 @@
 #include <string>
 #include <vector>
 
-static DD4hep::DDTest test( "SensThickness" ) ;
+static dd4hep::DDTest test( "SensThickness" ) ;
 
-template<typename T> void checkExtensions( DD4hep::Geometry::LCDD& lcdd, std::vector<std::string> detectorNames, std::vector<double> sensThickness) {
+template<typename T> void checkExtensions( dd4hep::Detector& lcdd, std::vector<std::string> detectorNames, std::vector<double> sensThickness) {
 
   int counter = 0;
   for (auto const& detName : detectorNames ) {
@@ -47,7 +47,7 @@ int main (int argc, char **args) {
   const double trackerThick = atof(args[2]);
   const double vertexThick = atof(args[3]);
 
-  DD4hep::Geometry::LCDD& lcdd = DD4hep::Geometry::LCDD::getInstance();
+  dd4hep::Detector& lcdd = dd4hep::Detector::getInstance();
   lcdd.fromCompact( compactFile );
 
   std::vector<std::string> endcaps = { "InnerTrackerEndcap",
@@ -62,8 +62,8 @@ int main (int argc, char **args) {
 					trackerThick*dd4hep::micrometer,
 					vertexThick*dd4hep::micrometer };
 
-  checkExtensions<DD4hep::DDRec::ZDiskPetalsData>( lcdd, endcaps, sensThickness );
-  checkExtensions<DD4hep::DDRec::ZPlanarData>( lcdd, barrels, sensThickness );
+  checkExtensions<dd4hep::rec::ZDiskPetalsData>( lcdd, endcaps, sensThickness );
+  checkExtensions<dd4hep::rec::ZPlanarData>( lcdd, barrels, sensThickness );
 
 
 }

--- a/plugins/CaloPreShowerSDAction.cpp
+++ b/plugins/CaloPreShowerSDAction.cpp
@@ -5,10 +5,10 @@
 #include "G4VProcess.hh"
 
 /// Namespace for the AIDA detector description toolkit
-namespace DD4hep {
+namespace dd4hep {
   
   /// Namespace for the Geant4 based simulation part of the AIDA detector description toolkit
-  namespace Simulation   {
+  namespace sim   {
     
     /**
      *  Geant4SensitiveAction<CalorimeterWithPreShowerLayer> sensitive detector for the special
@@ -47,8 +47,8 @@ namespace DD4hep {
     template <> 
     Geant4SensitiveAction<CalorimeterWithPreShowerLayer>::Geant4SensitiveAction(Geant4Context* ctxt,
 										const std::string& nam,
-										Geometry::DetElement det,
-										Geometry::LCDD& lcdd_ref)
+										DetElement det,
+										Detector& lcdd_ref)
       : Geant4Sensitive(ctxt,nam,det,lcdd_ref), m_collectionID(0)
     {
       initialize();
@@ -60,7 +60,7 @@ namespace DD4hep {
     /// Method for generating hit(s) using the information of G4Step object.
     template <> bool Geant4SensitiveAction<CalorimeterWithPreShowerLayer>::process(G4Step* step,G4TouchableHistory*) {
       typedef CalorimeterWithPreShowerLayer::Hit Hit;
-      StepHandler h(step);
+      Geant4StepHandler h(step);
       HitContribution contrib = Hit::extractContribution(step);
 
       long long int cell;
@@ -85,12 +85,12 @@ namespace DD4hep {
       }
 
       // get the layer number by decoding the cellID
-      Geometry::IDDescriptor idspec = m_sensitive.readout().idSpec() ;
+      IDDescriptor idspec = m_sensitive.readout().idSpec() ;
       DDSegmentation::BitField64& bf = *idspec.decoder() ;
       bf.setValue( cell )  ;
       int layer = bf["layer"] ;
       
-      HitCollection*  coll = ( layer== m_userData._firstLayerNumber ?  collection( m_userData._preShowerCollectionID ) : collection(m_collectionID) ) ;
+      Geant4HitCollection*  coll = ( layer== m_userData._firstLayerNumber ?  collection( m_userData._preShowerCollectionID ) : collection(m_collectionID) ) ;
       
       Hit* hit = coll->find<Hit>(CellIDCompare<Hit>(cell));
       if ( h.totalEnergy() < std::numeric_limits<double>::epsilon() )  {
@@ -124,8 +124,6 @@ namespace DD4hep {
 } // namespace
 
 
-
-using namespace DD4hep::Simulation;
 
 #include "DDG4/Factories.h"
 DECLARE_GEANT4SENSITIVE( CaloPreShowerSDAction )

--- a/plugins/TPCSDAction.cpp
+++ b/plugins/TPCSDAction.cpp
@@ -5,10 +5,10 @@
 #include "G4VProcess.hh"
 
 /// Namespace for the AIDA detector description toolkit
-namespace DD4hep {
+namespace dd4hep {
   
   /// Namespace for the Geant4 based simulation part of the AIDA detector description toolkit
-  namespace Simulation   {
+  namespace sim   {
     
     /**
      *  Geant4SensitiveAction<TPCSdData> sensitive detector for the special case of 
@@ -116,7 +116,7 @@ namespace DD4hep {
 
 	Readout readout   = sensitive->sensitiveDetector().readout();
 
-	Geometry::Segmentation segmentation = readout.segmentation();
+	Segmentation segmentation = readout.segmentation();
 	
 	if ( segmentation.isValid() )  {
 
@@ -516,8 +516,6 @@ namespace DD4hep {
   }
 }
 
-
-using namespace DD4hep::Simulation;
 
 #include "DDG4/Factories.h"
 DECLARE_GEANT4SENSITIVE( TPCSDAction )


### PR DESCRIPTION
Adapted namespaces, mostly by `using dd4hep::Class` statements, sometimes replacing namespaces in the code. 
Changed `LCDD& lcdd` to `Detector& theDetector`
LCGEO compiles, and together with the outstanding PR in AIDASoft/DD4hep#180 the tests are passing

FIXME:
- [ ] I don't understand how Segmentation::decoder was working in the past, that is a`const` function but the returned pointer was still used with non-const function. Using `const_cast` now, but maybe I am just not getting the write Segmentation class ? Though I already I tried two of them `dd4hep::Segmentation` and `dd4hep::DDSegmentation::Segmentation`

BEGINRELEASENOTES
- Adapt to changes in namespaces in DD4hep
ENDRELEASENOTES