### PR TITLE
Split libraries into one with and one without DDG4 dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,10 @@ option(CMAKE_MACOSX_RPATH "Build with rpath on macos" ON)
 find_package(DD4hep REQUIRED COMPONENTS DDSegmentation DDRec DDG4 DDParsers)
 dd4hep_set_compiler_flags()
 
+SET( DD4hep_REDUCED_COMPONENT ${DD4hep_COMPONENT_LIBRARIES} )
+## Drop DDG4 from components for normal geometry plugins
+LIST( REMOVE_AT DD4hep_REDUCED_COMPONENT -2 )
+
 find_package ( ROOT REQUIRED COMPONENTS Geom GenVector)
 include(${ROOT_USE_FILE})
 message ( STATUS "ROOT_VERSION: ${ROOT_VERSION}" )
@@ -64,9 +68,6 @@ include_directories( SYSTEM
 #  ${GEAR_INCLUDE_DIRS}
 
 file(GLOB sources 
-  ./plugins/TPCSDAction.cpp 
-  ./plugins/CaloPreShowerSDAction.cpp
-  ./plugins/Geant4EventReaderGuineaPig.cpp 
   ./detector/tracker/*.cpp 
   ./detector/calorimeter/*.cpp 
   ./detector/fcal/*.cpp 
@@ -74,6 +75,12 @@ file(GLOB sources
   ./detector/CaloTB/*.cpp 
   ./FCalTB/setup/*.cpp
   )
+
+file(GLOB G4sources
+  ./plugins/TPCSDAction.cpp
+  ./plugins/CaloPreShowerSDAction.cpp
+)
+
 
 #file(GLOB headers ./ILD/include/*.h)
 
@@ -83,8 +90,15 @@ if(DD4HEP_USE_PYROOT)
 endif()
 
 #Create target, library, rootmap, install
+
 add_dd4hep_plugin(${PackageName} SHARED ${sources})
-target_link_libraries(${PackageName} ${DD4hep_LIBRARIES} ${DD4hep_COMPONENT_LIBRARIES} ${ROOT_LIBRARIES} ${Geant4_LIBRARIES} ${LCIO_LIBRARIES})
+
+add_dd4hep_plugin(${PackageName}G4 SHARED ${G4sources})
+
+target_link_libraries(${PackageName} ${DD4hep_LIBRARIES} ${DD4hep_REDUCED_COMPONENT} ${ROOT_LIBRARIES} ${LCIO_LIBRARIES})
+
+target_link_libraries(${PackageName}G4 ${DD4hep_LIBRARIES} ${DD4hep_COMPONENT_LIBRARIES} ${ROOT_LIBRARIES} ${Geant4_LIBRARIES} ${LCIO_LIBRARIES})
+
 
 #Create this_package.sh file, and install
 dd4hep_instantiate_package(${PackageName})


### PR DESCRIPTION

BEGINRELEASENOTES
- Split libraries into one without linking against Geant4 and one with Geant4 dependency. Avoid loading of Geant4 libraries in reconstruction

ENDRELEASENOTES