### PR TITLE
ILD_*_v02 models: update to use DD4hep_Beampipe_o1_v01

### DIFF
--- a/ILD/compact/ILD_common_v02/Beampipe_o1_v01_01.xml
+++ b/ILD/compact/ILD_common_v02/Beampipe_o1_v01_01.xml
@@ -2,7 +2,7 @@
 
   <detectors>        
 
-<detector name="Tube" type="Beampipe_o1_v01" vis="BeamPipeVis" id="ILDDetID_NOTUSED">
+<detector name="Tube" type="DD4hep_Beampipe_o1_v01" vis="BeamPipeVis" id="ILDDetID_NOTUSED">
 
   <envelope vis="BlueVis">
     <shape type="Assembly"/>


### PR DESCRIPTION

BEGINRELEASENOTES
- now use DD4hep_Beampipe_o1_v01 driver (gets rid of "deprecated" warning when using Beampipe_o1_v01)
ENDRELEASENOTES