### PR TITLE
ILD_*_v02 models: Update ecal dims

### DIFF
--- a/ILD/compact/ILD_common_v02/SEcal05_siw_Barrel.xml
+++ b/ILD/compact/ILD_common_v02/SEcal05_siw_Barrel.xml
@@ -27,11 +27,13 @@
 	<slice material = "PCB"            thickness = "Ecal_Slab_PCB_thickness"    vis="Invisible"/>
         <slice material = "G4_AIR"         thickness = "Ecal_Slab_glue_gap"                      vis="Invisible" />
         <slice material = "Si"             thickness = "Ecal_Si_thickness" sensitive = "yes"     vis="Invisible"    />
+        <slice material = "G4_AIR"         thickness = "Ecal_Slab_glue_gap"                      vis="Invisible" />
         <slice material = "GroundOrHVMix"  thickness = "Ecal_Slab_ground_thickness"              vis="Invisible" />
         <slice material = "CarbonFiber"    thickness = "Ecal_fiber_thickness_slabAbs"                    vis="Invisible" />
         <slice material = "G4_W"           thickness = "Ecal_radiator_layers_set1_thickness"   vis="BlueVis"   radiator="yes"/>
         <slice material = "CarbonFiber"    thickness = "Ecal_fiber_thickness_slabAbs"                    vis="Invisible" />
         <slice material = "GroundOrHVMix"  thickness = "Ecal_Slab_ground_thickness"              vis="Invisible" />
+        <slice material = "G4_AIR"         thickness = "Ecal_Slab_glue_gap"                      vis="Invisible" />
         <slice material = "Si"             thickness = "Ecal_Si_thickness" sensitive = "yes"     vis="Invisible"    />
         <slice material = "G4_AIR"         thickness = "Ecal_Slab_glue_gap"                      vis="Invisible" />
 	<slice material = "PCB"            thickness = "Ecal_Slab_PCB_thickness"    vis="Invisible"/>
@@ -49,11 +51,13 @@
 	<slice material = "PCB"            thickness = "Ecal_Slab_PCB_thickness"    vis="Invisible"/>
         <slice material = "G4_AIR"         thickness = "Ecal_Slab_glue_gap"                      vis="Invisible" />
         <slice material = "Si"             thickness = "Ecal_Si_thickness" sensitive = "yes"     vis="Invisible"    />
+        <slice material = "G4_AIR"         thickness = "Ecal_Slab_glue_gap"                      vis="Invisible" />
         <slice material = "GroundOrHVMix"  thickness = "Ecal_Slab_ground_thickness"              vis="Invisible" />
         <slice material = "CarbonFiber"    thickness = "Ecal_fiber_thickness_slabAbs"                    vis="Invisible" />
         <slice material = "G4_W"           thickness = "Ecal_radiator_layers_set2_thickness"   vis="BlueVis"   radiator="yes"/>
         <slice material = "CarbonFiber"    thickness = "Ecal_fiber_thickness_slabAbs"                    vis="Invisible" />
         <slice material = "GroundOrHVMix"  thickness = "Ecal_Slab_ground_thickness"              vis="Invisible" />
+        <slice material = "G4_AIR"         thickness = "Ecal_Slab_glue_gap"                      vis="Invisible" />
         <slice material = "Si"             thickness = "Ecal_Si_thickness" sensitive = "yes"     vis="Invisible"    />
         <slice material = "G4_AIR"         thickness = "Ecal_Slab_glue_gap"                      vis="Invisible" />
 	<slice material = "PCB"            thickness = "Ecal_Slab_PCB_thickness"    vis="Invisible"/>

--- a/ILD/compact/ILD_common_v02/SEcal05_siw_ECRing.xml
+++ b/ILD/compact/ILD_common_v02/SEcal05_siw_ECRing.xml
@@ -32,11 +32,13 @@
 	<slice material = "PCB"            thickness = "Ecal_Slab_PCB_thickness"    vis="Invisible"/>
         <slice material = "G4_AIR"         thickness = "Ecal_Slab_glue_gap"                      vis="Invisible" />
         <slice material = "Si"             thickness = "Ecal_Si_thickness" sensitive = "yes"     vis="RedVis"    />
+        <slice material = "G4_AIR"         thickness = "Ecal_Slab_glue_gap"                      vis="Invisible" />
         <slice material = "GroundOrHVMix"  thickness = "Ecal_Slab_ground_thickness"              vis="Invisible" />
         <slice material = "CarbonFiber"         thickness = "Ecal_fiber_thickness_slabAbs"                    vis="Invisible" />
         <slice material = "G4_W"   thickness = "Ecal_radiator_layers_set1_thickness"   vis="GreenVis"   />
         <slice material = "CarbonFiber"         thickness = "Ecal_fiber_thickness_slabAbs"                    vis="Invisible" />
         <slice material = "GroundOrHVMix"  thickness = "Ecal_Slab_ground_thickness"              vis="Invisible" />
+        <slice material = "G4_AIR"         thickness = "Ecal_Slab_glue_gap"                      vis="Invisible" />
         <slice material = "Si"             thickness = "Ecal_Si_thickness" sensitive = "yes"     vis="RedVis"    />
         <slice material = "G4_AIR"         thickness = "Ecal_Slab_glue_gap"                      vis="Invisible" />
 	<slice material = "PCB"            thickness = "Ecal_Slab_PCB_thickness"    vis="Invisible"/>
@@ -53,11 +55,13 @@
 	<slice material = "PCB"            thickness = "Ecal_Slab_PCB_thickness"    vis="Invisible"/>
         <slice material = "G4_AIR"         thickness = "Ecal_Slab_glue_gap"                      vis="Invisible" />
         <slice material = "Si"             thickness = "Ecal_Si_thickness" sensitive = "yes"     vis="RedVis"    />
+        <slice material = "G4_AIR"         thickness = "Ecal_Slab_glue_gap"                      vis="Invisible" />
         <slice material = "GroundOrHVMix"  thickness = "Ecal_Slab_ground_thickness"              vis="Invisible" />
         <slice material = "CarbonFiber"         thickness = "Ecal_fiber_thickness_slabAbs"                    vis="Invisible" />
         <slice material = "G4_W"   thickness = "Ecal_radiator_layers_set2_thickness"   vis="GreenVis"   />
         <slice material = "CarbonFiber"         thickness = "Ecal_fiber_thickness_slabAbs"                    vis="Invisible" />
         <slice material = "GroundOrHVMix"  thickness = "Ecal_Slab_ground_thickness"              vis="Invisible" />
+        <slice material = "G4_AIR"         thickness = "Ecal_Slab_glue_gap"                      vis="Invisible" />
         <slice material = "Si"             thickness = "Ecal_Si_thickness" sensitive = "yes"     vis="RedVis"    />
         <slice material = "G4_AIR"         thickness = "Ecal_Slab_glue_gap"                      vis="Invisible" />
 	<slice material = "PCB"            thickness = "Ecal_Slab_PCB_thickness"    vis="Invisible"/>

--- a/ILD/compact/ILD_common_v02/SEcal05_siw_Endcaps.xml
+++ b/ILD/compact/ILD_common_v02/SEcal05_siw_Endcaps.xml
@@ -31,11 +31,13 @@
 	<slice material = "PCB"            thickness = "Ecal_Slab_PCB_thickness"    vis="Invisible"/>
         <slice material = "G4_AIR"         thickness = "Ecal_Slab_glue_gap"                      vis="Invisible" />
         <slice material = "Si"             thickness = "Ecal_Si_thickness" sensitive = "yes"     vis="RedVis"    />
+        <slice material = "G4_AIR"         thickness = "Ecal_Slab_glue_gap"                      vis="Invisible" />
         <slice material = "GroundOrHVMix"  thickness = "Ecal_Slab_ground_thickness"              vis="Invisible" />
         <slice material = "CarbonFiber"         thickness = "Ecal_fiber_thickness_slabAbs"                    vis="Invisible" />
         <slice material = "G4_W"   thickness = "Ecal_radiator_layers_set1_thickness"   vis="BlueVis"   />
         <slice material = "CarbonFiber"         thickness = "Ecal_fiber_thickness_slabAbs"                    vis="Invisible" />
         <slice material = "GroundOrHVMix"  thickness = "Ecal_Slab_ground_thickness"              vis="Invisible" />
+        <slice material = "G4_AIR"         thickness = "Ecal_Slab_glue_gap"                      vis="Invisible" />
         <slice material = "Si"             thickness = "Ecal_Si_thickness" sensitive = "yes"     vis="RedVis"    />
         <slice material = "G4_AIR"         thickness = "Ecal_Slab_glue_gap"                      vis="Invisible" />
 	<slice material = "PCB"            thickness = "Ecal_Slab_PCB_thickness"    vis="Invisible"/>
@@ -53,11 +55,13 @@
 	<slice material = "PCB"            thickness = "Ecal_Slab_PCB_thickness"    vis="Invisible"/>
         <slice material = "G4_AIR"         thickness = "Ecal_Slab_glue_gap"                      vis="Invisible" />
         <slice material = "Si"             thickness = "Ecal_Si_thickness" sensitive = "yes"     vis="RedVis"    />
+        <slice material = "G4_AIR"         thickness = "Ecal_Slab_glue_gap"                      vis="Invisible" />
         <slice material = "GroundOrHVMix"  thickness = "Ecal_Slab_ground_thickness"              vis="Invisible" />
         <slice material = "CarbonFiber"         thickness = "Ecal_fiber_thickness_slabAbs"                    vis="Invisible" />
         <slice material = "G4_W"   thickness = "Ecal_radiator_layers_set2_thickness"   vis="BlueVis"   />
         <slice material = "CarbonFiber"         thickness = "Ecal_fiber_thickness_slabAbs"                    vis="Invisible" />
         <slice material = "GroundOrHVMix"  thickness = "Ecal_Slab_ground_thickness"              vis="Invisible" />
+        <slice material = "G4_AIR"         thickness = "Ecal_Slab_glue_gap"                      vis="Invisible" />
         <slice material = "Si"             thickness = "Ecal_Si_thickness" sensitive = "yes"     vis="RedVis"    />
         <slice material = "G4_AIR"         thickness = "Ecal_Slab_glue_gap"                      vis="Invisible" />
 	<slice material = "PCB"            thickness = "Ecal_Slab_PCB_thickness"    vis="Invisible"/>

--- a/ILD/compact/ILD_common_v02/ecal_defs.xml
+++ b/ILD/compact/ILD_common_v02/ecal_defs.xml
@@ -2,8 +2,8 @@
 
   <constant name="Ecal_Barrel_halfZ" value="TPC_Ecal_Hcal_barrel_halfZ"/>
 
-  <constant name="Ecal_nlayers1" value="21"/>
-  <constant name="Ecal_nlayers2" value="9"/>
+  <constant name="Ecal_nlayers1" value="20"/>
+  <constant name="Ecal_nlayers2" value="10"/>
   <constant name="Ecal_nlayers3" value="0"/>
   <constant name="Ecal_radiator_layers_set1_thickness" value="2.1*mm"/>
   <constant name="Ecal_radiator_layers_set2_thickness" value="4.2*mm"/>
@@ -16,19 +16,20 @@
   <constant name="Ecal_fiber_thickness_slabAbs" value="0.15*mm"/>
 
   <constant name="Ecal_front_face_thickness" value="0.66*mm"/> <!-- 4.04 - 2.1 - 0.44 - 2*0.42  = 0.66 -->
-  <constant name="Ecal_support_thickness" value="(14.0+2.09)*mm"/> <!-- 14.44 - 0.44 --> <!-- + FUDGE FACTOR -->
+  <constant name="Ecal_support_thickness" value="14.49*mm"/> <!-- 14.93 - 0.44 -->
 
-  <constant name="Ecal_lateral_face_thickness" value="(1.10+0.5)*mm"/> <!-- 1.54 - 0.44  --> <!-- 0.5 for the tolerance -->
+  <constant name="Ecal_lateral_face_thickness" value="(1.10+0.5)*mm"/> <!-- 1.54 - 0.44  --> <!-- 0.5 for the 1mm tolerance between modules -->
 
   <constant name="Ecal_Alveolus_Air_Gap" value="0.2*mm"/>
   <constant name="Ecal_Si_thickness" value=".525*mm"/>
   <constant name="Ecal_Slab_H_fiber_thickness" value="0.55*mm"/>
   <constant name="Ecal_Slab_ASIC_thickness" value="0.7*mm"/>
   <constant name="Ecal_Slab_PCB_thickness" value="1.0*mm"/>
-  <constant name="Ecal_Slab_copper_thickness" value="0.35*mm"/>
+  <constant name="Ecal_Slab_copper_thickness" value="0.40*mm"/>
   <constant name="Ecal_Slab_glue_gap" value="0.1*mm"/>
   <constant name="Ecal_Slab_ground_thickness" value="0.1*mm"/>
-  <constant name="Ecal_Slab_shielding" value="0.0*mm"/>
+  <constant name="Ecal_Slab_shielding" value="0.1*mm"/>
+
   <constant name="Ecal_guard_ring_size" value="0.5*mm"/>
   <constant name="Ecal_n_wafers_per_tower" value="2"/>
 

--- a/ILD/compact/ILD_common_v02/ecal_defs.xml
+++ b/ILD/compact/ILD_common_v02/ecal_defs.xml
@@ -45,7 +45,7 @@
   <!-- constant name="Ecal_cables_gap" value="100.*mm"/ -->
   <constant name="Ecal_cables_gap" value="Ecal_endcap_zmin-TPC_Ecal_Hcal_barrel_halfZ"/>
 
-  <constant name="Ecal_Slab_Plug_length" value="5*mm"/> <!-- TO CHECK ! ! -->
+  <constant name="Ecal_Slab_Plug_length" value="8*mm"/>
 
   <!-- needed only for ecal ring driver... -->
   <constant name="Ecal_cells_size" value="5.*mm"/>

--- a/ILD/compact/ILD_common_v02/top_defs_common_v02.xml
+++ b/ILD/compact/ILD_common_v02/top_defs_common_v02.xml
@@ -45,13 +45,13 @@
   <constant name="Ecal_Hcal_symmetry"   value="8"/>
 
   <!-- constant name="Ecal_barrel_thickness" value="185.0*mm"/ -->
-  <constant name="Ecal_barrel_thickness" value="215.2*mm"/>
+  <constant name="Ecal_barrel_thickness" value="223.2*mm"/>
 
 
   <constant name="Hcal_Ecal_gap" value="30*mm"/>
 
   <!-- constant name="Ecal_endcap_zmin" value="2450.0*mm"/ -->
-  <constant name="Ecal_endcap_zmin" value="TPC_Ecal_Hcal_barrel_halfZ + 69.8*mm"/>
+  <constant name="Ecal_endcap_zmin" value="TPC_Ecal_Hcal_barrel_halfZ + 61.8*mm"/>
 
   <constant name="Ecal_endcap_center_box_size" value="800.0*mm"/>
 

--- a/ILD/compact/ILD_common_v02/tpc10_01.xml
+++ b/ILD/compact/ILD_common_v02/tpc10_01.xml
@@ -22,7 +22,7 @@
       <!--	ORIGINAL :     dr_InnerServiceArea="30*mm" dr_OuterServiceArea="30*mm"  DANIEL REDUCED TO FIT THICK ECAL -->
 
       <global TPC_pad_height="6*mm" TPC_pad_width="1*mm"  TPC_max_step_length="5*mm" dr_InnerWall="25*mm" 
-	      dr_InnerServiceArea="28.9*mm" dr_OuterServiceArea="0.9*mm"
+	      dr_InnerServiceArea="25.9*mm" dr_OuterServiceArea="0.9*mm"
               dr_OuterWall="55*mm" dz_Cathode="0.06*mm" dz_Readout="25*mm" dz_Endplate="100*mm"
               chamber_Gas="TDR_gas" sensitive_threshold_eV="32*eV"  />
 

--- a/ILD/compact/ILD_l1_v02/top_defs_ILD_l1_v02.xml
+++ b/ILD/compact/ILD_l1_v02/top_defs_ILD_l1_v02.xml
@@ -5,7 +5,7 @@
   </comment>
 
   <constant name="Field_nominal_value" value="3.5*tesla"/>
-  <constant name="top_TPC_outer_radius"    value="1777.8*mm"/>
+  <constant name="top_TPC_outer_radius"    value="1769.8*mm"/>
   <constant name="Ecal_endcap_extra_size" value="67.84*mm"/>
   <constant name="Ecal_endcap_number_of_towers" type="string" value="3 3 3"/>
 

--- a/ILD/compact/ILD_l2_v02/top_defs_ILD_l2_v02.xml
+++ b/ILD/compact/ILD_l2_v02/top_defs_ILD_l2_v02.xml
@@ -5,7 +5,7 @@ all hardcoded overall dimensions which differ between large and small models
 </comment>
 
   <constant name="Field_nominal_value" value="3.5*tesla"/>
-  <constant name="top_TPC_outer_radius"    value="1777.8*mm"/>
+  <constant name="top_TPC_outer_radius"    value="1769.8*mm"/>
   <constant name="Ecal_endcap_extra_size" value="67.84*mm"/>
   <constant name="Ecal_endcap_number_of_towers" type="string" value="3 3 3"/>
 

--- a/ILD/compact/ILD_l4_v02/top_defs_ILD_l4_v02.xml
+++ b/ILD/compact/ILD_l4_v02/top_defs_ILD_l4_v02.xml
@@ -5,7 +5,7 @@ all hardcoded overall dimensions which differ between large and small models
 </comment>
 
   <constant name="Field_nominal_value" value="3.5*tesla"/>
-  <constant name="top_TPC_outer_radius"    value="1777.8*mm"/>
+  <constant name="top_TPC_outer_radius"    value="1769.8*mm"/>
   <constant name="Ecal_endcap_extra_size" value="67.84*mm"/>
   <constant name="Ecal_endcap_number_of_towers" type="string" value="3 3 3"/>
 

--- a/ILD/compact/ILD_s1_v02/top_defs_ILD_s1_v02.xml
+++ b/ILD/compact/ILD_s1_v02/top_defs_ILD_s1_v02.xml
@@ -4,9 +4,9 @@
 all hardcoded overall dimensions which differ between large and small models
 </comment>
 
-  <constant name="Field_nominal_value" value="4.0*tesla"/>   <!-- changed wrt large model -->
-  <constant name="top_TPC_outer_radius"    value="1460*mm"/>   <!-- changed wrt large model -->
-  <constant name="Ecal_endcap_extra_size" value="7.72*mm"/>   <!-- changed wrt large model -->
-  <constant name="Ecal_endcap_number_of_towers" type="string" value="4 3"/>   <!-- changed wrt large model -->
+  <constant name="Field_nominal_value" value="4.0*tesla"/>
+  <constant name="top_TPC_outer_radius"    value="1426.8*mm"/>
+  <constant name="Ecal_endcap_extra_size" value="32.92*mm"/>
+  <constant name="Ecal_endcap_number_of_towers" type="string" value="4 3"/>
 
 </define>

--- a/ILD/compact/ILD_s2_v02/top_defs_ILD_s2_v02.xml
+++ b/ILD/compact/ILD_s2_v02/top_defs_ILD_s2_v02.xml
@@ -4,9 +4,9 @@
 all hardcoded overall dimensions which differ between large and small models
 </comment>
 
-  <constant name="Field_nominal_value" value="4.0*tesla"/>   <!-- changed wrt large model -->
-  <constant name="top_TPC_outer_radius"    value="1460*mm"/>   <!-- changed wrt large model -->
-  <constant name="Ecal_endcap_extra_size" value="7.72*mm"/>   <!-- changed wrt large model -->
-  <constant name="Ecal_endcap_number_of_towers" type="string" value="4 3"/>   <!-- changed wrt large model -->
+  <constant name="Field_nominal_value" value="4.0*tesla"/>
+  <constant name="top_TPC_outer_radius"    value="1426.8*mm"/>
+  <constant name="Ecal_endcap_extra_size" value="32.92*mm"/>
+  <constant name="Ecal_endcap_number_of_towers" type="string" value="4 3"/>
 
 </define>

--- a/ILD/compact/ILD_s4_v02/top_defs_ILD_s4_v02.xml
+++ b/ILD/compact/ILD_s4_v02/top_defs_ILD_s4_v02.xml
@@ -5,8 +5,8 @@ all hardcoded overall dimensions which differ between large and small models
 </comment>
 
   <constant name="Field_nominal_value" value="4.0*tesla"/>   <!-- changed wrt large model -->
-  <constant name="top_TPC_outer_radius"    value="1460*mm"/>   <!-- changed wrt large model -->
-  <constant name="Ecal_endcap_extra_size" value="7.72*mm"/>   <!-- changed wrt large model -->
+  <constant name="top_TPC_outer_radius"    value="1426.8*mm"/>   <!-- changed wrt large model -->
+  <constant name="Ecal_endcap_extra_size" value="32.92*mm"/>   <!-- changed wrt large model -->
   <constant name="Ecal_endcap_number_of_towers" type="string" value="4 3"/>   <!-- changed wrt large model -->
 
 </define>

--- a/ILD/compact/ILD_s4_v02/top_defs_ILD_s4_v02.xml
+++ b/ILD/compact/ILD_s4_v02/top_defs_ILD_s4_v02.xml
@@ -4,9 +4,9 @@
 all hardcoded overall dimensions which differ between large and small models
 </comment>
 
-  <constant name="Field_nominal_value" value="4.0*tesla"/>   <!-- changed wrt large model -->
-  <constant name="top_TPC_outer_radius"    value="1426.8*mm"/>   <!-- changed wrt large model -->
-  <constant name="Ecal_endcap_extra_size" value="32.92*mm"/>   <!-- changed wrt large model -->
-  <constant name="Ecal_endcap_number_of_towers" type="string" value="4 3"/>   <!-- changed wrt large model -->
+  <constant name="Field_nominal_value" value="4.0*tesla"/>
+  <constant name="top_TPC_outer_radius"    value="1426.8*mm"/>
+  <constant name="Ecal_endcap_extra_size" value="32.92*mm"/>
+  <constant name="Ecal_endcap_number_of_towers" type="string" value="4 3"/>
 
 </define>

--- a/detector/calorimeter/SEcal05_Barrel.cpp
+++ b/detector/calorimeter/SEcal05_Barrel.cpp
@@ -176,6 +176,7 @@ static Ref_t create_detector(Detector& theDetector, xml_h element, SensitiveDete
 
   // overall size
   double Ecal_inner_radius                  = theDetector.constant<double>("Ecal_inner_radius");
+
   double Ecal_Barrel_halfZ                  = theDetector.constant<double>("Ecal_Barrel_halfZ");
   int    Ecal_barrel_z_modules              = theDetector.constant<int>("Ecal_barrel_z_modules");
   int    Ecal_barrel_number_of_towers       = theDetector.constant<int>("Ecal_barrel_number_of_towers");
@@ -259,12 +260,6 @@ static Ref_t create_detector(Detector& theDetector, xml_h element, SensitiveDete
                          Ecal_support_thickness);
 
   helper.setPlugLength( Ecal_plugLength );
-
-
-
-  if ( !Ecal_Barrel_PreshowerLayer && Ecal_front_face_thickness>0 ) {
-    cout << "WARNING SEcal05_Barrel: using front CF plate in a non-preshower setup: do you really want this?" << endl;
-  }
 
   // check resulting thickness is consistent with what's in compact description
   float module_thickness = helper.getTotalThickness();

--- a/detector/calorimeter/SEcal05_ECRing.cpp
+++ b/detector/calorimeter/SEcal05_ECRing.cpp
@@ -391,7 +391,7 @@ static Ref_t create_detector(Detector& theDetector, xml_h element, SensitiveDete
 	  radiator_dim_Z = 0;
 	} else { // include W+CF wrapping; only one side of alveolus
 	  cout << " -- no preshower, including absorber" << endl;
-	  this_struct_CFthick_beforeAbs = _CF_absWrap;
+	  this_struct_CFthick_beforeAbs = Ecal_front_face_thickness + _CF_absWrap;
 	  this_struct_CFthick_afterAbs = _CF_absWrap + _CF_alvWall;
 	  radiator_dim_Z = Ecal_radiator_thickness1; // this line implicitly assumes Ecal_nlayers1>0...
 	  //rad_pos_Z = radiator_dim_Z/2. + this_struct_CFthick_beforeAbs; // distance from top surface of structure to centre of radiator
@@ -417,10 +417,6 @@ static Ref_t create_detector(Detector& theDetector, xml_h element, SensitiveDete
       }
       //-------------------------------
 
-
-      cout << "struct radiator thickness in layer " << l_num << " = " << radiator_dim_Z << endl;
-
-      
       radiator_dim_y = radiator_dim_Z; // ahh different axis conventions....
 
       l_pos_z += this_struct_CFthick_beforeAbs + radiator_dim_y/2;
@@ -462,7 +458,7 @@ static Ref_t create_detector(Detector& theDetector, xml_h element, SensitiveDete
       // PlacedVolume  EndcapStructureLayer_phv =
 	EnvLogECRing.placeVolume(EndcapStructureLayer_vol,bsl_tran3D);
 	      
-      cout << "placed structural absorber layer at " << bsl_pos_z << endl;
+	//      cout << "placed structural absorber layer at " << bsl_pos_z << endl;
       
 
       }
@@ -478,14 +474,7 @@ static Ref_t create_detector(Detector& theDetector, xml_h element, SensitiveDete
 
       // now move to the alveolus and what's inside
 
-
-
-
-      
       double l_thickness = layering.layer(l_num-1)->thickness();  // Layer's thickness. this is the internal thickness of the alveolus
-
-
-      cout << "l_thickness " << l_thickness << endl;
 
       l_pos_z  += l_thickness/2.; // add in half the alveolus thickness
       
@@ -738,8 +727,6 @@ static Ref_t create_detector(Detector& theDetector, xml_h element, SensitiveDete
 //      l_pos_z +=   (l_thickness/2. +(radiator_dim_y/2. + Ecal_fiber_thickness * (N_FIBERS_ALVOULUS + N_FIBERS_W_STRUCTURE))*2.);
       
       l_pos_z +=   l_thickness/2.; // add in the other half of the alveolus
-
-      cout << "l_pos_z after alveolus = " << l_pos_z << endl;
 
       ++l_num;
  

--- a/detector/calorimeter/SEcal05_Endcaps.cpp
+++ b/detector/calorimeter/SEcal05_Endcaps.cpp
@@ -326,11 +326,11 @@ static Ref_t create_detector(Detector& theDetector, xml_h element, SensitiveDete
     caloData->layers[i].distance += Ecal_Barrel_halfZ + Ecal_cables_gap; // add IP->front face distance
   }
 
-  cout << "cell sizes: " << endl;
-  for (size_t i=0; i<caloData->layers.size(); i++) {
-    cout << "sensitive layer " << i << " : x,y = " << caloData->layers[i].cellSize0 << " " << caloData->layers[i].cellSize1 << endl;
-  }
-
+  //  cout << "cell sizes: " << endl;
+  //  for (size_t i=0; i<caloData->layers.size(); i++) {
+  //    cout << "sensitive layer " << i << " : x,y = " << caloData->layers[i].cellSize0 << " " << caloData->layers[i].cellSize1 << endl;
+  //  }
+  
   caloData->layoutType = LayeredCalorimeterData::EndcapLayout ;
   caloData->inner_symmetry = 4  ; // hard code cernter box hole
   caloData->outer_symmetry = 8  ; // outer Octagun

--- a/detector/calorimeter/SEcal05_Endcaps.cpp
+++ b/detector/calorimeter/SEcal05_Endcaps.cpp
@@ -181,9 +181,6 @@ static Ref_t create_detector(Detector& theDetector, xml_h element, SensitiveDete
 
   // layer configuration
   helper.setPreshower( Ecal_Endcap_PreshowerLayer );
-  if ( !Ecal_Endcap_PreshowerLayer && Ecal_front_face_thickness>0 ) {
-    cout << "WARNING, using front CF plate in a non-preshower setup: do you really want this?" << endl;
-  }
 
   cout << "Preshower ? " << Ecal_Endcap_PreshowerLayer << endl;
 

--- a/detector/calorimeter/SEcal05_Helpers.cpp
+++ b/detector/calorimeter/SEcal05_Helpers.cpp
@@ -70,6 +70,7 @@ float SEcal05_Helpers::getTotalThickness() {
   assert( (_preshower==0 || _preshower==1) && "_preshower not set" );
   assert( _CF_absWrap>=0. && _CF_alvWall>=0. && _CF_front>=0. && _CF_back>=0. && "CF thicknesses not set" );
   float totalThickness = _CF_front+_CF_back;// front and back supports
+
   // the absorber in the structure
   for (unsigned int i=0; i<_nlayers1+_nlayers2+_nlayers3; i++) {
     bool inStructure = _preshower ? i%2==1 : i%2==0 ;
@@ -472,7 +473,7 @@ void SEcal05_Helpers::makeModule( dd4hep::Volume & mod_vol,  // the volume we'll
           radiator_dim_Z = 0;
         } else { // include W+CF wrapping; only one side of alveolus
           // cout << " -- no preshower, including absorber" << endl;
-          this_struct_CFthick_beforeAbs = _CF_absWrap;
+          this_struct_CFthick_beforeAbs = _CF_front + _CF_absWrap; // allow for initial CF front plate also in no preshower case - djeans 6 july 2017
           this_struct_CFthick_afterAbs = _CF_absWrap + _CF_alvWall;
           radiator_dim_Z = getAbsThickness( absorber_index++ );
           rad_pos_Z = radiator_dim_Z/2. + this_struct_CFthick_beforeAbs; // distance from top surface of structure to centre of radiator


### PR DESCRIPTION

BEGINRELEASENOTES
- many tweaks to ECAL dimensions in ILD_*_V02 models, referring to technical design document from H.Videau et al.
- a couple of small bug fixes to ECAL drivers (previously ignored request for extra CF thickness in front face, if no preshower was set)
- adjusted TPC dimensions and barrel-endcap gap to accommodate new ECAL
ENDRELEASENOTES