### PR TITLE
Fix ild o4

### DIFF
--- a/ILD/compact/ILD_common_v02/SHcalSc04_Barrel_v04.xml
+++ b/ILD/compact/ILD_common_v02/SHcalSc04_Barrel_v04.xml
@@ -25,10 +25,10 @@
       <layer repeat="Hcal_nlayers" vis="SeeThrough">
 
         <slice material="Air"      thickness="Hcal_chamber_thickness - ( HcalSD_glass_anode_thickness + HcalSD_sensitive_gas_gap + HcalSD_glass_cathode_thickness + Hcal_scintillator_thickness)" vis="Invisible" />
-        <slice material="G4_POLYSTYRENE" thickness = "Hcal_scintillator_thickness" sensitive = "yes"   limits="cal_limi        <slice material="FloatGlass" thickness="HcalSD_glass_anode_thickness" vis="Invisible"/>
+        <slice material="G4_POLYSTYRENE" thickness = "Hcal_scintillator_thickness" sensitive = "yes"   limits="cal_limits"  vis="CyanVis"   />
+        <slice material="FloatGlass" thickness="HcalSD_glass_anode_thickness" vis="Invisible"/>
         <slice material="RPCGAS2"    thickness="HcalSD_sensitive_gas_gap" sensitive="yes" limits="cal_limits" vis="YellowVis"/>
         <slice material="FloatGlass" thickness="HcalSD_glass_cathode_thickness" vis="Invisible"/>
-ts"  vis="CyanVis"   />
       </layer>
     </detector>
   </detectors>

--- a/ILD/compact/ILD_common_v02/SHcalSc04_Barrel_v04.xml
+++ b/ILD/compact/ILD_common_v02/SHcalSc04_Barrel_v04.xml
@@ -25,10 +25,10 @@
       <layer repeat="Hcal_nlayers" vis="SeeThrough">
 
         <slice material="Air"      thickness="Hcal_chamber_thickness - ( HcalSD_glass_anode_thickness + HcalSD_sensitive_gas_gap + HcalSD_glass_cathode_thickness + Hcal_scintillator_thickness)" vis="Invisible" />
-        <slice material="FloatGlass" thickness="HcalSD_glass_anode_thickness" vis="Invisible"/>
+        <slice material="G4_POLYSTYRENE" thickness = "Hcal_scintillator_thickness" sensitive = "yes"   limits="cal_limi        <slice material="FloatGlass" thickness="HcalSD_glass_anode_thickness" vis="Invisible"/>
         <slice material="RPCGAS2"    thickness="HcalSD_sensitive_gas_gap" sensitive="yes" limits="cal_limits" vis="YellowVis"/>
         <slice material="FloatGlass" thickness="HcalSD_glass_cathode_thickness" vis="Invisible"/>
-        <slice material="G4_POLYSTYRENE" thickness = "Hcal_scintillator_thickness" sensitive = "yes"   limits="cal_limits"  vis="CyanVis"   />
+ts"  vis="CyanVis"   />
       </layer>
     </detector>
   </detectors>
@@ -36,12 +36,12 @@
   <readouts>
     <readout name="HcalBarrelReadout">
       <segmentation   type="MultiSegmentation"  key="slice">
-        <segmentation name="RPCgrid" type="CartesianGridXY"    key_value="2"    grid_size_x="SDHCal_cell_size" grid_size_y="SDHCal_cell_size" />
-        <segmentation name="Scigrid"  type="TiledLayerGridXY"  key_value="4"  grid_size_x="3" grid_size_y="3.03248"/>
+        <segmentation name="RPCgrid" type="CartesianGridXY"    key_value="3"    grid_size_x="SDHCal_cell_size" grid_size_y="SDHCal_cell_size" />
+        <segmentation name="Scigrid"  type="TiledLayerGridXY"  key_value="1"  grid_size_x="3" grid_size_y="3.03248"/>
       </segmentation>
       <hits_collections>
-        <hits_collection name="HCalBarrelRPCHits"  key="slice" key_value="2"/>
-        <hits_collection name="HcalBarrelRegCollection"  key="slice" key_value="4"/>
+        <hits_collection name="HCalBarrelRPCHits"  key="slice" key_value="3"/>
+        <hits_collection name="HcalBarrelRegCollection"  key="slice" key_value="1"/>
       </hits_collections>
       <id>system:5,module:3,stave:4,tower:5,layer:6,slice:4,x:32:-16,y:-16</id>
     </readout>

--- a/ILD/compact/ILD_common_v02/SHcalSc04_EndcapRing_v01.xml
+++ b/ILD/compact/ILD_common_v02/SHcalSc04_EndcapRing_v01.xml
@@ -29,10 +29,10 @@
       <subsegmentation key="slice" value="Hcal_readout_segmentation_slice_endcap"/>
 
       <layer vis="SeeThrough">
-        <slice material="G4_POLYSTYRENE" thickness = "Hcal_scintillator_thickness" sensitive = "yes"   limits="cal_limits"  vis="CyanVis"   />
         <slice material="FloatGlass" thickness="HcalSD_glass_cathode_thickness" vis="Invisible"/>
         <slice material="RPCGAS2"    thickness="HcalSD_sensitive_gas_gap" sensitive="yes" limits="cal_limits" vis="YellowVis"/>
         <slice material="FloatGlass" thickness="HcalSD_glass_anode_thickness" vis="Invisible"/>
+        <slice material="G4_POLYSTYRENE" thickness = "Hcal_scintillator_thickness" sensitive = "yes"   limits="cal_limits"  vis="CyanVis"   />
         <slice material="Air"      thickness="Hcal_chamber_thickness - ( HcalSD_glass_anode_thickness + HcalSD_sensitive_gas_gap + HcalSD_glass_cathode_thickness + Hcal_scintillator_thickness)" vis="Invisible" />
       </layer>
 
@@ -42,12 +42,12 @@
   <readouts>
     <readout name="HcalEndcapRingReadout">
       <segmentation   type="MultiSegmentation"  key="slice">
-        <segmentation name="RPCgrid" type="CartesianGridXY"    key_value="2"    grid_size_x="SDHCal_cell_size" grid_size_y="SDHCal_cell_size" />
-        <segmentation name="Scigrid" type="CartesianGridXY"    key_value="0"    grid_size_x="AHCal_cell_size" grid_size_y="AHCal_cell_size" />
+        <segmentation name="RPCgrid" type="CartesianGridXY"    key_value="1"    grid_size_x="SDHCal_cell_size" grid_size_y="SDHCal_cell_size" />
+        <segmentation name="Scigrid" type="CartesianGridXY"    key_value="3"    grid_size_x="AHCal_cell_size" grid_size_y="AHCal_cell_size" />
       </segmentation>
       <hits_collections>
-        <hits_collection name="HCalECRingRPCHits"  key="slice" key_value="2"/>
-        <hits_collection name="HcalEndcapRingCollection"  key="slice" key_value="0"/>
+        <hits_collection name="HCalECRingRPCHits"  key="slice" key_value="1"/>
+        <hits_collection name="HcalEndcapRingCollection"  key="slice" key_value="3"/>
       </hits_collections>
       <id>system:5,module:3,stave:4,tower:3,layer:6,slice:4,x:32:-16,y:-16</id>
     </readout>

--- a/ILD/compact/ILD_common_v02/SHcalSc04_Endcaps_v01_LARGE.xml
+++ b/ILD/compact/ILD_common_v02/SHcalSc04_Endcaps_v01_LARGE.xml
@@ -43,10 +43,10 @@
       <subsegmentation key="slice" value="Hcal_readout_segmentation_slice_endcap"/>
 
       <layer repeat="Hcal_nlayers" vis="SeeThrough">
-        <slice material="G4_POLYSTYRENE" thickness = "Hcal_scintillator_thickness" sensitive = "yes"   limits="cal_limits"  vis="CyanVis"   />
         <slice material="FloatGlass" thickness="HcalSD_glass_cathode_thickness" vis="Invisible"/>
         <slice material="RPCGAS2"    thickness="HcalSD_sensitive_gas_gap" sensitive="yes" limits="cal_limits" vis="YellowVis"/>
         <slice material="FloatGlass" thickness="HcalSD_glass_anode_thickness" vis="Invisible"/>
+        <slice material="G4_POLYSTYRENE" thickness = "Hcal_scintillator_thickness" sensitive = "yes"   limits="cal_limits"  vis="CyanVis"   />
         <slice material="Air"      thickness="Hcal_chamber_thickness - ( HcalSD_glass_anode_thickness + HcalSD_sensitive_gas_gap + HcalSD_glass_cathode_thickness + Hcal_scintillator_thickness)" vis="Invisible" />
       </layer>
     </detector>
@@ -55,12 +55,12 @@
   <readouts>
     <readout name="HcalEndcapsReadout">
       <segmentation   type="MultiSegmentation"  key="slice">
-        <segmentation name="RPCgrid" type="CartesianGridXZ"    key_value="2"    grid_size_x="SDHCal_cell_size" grid_size_z="SDHCal_cell_size" />
-        <segmentation name="Scigrid"  type="CartesianGridXZ"  key_value="0"  grid_size_x="AHCal_cell_size" grid_size_z="AHCal_cell_size" offset_x="AHCal_cell_size/2.0" offset_z="AHCal_cell_size/2.0" />
+        <segmentation name="RPCgrid" type="CartesianGridXZ"    key_value="1"    grid_size_x="SDHCal_cell_size" grid_size_z="SDHCal_cell_size" />
+        <segmentation name="Scigrid"  type="CartesianGridXZ"  key_value="3"  grid_size_x="AHCal_cell_size" grid_size_z="AHCal_cell_size" offset_x="AHCal_cell_size/2.0" offset_z="AHCal_cell_size/2.0" />
       </segmentation>
       <hits_collections>
-        <hits_collection name="HCalEndcapRPCHits"  key="slice" key_value="2"/>
-        <hits_collection name="HcalEndcapsCollection"  key="slice" key_value="0"/>
+        <hits_collection name="HCalEndcapRPCHits"  key="slice" key_value="1"/>
+        <hits_collection name="HcalEndcapsCollection"  key="slice" key_value="3"/>
       </hits_collections>
       <id>system:5,module:3,stave:3,tower:5,layer:6,slice:4,x:32:-16,z:-16</id>
     </readout>

--- a/ILD/compact/ILD_common_v02/SHcalSc04_Endcaps_v01_SMALL.xml
+++ b/ILD/compact/ILD_common_v02/SHcalSc04_Endcaps_v01_SMALL.xml
@@ -41,10 +41,10 @@
       <subsegmentation key="slice" value="Hcal_readout_segmentation_slice_endcap"/>
 
       <layer repeat="Hcal_nlayers" vis="SeeThrough">
-        <slice material="G4_POLYSTYRENE" thickness = "Hcal_scintillator_thickness" sensitive = "yes"   limits="cal_limits"  vis="CyanVis"   />
         <slice material="FloatGlass" thickness="HcalSD_glass_cathode_thickness" vis="Invisible"/>
         <slice material="RPCGAS2"    thickness="HcalSD_sensitive_gas_gap" sensitive="yes" limits="cal_limits" vis="YellowVis"/>
         <slice material="FloatGlass" thickness="HcalSD_glass_anode_thickness" vis="Invisible"/>
+        <slice material="G4_POLYSTYRENE" thickness = "Hcal_scintillator_thickness" sensitive = "yes"   limits="cal_limits"  vis="CyanVis"   />
         <slice material="Air"      thickness="Hcal_chamber_thickness - ( HcalSD_glass_anode_thickness + HcalSD_sensitive_gas_gap + HcalSD_glass_cathode_thickness + Hcal_scintillator_thickness)" vis="Invisible" />
       </layer>
     </detector>
@@ -53,12 +53,12 @@
   <readouts>
     <readout name="HcalEndcapsReadout">
       <segmentation   type="MultiSegmentation"  key="slice">
-        <segmentation name="RPCgrid" type="CartesianGridXZ"    key_value="2"    grid_size_x="SDHCal_cell_size" grid_size_z="SDHCal_cell_size" />
-        <segmentation name="Scigrid"  type="CartesianGridXZ"  key_value="0"  grid_size_x="AHCal_cell_size" grid_size_z="AHCal_cell_size" offset_x="AHCal_cell_size/2.0" offset_z="AHCal_cell_size/2.0" />
+        <segmentation name="RPCgrid" type="CartesianGridXZ"    key_value="1"    grid_size_x="SDHCal_cell_size" grid_size_z="SDHCal_cell_size" />
+        <segmentation name="Scigrid"  type="CartesianGridXZ"  key_value="3"  grid_size_x="AHCal_cell_size" grid_size_z="AHCal_cell_size" offset_x="AHCal_cell_size/2.0" offset_z="AHCal_cell_size/2.0" />
       </segmentation>
       <hits_collections>
-        <hits_collection name="HCalEndcapRPCHits"  key="slice" key_value="2"/>
-        <hits_collection name="HcalEndcapsCollection"  key="slice" key_value="0"/>
+        <hits_collection name="HCalEndcapRPCHits"  key="slice" key_value="1"/>
+        <hits_collection name="HcalEndcapsCollection"  key="slice" key_value="3"/>
       </hits_collections>
       <id>system:5,module:3,stave:3,tower:5,layer:6,slice:4,x:32:-16,z:-16</id>
     </readout>

--- a/ILD/compact/ILD_common_v02/tracker_defs.xml
+++ b/ILD/compact/ILD_common_v02/tracker_defs.xml
@@ -2,10 +2,12 @@
 
   <constant name="VXD_radius_r1" value="16*mm"/>
   <constant name="VXD_length_r1" value="62.5*mm"/>
-
   <constant name="VXD_radius_r3" value="37*mm"/>
   <constant name="VXD_length_r3" value="125*mm"/>
-
   <constant name="VXD_radius_r5" value="58*mm"/>
+
+
+  <constant name="tracker_region_rmax" value="TPC_outer_radius" />
+  <constant name="tracker_region_zmax" value="Ecal_endcap_zmin" />
 
 </define>

--- a/ILD/compact/ILD_l4_v01/ILD_l4_v01.xml
+++ b/ILD/compact/ILD_l4_v01/ILD_l4_v01.xml
@@ -37,8 +37,8 @@
     <constant name="AHCal_cell_size" value="3.0*cm"/>
     <constant name="SDHCal_cell_size" value="1.0*cm"/>
     <!-- barrel and endcvap constructors use the slices in reversed order ! -->
-    <constant name="Hcal_readout_segmentation_slice_barrel" value="4"/>
-    <constant name="Hcal_readout_segmentation_slice_endcap" value="0"/>
+    <constant name="Hcal_readout_segmentation_slice_barrel" value="1"/>
+    <constant name="Hcal_readout_segmentation_slice_endcap" value="3"/>
 
   </define>
 
@@ -188,36 +188,36 @@
 
     <readout name="HcalBarrelReadout">
       <segmentation   type="MultiSegmentation"  key="slice">
-        <segmentation name="RPCgrid" type="CartesianGridXY"    key_value="2"    grid_size_x="SDHCal_cell_size" grid_size_y="SDHCal_cell_size" />
-	<segmentation name="Scigrid"  type="TiledLayerGridXY"  key_value="4"  grid_size_x="3" grid_size_y="3.03248"/>
+        <segmentation name="RPCgrid" type="CartesianGridXY"    key_value="3"    grid_size_x="SDHCal_cell_size" grid_size_y="SDHCal_cell_size" />
+	<segmentation name="Scigrid"  type="TiledLayerGridXY"  key_value="1"  grid_size_x="3" grid_size_y="3.03248"/>
        </segmentation>
       <hits_collections>
-        <hits_collection name="HCalBarrelRPCHits"  key="slice" key_value="2"/>
-        <hits_collection name="HcalBarrelRegCollection"  key="slice" key_value="4"/>
+        <hits_collection name="HCalBarrelRPCHits"  key="slice" key_value="3"/>
+        <hits_collection name="HcalBarrelRegCollection"  key="slice" key_value="1"/>
       </hits_collections>
       <id>system:5,module:3,stave:4,tower:5,layer:6,slice:4,x:32:-16,y:-16</id>
     </readout>
 
     <readout name="HcalEndcapsReadout">
       <segmentation   type="MultiSegmentation"  key="slice">
-        <segmentation name="RPCgrid" type="CartesianGridXZ"    key_value="2"    grid_size_x="SDHCal_cell_size" grid_size_z="SDHCal_cell_size" />
-	<segmentation name="Scigrid"  type="CartesianGridXZ"  key_value="0"  grid_size_x="AHCal_cell_size" grid_size_z="AHCal_cell_size" offset_x="AHCal_cell_size/2.0" offset_z="AHCal_cell_size/2.0" />
+        <segmentation name="RPCgrid" type="CartesianGridXZ"    key_value="1"    grid_size_x="SDHCal_cell_size" grid_size_z="SDHCal_cell_size" />
+	<segmentation name="Scigrid"  type="CartesianGridXZ"  key_value="3"  grid_size_x="AHCal_cell_size" grid_size_z="AHCal_cell_size" offset_x="AHCal_cell_size/2.0" offset_z="AHCal_cell_size/2.0" />
       </segmentation>
       <hits_collections>
-        <hits_collection name="HCalEndcapRPCHits"  key="slice" key_value="2"/>
-        <hits_collection name="HcalEndcapsCollection"  key="slice" key_value="0"/>
+        <hits_collection name="HCalEndcapRPCHits"  key="slice" key_value="1"/>
+        <hits_collection name="HcalEndcapsCollection"  key="slice" key_value="3"/>
       </hits_collections>
       <id>system:5,module:3,stave:3,tower:5,layer:6,slice:4,x:32:-16,z:-16</id>
     </readout>
 
     <readout name="HcalEndcapRingReadout">
       <segmentation   type="MultiSegmentation"  key="slice">
-        <segmentation name="RPCgrid" type="CartesianGridXY"    key_value="2"    grid_size_x="SDHCal_cell_size" grid_size_y="SDHCal_cell_size" />
-        <segmentation name="Scigrid" type="CartesianGridXY"    key_value="0"    grid_size_x="AHCal_cell_size" grid_size_y="AHCal_cell_size" />
+        <segmentation name="RPCgrid" type="CartesianGridXY"    key_value="1"    grid_size_x="SDHCal_cell_size" grid_size_y="SDHCal_cell_size" />
+        <segmentation name="Scigrid" type="CartesianGridXY"    key_value="3"    grid_size_x="AHCal_cell_size" grid_size_y="AHCal_cell_size" />
       </segmentation>
       <hits_collections>
-        <hits_collection name="HCalECRingRPCHits"  key="slice" key_value="2"/>
-        <hits_collection name="HcalEndcapRingCollection"  key="slice" key_value="0"/>
+        <hits_collection name="HCalECRingRPCHits"  key="slice" key_value="1"/>
+        <hits_collection name="HcalEndcapRingCollection"  key="slice" key_value="3"/>
       </hits_collections>
       <id>system:5,module:3,stave:4,tower:3,layer:6,slice:4,x:32:-16,y:-16</id>
     </readout>

--- a/ILD/compact/ILD_l4_v01/SHcalSc04_Barrel_v04.xml
+++ b/ILD/compact/ILD_l4_v01/SHcalSc04_Barrel_v04.xml
@@ -22,9 +22,9 @@
     <layer repeat="Hcal_nlayers" vis="SeeThrough">
 
         <slice material="Air"      thickness="Hcal_chamber_thickness - ( HcalSD_glass_anode_thickness + HcalSD_sensitive_gas_gap + HcalSD_glass_cathode_thickness + Hcal_scintillator_thickness)" vis="Invisible" />
+        <slice material="G4_POLYSTYRENE" thickness = "Hcal_scintillator_thickness" sensitive = "yes"   limits="cal_limits"  vis="CyanVis"   />
 	<slice material="FloatGlass" thickness="HcalSD_glass_anode_thickness" vis="Invisible"/>
 	<slice material="RPCGAS2"    thickness="HcalSD_sensitive_gas_gap" sensitive="yes" limits="cal_limits" vis="YellowVis"/>
 	<slice material="FloatGlass" thickness="HcalSD_glass_cathode_thickness" vis="Invisible"/>
-        <slice material="G4_POLYSTYRENE" thickness = "Hcal_scintillator_thickness" sensitive = "yes"   limits="cal_limits"  vis="CyanVis"   />
     </layer>
 </detector>

--- a/ILD/compact/ILD_l4_v01/SHcalSc04_EndcapRing_v01.xml
+++ b/ILD/compact/ILD_l4_v01/SHcalSc04_EndcapRing_v01.xml
@@ -26,10 +26,10 @@
     <subsegmentation key="slice" value="Hcal_readout_segmentation_slice_endcap"/>
 
     <layer vis="SeeThrough">
-      <slice material="G4_POLYSTYRENE" thickness = "Hcal_scintillator_thickness" sensitive = "yes"   limits="cal_limits"  vis="CyanVis"   />
       <slice material="FloatGlass" thickness="HcalSD_glass_cathode_thickness" vis="Invisible"/>
       <slice material="RPCGAS2"    thickness="HcalSD_sensitive_gas_gap" sensitive="yes" limits="cal_limits" vis="YellowVis"/>
       <slice material="FloatGlass" thickness="HcalSD_glass_anode_thickness" vis="Invisible"/>
+      <slice material="G4_POLYSTYRENE" thickness = "Hcal_scintillator_thickness" sensitive = "yes"   limits="cal_limits"  vis="CyanVis"   />
       <slice material="Air"      thickness="Hcal_chamber_thickness - ( HcalSD_glass_anode_thickness + HcalSD_sensitive_gas_gap + HcalSD_glass_cathode_thickness + Hcal_scintillator_thickness)" vis="Invisible" />
     </layer>
 

--- a/ILD/compact/ILD_l4_v01/SHcalSc04_Endcaps_v01.xml
+++ b/ILD/compact/ILD_l4_v01/SHcalSc04_Endcaps_v01.xml
@@ -40,10 +40,10 @@
     <subsegmentation key="slice" value="Hcal_readout_segmentation_slice_endcap"/>
 
     <layer repeat="Hcal_nlayers" vis="SeeThrough">
-      <slice material="G4_POLYSTYRENE" thickness = "Hcal_scintillator_thickness" sensitive = "yes"   limits="cal_limits"  vis="CyanVis"   />
       <slice material="FloatGlass" thickness="HcalSD_glass_cathode_thickness" vis="Invisible"/>
       <slice material="RPCGAS2"    thickness="HcalSD_sensitive_gas_gap" sensitive="yes" limits="cal_limits" vis="YellowVis"/>
       <slice material="FloatGlass" thickness="HcalSD_glass_anode_thickness" vis="Invisible"/>
+      <slice material="G4_POLYSTYRENE" thickness = "Hcal_scintillator_thickness" sensitive = "yes"   limits="cal_limits"  vis="CyanVis"   />
       <slice material="Air"      thickness="Hcal_chamber_thickness - ( HcalSD_glass_anode_thickness + HcalSD_sensitive_gas_gap + HcalSD_glass_cathode_thickness + Hcal_scintillator_thickness)" vis="Invisible" />
     </layer>
 </detector>

--- a/ILD/compact/ILD_l4_v02/ILD_l4_v02.xml
+++ b/ILD/compact/ILD_l4_v02/ILD_l4_v02.xml
@@ -32,6 +32,12 @@
     <include ref="../ILD_common_v02/services_defs.xml"/>
     <include ref="${DD4hepINSTALL}/DDDetectors/compact/detector_types.xml"/>
 
+    <constant name="tracker_region_rmax" value="TPC_outer_radius" />
+    <constant name="tracker_region_zmax" value="Ecal_endcap_zmin" />
+    <!-- barrel and endcvap constructors use the slices in reversed order ! -->
+    <constant name="Hcal_readout_segmentation_slice_barrel" value="1"/>
+    <constant name="Hcal_readout_segmentation_slice_endcap" value="3"/>
+
   </define>
 
   <limits>
@@ -71,6 +77,28 @@
   <include ref="../ILD_common_v02/coil03.xml"/>
   <include ref="../ILD_common_v02/SServices00.xml"/>
   <include ref="../ILD_common_v02/plugins.xml"/>
+
+  <plugins>
+    <plugin name="DD4hep_CaloFaceEndcapSurfacePlugin">
+      <argument value="EcalEndcap"/>
+      <argument value="zpos=EcalEndcap_min_z"    />
+      <argument value="radius=EcalEndcap_outer_radius"  />
+      <argument value="phi0=0"    />
+      <argument value="symmetry=EcalEndcap_symmetry"/>
+      <argument value="systemID=ILDDetID_ECAL_ENDCAP"/>
+      <comment> <argument value="encoding=system:5,side:-2,layer:9,module:8,sensor:8"/> </comment>
+    </plugin>
+    <plugin name="DD4hep_CaloFaceBarrelSurfacePlugin">
+      <argument value="EcalBarrel"/>
+      <argument value="length=2.*Ecal_half_length"    />
+      <argument value="radius=Ecal_inner_radius"  />
+      <argument value="phi0=0"    />
+      <argument value="symmetry=Ecal_symmetry"/>
+      <argument value="systemID=ILDDetID_ECAL"/>
+      <comment> <argument value="encoding=system:5,side:-2,layer:9,module:8,sensor:8"/> </comment>
+    </plugin>
+    <plugin name="InstallSurfaceManager"/>
+  </plugins>
 
   <fields>
     <field type="solenoid" name="GlobalSolenoid" inner_field="Field_nominal_value"

--- a/ILD/compact/ILD_l4_v02/ILD_l4_v02.xml
+++ b/ILD/compact/ILD_l4_v02/ILD_l4_v02.xml
@@ -32,8 +32,6 @@
     <include ref="../ILD_common_v02/services_defs.xml"/>
     <include ref="${DD4hepINSTALL}/DDDetectors/compact/detector_types.xml"/>
 
-    <constant name="tracker_region_rmax" value="TPC_outer_radius" />
-    <constant name="tracker_region_zmax" value="Ecal_endcap_zmin" />
     <!-- barrel and endcvap constructors use the slices in reversed order ! -->
     <constant name="Hcal_readout_segmentation_slice_barrel" value="1"/>
     <constant name="Hcal_readout_segmentation_slice_endcap" value="3"/>


### PR DESCRIPTION
BEGINRELEASENOTES
- fix ILD_o4 models:
- ILD_l4_v01:  
   - reverse order of RPC and scintillator  ( RPC first)
- ILD_l/s4_v02:
   - reverse order of RPC and scintillator  ( RPC first)
   - add parameters for tracking volume and reconstruction geometry
   - add surface plugins for tracking

ENDRELEASENOTES