### PR TITLE
 Fix ILD_l4_v02 OverLap.

### DIFF
--- a/ILD/compact/ILD_common_v02/envelope_defs.xml
+++ b/ILD/compact/ILD_common_v02/envelope_defs.xml
@@ -129,7 +129,7 @@
 
   <constant name="YokeEndcapPlug_inner_radius"    value="YokeEndcap_inner_radius"/>
   <constant name="YokeEndcapPlug_outer_radius"    value="Hcal_outer_radius"/>
-  <constant name="YokeEndcapPlug_min_z"           value="HcalEndcap_max_z + env_safety"/> <!-- 3981.5*mm"/> FixMe! Trap. and Mokka hardcode number -->
+  <constant name="YokeEndcapPlug_min_z"           value="HcalEndcap_max_z + env_safety*2.0"/>
   <constant name="YokeEndcapPlug_max_z"           value="YokeEndcap_min_z"/>
   <constant name="YokeEndcapPlug_symmetry"        value="Yoke_symmetry"/>
 

--- a/ILD/compact/ILD_common_v02/ftd_simple_staggered_02.xml
+++ b/ILD/compact/ILD_common_v02/ftd_simple_staggered_02.xml
@@ -19,7 +19,7 @@
                   <shape type="Tube" rmin="FTD_inner_radius"   rmax="FTD_outer_radius" dz="FTD_half_length"  />
                   <shape type="Tube" rmin="0." rmax="FTD_outer_radius+env_safety" dz="FTD_min_z_0" />
                 </shape>
-                <shape type="Tube" rmin="FTD_outer_radius_1" rmax="FTD_outer_radius+env_safety" dz="FTD_min_z_2-2.0*mm" />
+                <shape type="Tube" rmin="FTD_outer_radius_1" rmax="FTD_outer_radius+env_safety" dz="FTD_min_z_2-1.999*mm" />
               </shape>
               <shape type="Tube" rmin="FTD_outer_radius_2" rmax="FTD_outer_radius+env_safety" dz="FTD_min_z_2" />
             </shape>

--- a/detector/calorimeter/Yoke05_Endcaps.cpp
+++ b/detector/calorimeter/Yoke05_Endcaps.cpp
@@ -135,7 +135,7 @@ static Ref_t create_detector(Detector& theDetector, xml_h element, SensitiveDete
     + 0.1; // the tolerance 1 mm
 
   double yokeEndcapThickness    =   number_of_layers*(iron_thickness  + gap_thickness)
-    + 2*(5.6*iron_thickness + gap_thickness);
+    + 2*(5.6*iron_thickness + gap_thickness) + gap_thickness;
 
   double rInnerEndcap           =    Yoke_endcap_inner_radius;
   double rOuterEndcap           =    rInnerBarrel + yokeBarrelThickness;


### PR DESCRIPTION
BEGINRELEASENOTES
- Fix ILD_*_v02 OverLap
  - Add one more env_safety to avoid YokeEndcaps and HcalEndcaps overlap.
  - To adjust the FTD envelope to fix the SIT cable cone overlap.
  - Added one more gap_thickness to fix the YokeEndcap extruded by the last layer.

ENDRELEASENOTES