### PR TITLE
ILD_*_v02 models: more explicit layering in SEcal*

### DIFF
--- a/ILD/compact/ILD_common_v02/SEcal05_siw_Barrel.xml
+++ b/ILD/compact/ILD_common_v02/SEcal05_siw_Barrel.xml
@@ -21,7 +21,10 @@
 
       <layer repeat="Ecal_nlayers1/2" vis="SeeThrough" > <!-- 10 double SD Layers, and 5 W palte after each double SD Layer -->
         <slice material = "G4_AIR"         thickness = "Ecal_Alveolus_Air_Gap/2."                vis="Invisible" />
-        <slice material = "siPCBMix"       thickness = "Ecal_Slab_PCB_thickness+Ecal_Slab_copper_thickness+Ecal_Slab_shielding" vis="Invisible" />
+	<slice material = "G4_Al"          thickness = "Ecal_Slab_shielding"        vis="Invisible" />
+	<slice material = "G4_Cu"          thickness = "Ecal_Slab_copper_thickness"        vis="Invisible" />
+	<slice material = "G4_AIR"         thickness = "Ecal_Slab_ASIC_thickness"   vis="Invisible"/>
+	<slice material = "PCB"            thickness = "Ecal_Slab_PCB_thickness"    vis="Invisible"/>
         <slice material = "G4_AIR"         thickness = "Ecal_Slab_glue_gap"                      vis="Invisible" />
         <slice material = "Si"             thickness = "Ecal_Si_thickness" sensitive = "yes"     vis="Invisible"    />
         <slice material = "GroundOrHVMix"  thickness = "Ecal_Slab_ground_thickness"              vis="Invisible" />
@@ -31,14 +34,19 @@
         <slice material = "GroundOrHVMix"  thickness = "Ecal_Slab_ground_thickness"              vis="Invisible" />
         <slice material = "Si"             thickness = "Ecal_Si_thickness" sensitive = "yes"     vis="Invisible"    />
         <slice material = "G4_AIR"         thickness = "Ecal_Slab_glue_gap"                      vis="Invisible" />
-        <slice material = "siPCBMix"       thickness = "Ecal_Slab_PCB_thickness+Ecal_Slab_copper_thickness+Ecal_Slab_shielding" vis="Invisible" />
+	<slice material = "PCB"            thickness = "Ecal_Slab_PCB_thickness"    vis="Invisible"/>
+	<slice material = "G4_AIR"         thickness = "Ecal_Slab_ASIC_thickness"   vis="Invisible"/>
+	<slice material = "G4_Cu"          thickness = "Ecal_Slab_copper_thickness"        vis="Invisible" />
+	<slice material = "G4_Al"          thickness = "Ecal_Slab_shielding"        vis="Invisible" />
         <slice material = "G4_AIR"         thickness = "Ecal_Alveolus_Air_Gap/2."                vis="Invisible" />
-        <!-- There is a structure after each active layer. (W+Fiber) W will be built inside dirver, 2 Fiber will be used in placement, not here. -->
       </layer>
+
       <layer repeat="(Ecal_nlayers2+1)/2" vis="SeeThrough">
-        <!-- Here is only the active layer, each layer have 5 alveolus -->
         <slice material = "G4_AIR"         thickness = "Ecal_Alveolus_Air_Gap/2."                vis="Invisible" />
-        <slice material = "siPCBMix"       thickness = "Ecal_Slab_PCB_thickness+Ecal_Slab_copper_thickness+Ecal_Slab_shielding" vis="Invisible" />
+	<slice material = "G4_Al"          thickness = "Ecal_Slab_shielding"        vis="Invisible" />
+	<slice material = "G4_Cu"          thickness = "Ecal_Slab_copper_thickness"        vis="Invisible" />
+	<slice material = "G4_AIR"         thickness = "Ecal_Slab_ASIC_thickness"   vis="Invisible"/>
+	<slice material = "PCB"            thickness = "Ecal_Slab_PCB_thickness"    vis="Invisible"/>
         <slice material = "G4_AIR"         thickness = "Ecal_Slab_glue_gap"                      vis="Invisible" />
         <slice material = "Si"             thickness = "Ecal_Si_thickness" sensitive = "yes"     vis="Invisible"    />
         <slice material = "GroundOrHVMix"  thickness = "Ecal_Slab_ground_thickness"              vis="Invisible" />
@@ -48,9 +56,11 @@
         <slice material = "GroundOrHVMix"  thickness = "Ecal_Slab_ground_thickness"              vis="Invisible" />
         <slice material = "Si"             thickness = "Ecal_Si_thickness" sensitive = "yes"     vis="Invisible"    />
         <slice material = "G4_AIR"         thickness = "Ecal_Slab_glue_gap"                      vis="Invisible" />
-        <slice material = "siPCBMix"       thickness = "Ecal_Slab_PCB_thickness+Ecal_Slab_copper_thickness+Ecal_Slab_shielding" vis="Invisible" />
+	<slice material = "PCB"            thickness = "Ecal_Slab_PCB_thickness"    vis="Invisible"/>
+	<slice material = "G4_AIR"         thickness = "Ecal_Slab_ASIC_thickness"   vis="Invisible"/>
+	<slice material = "G4_Cu"          thickness = "Ecal_Slab_copper_thickness"        vis="Invisible" />
+	<slice material = "G4_Al"          thickness = "Ecal_Slab_shielding"        vis="Invisible" />
         <slice material = "G4_AIR"         thickness = "Ecal_Alveolus_Air_Gap/2."                vis="Invisible" />
-        <!-- There is a structure after each active layer.(W+Fiber) will be built inside dirver, 2 Fiber will be used in placement, not here. -->
       </layer>
     </detector>
 

--- a/ILD/compact/ILD_common_v02/SEcal05_siw_ECRing.xml
+++ b/ILD/compact/ILD_common_v02/SEcal05_siw_ECRing.xml
@@ -24,43 +24,47 @@
 
       <staves  material = "G4_W"  vis="GreenVis"/>
 
-      <layer repeat="Ecal_nlayers1/2" vis="SeeThrough" > <!-- 10 double SD Layers, and 5 W palte after each double SD Layer -->
-        <!-- Here is only the active layer, each layer have 5 alveolus -->
+      <layer repeat="Ecal_nlayers1/2" vis="SeeThrough" >
         <slice material = "G4_AIR"         thickness = "Ecal_Alveolus_Air_Gap/2."                vis="Invisible" />
-        <slice material = "siPCBMix"       thickness = "Ecal_Slab_PCB_thickness+Ecal_Slab_copper_thickness+Ecal_Slab_shielding" vis="Invisible" />
+	<slice material = "G4_Al"          thickness = "Ecal_Slab_shielding"        vis="Invisible" />
+	<slice material = "G4_Cu"          thickness = "Ecal_Slab_copper_thickness"        vis="Invisible" />
+	<slice material = "G4_AIR"         thickness = "Ecal_Slab_ASIC_thickness"   vis="Invisible"/>
+	<slice material = "PCB"            thickness = "Ecal_Slab_PCB_thickness"    vis="Invisible"/>
         <slice material = "G4_AIR"         thickness = "Ecal_Slab_glue_gap"                      vis="Invisible" />
         <slice material = "Si"             thickness = "Ecal_Si_thickness" sensitive = "yes"     vis="RedVis"    />
-        <!--slice material = "groundMix"      thickness = "Ecal_Slab_ground_thickness" /-->
         <slice material = "GroundOrHVMix"  thickness = "Ecal_Slab_ground_thickness"              vis="Invisible" />
         <slice material = "CarbonFiber"         thickness = "Ecal_fiber_thickness_slabAbs"                    vis="Invisible" />
         <slice material = "G4_W"   thickness = "Ecal_radiator_layers_set1_thickness"   vis="GreenVis"   />
         <slice material = "CarbonFiber"         thickness = "Ecal_fiber_thickness_slabAbs"                    vis="Invisible" />
-        <!--slice material = "groundMix"      thickness = "Ecal_Slab_ground_thickness" /-->
         <slice material = "GroundOrHVMix"  thickness = "Ecal_Slab_ground_thickness"              vis="Invisible" />
         <slice material = "Si"             thickness = "Ecal_Si_thickness" sensitive = "yes"     vis="RedVis"    />
         <slice material = "G4_AIR"         thickness = "Ecal_Slab_glue_gap"                      vis="Invisible" />
-        <slice material = "siPCBMix"       thickness = "Ecal_Slab_PCB_thickness+Ecal_Slab_copper_thickness+Ecal_Slab_shielding" vis="Invisible" />
+	<slice material = "PCB"            thickness = "Ecal_Slab_PCB_thickness"    vis="Invisible"/>
+	<slice material = "G4_AIR"         thickness = "Ecal_Slab_ASIC_thickness"   vis="Invisible"/>
+	<slice material = "G4_Cu"          thickness = "Ecal_Slab_copper_thickness"        vis="Invisible" />
+	<slice material = "G4_Al"          thickness = "Ecal_Slab_shielding"        vis="Invisible" />
         <slice material = "G4_AIR"         thickness = "Ecal_Alveolus_Air_Gap/2."                vis="Invisible" />
-        <!-- There is a structure after each active layer. (W+Fiber) W will be built inside dirver, 2 Fiber will be used in placement, not here. -->
       </layer>
-      <layer repeat="(Ecal_nlayers2+1)/2" vis="SeeThrough"> <!-- 5 double SD Layers, and 4 W palte after each double SD Layer, without the last W plate -->
-        <!-- Here is only the active layer, each layer have 5 alveolus -->
+      <layer repeat="(Ecal_nlayers2+1)/2" vis="SeeThrough">
         <slice material = "G4_AIR"         thickness = "Ecal_Alveolus_Air_Gap/2."                vis="Invisible" />
-        <slice material = "siPCBMix"       thickness = "Ecal_Slab_PCB_thickness+Ecal_Slab_copper_thickness+Ecal_Slab_shielding" vis="Invisible" />
+	<slice material = "G4_Al"          thickness = "Ecal_Slab_shielding"        vis="Invisible" />
+	<slice material = "G4_Cu"          thickness = "Ecal_Slab_copper_thickness"        vis="Invisible" />
+	<slice material = "G4_AIR"         thickness = "Ecal_Slab_ASIC_thickness"   vis="Invisible"/>
+	<slice material = "PCB"            thickness = "Ecal_Slab_PCB_thickness"    vis="Invisible"/>
         <slice material = "G4_AIR"         thickness = "Ecal_Slab_glue_gap"                      vis="Invisible" />
         <slice material = "Si"             thickness = "Ecal_Si_thickness" sensitive = "yes"     vis="RedVis"    />
-        <!--slice material = "groundMix"      thickness = "Ecal_Slab_ground_thickness" /-->
         <slice material = "GroundOrHVMix"  thickness = "Ecal_Slab_ground_thickness"              vis="Invisible" />
         <slice material = "CarbonFiber"         thickness = "Ecal_fiber_thickness_slabAbs"                    vis="Invisible" />
         <slice material = "G4_W"   thickness = "Ecal_radiator_layers_set2_thickness"   vis="GreenVis"   />
         <slice material = "CarbonFiber"         thickness = "Ecal_fiber_thickness_slabAbs"                    vis="Invisible" />
-        <!--slice material = "groundMix"      thickness = "Ecal_Slab_ground_thickness" /-->
         <slice material = "GroundOrHVMix"  thickness = "Ecal_Slab_ground_thickness"              vis="Invisible" />
         <slice material = "Si"             thickness = "Ecal_Si_thickness" sensitive = "yes"     vis="RedVis"    />
         <slice material = "G4_AIR"         thickness = "Ecal_Slab_glue_gap"                      vis="Invisible" />
-        <slice material = "siPCBMix"       thickness = "Ecal_Slab_PCB_thickness+Ecal_Slab_copper_thickness+Ecal_Slab_shielding" vis="Invisible" />
+	<slice material = "PCB"            thickness = "Ecal_Slab_PCB_thickness"    vis="Invisible"/>
+	<slice material = "G4_AIR"         thickness = "Ecal_Slab_ASIC_thickness"   vis="Invisible"/>
+	<slice material = "G4_Cu"          thickness = "Ecal_Slab_copper_thickness"        vis="Invisible" />
+	<slice material = "G4_Al"          thickness = "Ecal_Slab_shielding"        vis="Invisible" />
         <slice material = "G4_AIR"         thickness = "Ecal_Alveolus_Air_Gap/2."                vis="Invisible" />
-        <!-- There is a structure after each active layer.(W+Fiber) will be built inside dirver, 2 Fiber will be used in placement, not here. -->
       </layer>
     </detector>
   </detectors>

--- a/ILD/compact/ILD_common_v02/SEcal05_siw_Endcaps.xml
+++ b/ILD/compact/ILD_common_v02/SEcal05_siw_Endcaps.xml
@@ -23,44 +23,48 @@
 
       <staves  material = "G4_W"  vis="BlueVis"/>
 
-      <layer repeat="Ecal_nlayers1/2" vis="SeeThrough" > <!-- 10 double SD Layers, and 5 W palte after each double SD Layer -->
-        <!-- Here is only the active layer, each layer have 5 alveolus -->
+      <layer repeat="Ecal_nlayers1/2" vis="SeeThrough" >
         <slice material = "G4_AIR"         thickness = "Ecal_Alveolus_Air_Gap/2."                vis="Invisible" />
-        <slice material = "siPCBMix"       thickness = "Ecal_Slab_PCB_thickness+Ecal_Slab_copper_thickness+Ecal_Slab_shielding" vis="Invisible" />
+	<slice material = "G4_Al"          thickness = "Ecal_Slab_shielding"        vis="Invisible" />
+	<slice material = "G4_Cu"          thickness = "Ecal_Slab_copper_thickness"        vis="Invisible" />
+	<slice material = "G4_AIR"         thickness = "Ecal_Slab_ASIC_thickness"   vis="Invisible"/>
+	<slice material = "PCB"            thickness = "Ecal_Slab_PCB_thickness"    vis="Invisible"/>
         <slice material = "G4_AIR"         thickness = "Ecal_Slab_glue_gap"                      vis="Invisible" />
         <slice material = "Si"             thickness = "Ecal_Si_thickness" sensitive = "yes"     vis="RedVis"    />
-        <!--slice material = "groundMix"      thickness = "Ecal_Slab_ground_thickness" /-->
         <slice material = "GroundOrHVMix"  thickness = "Ecal_Slab_ground_thickness"              vis="Invisible" />
         <slice material = "CarbonFiber"         thickness = "Ecal_fiber_thickness_slabAbs"                    vis="Invisible" />
         <slice material = "G4_W"   thickness = "Ecal_radiator_layers_set1_thickness"   vis="BlueVis"   />
         <slice material = "CarbonFiber"         thickness = "Ecal_fiber_thickness_slabAbs"                    vis="Invisible" />
-        <!--slice material = "groundMix"      thickness = "Ecal_Slab_ground_thickness" /-->
         <slice material = "GroundOrHVMix"  thickness = "Ecal_Slab_ground_thickness"              vis="Invisible" />
         <slice material = "Si"             thickness = "Ecal_Si_thickness" sensitive = "yes"     vis="RedVis"    />
         <slice material = "G4_AIR"         thickness = "Ecal_Slab_glue_gap"                      vis="Invisible" />
-        <slice material = "siPCBMix"       thickness = "Ecal_Slab_PCB_thickness+Ecal_Slab_copper_thickness+Ecal_Slab_shielding" vis="Invisible" />
+	<slice material = "PCB"            thickness = "Ecal_Slab_PCB_thickness"    vis="Invisible"/>
+	<slice material = "G4_AIR"         thickness = "Ecal_Slab_ASIC_thickness"   vis="Invisible"/>
+	<slice material = "G4_Cu"          thickness = "Ecal_Slab_copper_thickness"        vis="Invisible" />
+	<slice material = "G4_Al"          thickness = "Ecal_Slab_shielding"        vis="Invisible" />
         <slice material = "G4_AIR"         thickness = "Ecal_Alveolus_Air_Gap/2."                vis="Invisible" />
-        <!-- There is a structure after each active layer. (W+Fiber) W will be built inside dirver, 2 Fiber will be used in placement, not here. -->
       </layer>
 
-      <layer repeat="(Ecal_nlayers2+1)/2" vis="SeeThrough"> <!-- 5 double SD Layers, and 4 W palte after each double SD Layer, without the last W plate -->
-        <!-- Here is only the active layer, each layer have 5 alveolus -->
+      <layer repeat="(Ecal_nlayers2+1)/2" vis="SeeThrough">
         <slice material = "G4_AIR"         thickness = "Ecal_Alveolus_Air_Gap/2."                vis="Invisible" />
-        <slice material = "siPCBMix"       thickness = "Ecal_Slab_PCB_thickness+Ecal_Slab_copper_thickness+Ecal_Slab_shielding" vis="Invisible" />
+	<slice material = "G4_Al"          thickness = "Ecal_Slab_shielding"        vis="Invisible" />
+	<slice material = "G4_Cu"          thickness = "Ecal_Slab_copper_thickness"        vis="Invisible" />
+	<slice material = "G4_AIR"         thickness = "Ecal_Slab_ASIC_thickness"   vis="Invisible"/>
+	<slice material = "PCB"            thickness = "Ecal_Slab_PCB_thickness"    vis="Invisible"/>
         <slice material = "G4_AIR"         thickness = "Ecal_Slab_glue_gap"                      vis="Invisible" />
         <slice material = "Si"             thickness = "Ecal_Si_thickness" sensitive = "yes"     vis="RedVis"    />
-        <!--slice material = "groundMix"      thickness = "Ecal_Slab_ground_thickness" /-->
         <slice material = "GroundOrHVMix"  thickness = "Ecal_Slab_ground_thickness"              vis="Invisible" />
         <slice material = "CarbonFiber"         thickness = "Ecal_fiber_thickness_slabAbs"                    vis="Invisible" />
         <slice material = "G4_W"   thickness = "Ecal_radiator_layers_set2_thickness"   vis="BlueVis"   />
         <slice material = "CarbonFiber"         thickness = "Ecal_fiber_thickness_slabAbs"                    vis="Invisible" />
-        <!--slice material = "groundMix"      thickness = "Ecal_Slab_ground_thickness" /-->
         <slice material = "GroundOrHVMix"  thickness = "Ecal_Slab_ground_thickness"              vis="Invisible" />
         <slice material = "Si"             thickness = "Ecal_Si_thickness" sensitive = "yes"     vis="RedVis"    />
         <slice material = "G4_AIR"         thickness = "Ecal_Slab_glue_gap"                      vis="Invisible" />
-        <slice material = "siPCBMix"       thickness = "Ecal_Slab_PCB_thickness+Ecal_Slab_copper_thickness+Ecal_Slab_shielding" vis="Invisible" />
+	<slice material = "PCB"            thickness = "Ecal_Slab_PCB_thickness"    vis="Invisible"/>
+	<slice material = "G4_AIR"         thickness = "Ecal_Slab_ASIC_thickness"   vis="Invisible"/>
+	<slice material = "G4_Cu"          thickness = "Ecal_Slab_copper_thickness"        vis="Invisible" />
+	<slice material = "G4_Al"          thickness = "Ecal_Slab_shielding"        vis="Invisible" />
         <slice material = "G4_AIR"         thickness = "Ecal_Alveolus_Air_Gap/2."                vis="Invisible" />
-        <!-- There is a structure after each active layer.(W+Fiber) will be built inside dirver, 2 Fiber will be used in placement, not here. -->
       </layer>
     </detector>
 

--- a/ILD/compact/ILD_common_v02/ecal_defs.xml
+++ b/ILD/compact/ILD_common_v02/ecal_defs.xml
@@ -23,7 +23,8 @@
   <constant name="Ecal_Alveolus_Air_Gap" value="0.2*mm"/>
   <constant name="Ecal_Si_thickness" value=".525*mm"/>
   <constant name="Ecal_Slab_H_fiber_thickness" value="0.55*mm"/>
-  <constant name="Ecal_Slab_PCB_thickness" value="1.70*mm"/>
+  <constant name="Ecal_Slab_ASIC_thickness" value="0.7*mm"/>
+  <constant name="Ecal_Slab_PCB_thickness" value="1.0*mm"/>
   <constant name="Ecal_Slab_copper_thickness" value="0.35*mm"/>
   <constant name="Ecal_Slab_glue_gap" value="0.1*mm"/>
   <constant name="Ecal_Slab_ground_thickness" value="0.1*mm"/>


### PR DESCRIPTION

BEGINRELEASENOTES
- previously several ECAL sub-layers were combined into an averaged material to simplify simulation.
This requires to redefine this material every time thicknesses change (quite often at the moment), which was not done consistently. 
For the time being, separate the components to ensure correct material description. 
(Consider recombining when sub-layer thicknesses are fixed and stable.)
ENDRELEASENOTES