### PR TITLE
new ILD_?5_v02 models with hybrid ecal structure. Cosmetic fix to ILD_?4 hcal description.

### DIFF
--- a/ILD/compact/ILD_common_v02/SEcal05_hybrid_Barrel.xml
+++ b/ILD/compact/ILD_common_v02/SEcal05_hybrid_Barrel.xml
@@ -1,0 +1,95 @@
+<lccdd>
+  <detectors>
+
+    <detector name="EcalBarrel" type="SEcal05_Barrel" id="ILDDetID_ECAL" readout="EcalBarrelCollection" vis="BlueVis" >
+
+      <comment>EM Calorimeter Barrel</comment>
+
+      <envelope vis="ILD_ECALVis">
+        <shape type="PolyhedraRegular" numsides="Ecal_symmetry"  rmin="Ecal_inner_radius - env_safety"
+               rmax="Ecal_outer_radius + env_safety" dz="2.*Ecal_half_length + env_safety"  material = "Air" vis="Invisible" />
+        <rotation x="0*deg" y="0*deg" z="90*deg-180*deg/Ecal_symmetry"/>
+      </envelope>
+
+      <type_flags type=" DetType_CALORIMETER + DetType_BARREL + DetType_ELECTROMAGNETIC " />
+
+
+      <dimensions numsides="Ecal_symmetry" rmin="Ecal_inner_radius" rmax="Ecal_outer_radius" z="Ecal_half_length" />
+      <staves  material = "G4_W"  vis="BlueVis"/>
+
+
+      <!--  select which subsegmentation will be used to fill the DDRec:LayeredCalorimeterData cell dimensions -->
+      <subsegmentation key="slice" value="3 9"/>
+
+      <layer repeat="Ecal_nlayers1/2" vis="SeeThrough" >
+	<slice material = "G4_Al"          thickness = "Ecal_Slab_shielding"                 vis="Invisible" />
+	<slice material = "G4_Cu"          thickness = "Ecal_Slab_copper_thickness"          vis="Invisible" />
+        <slice material = "G4_POLYSTYRENE" thickness = "Ecal_Sc_thickness" sensitive = "yes" vis="CyanVis"   />
+        <slice material = "Si"             thickness = "Ecal_Si_thickness" sensitive = "yes" vis="Invisible" />
+        <slice material = "GroundOrHVMix"  thickness = "Ecal_Slab_ground_thickness"          vis="Invisible" />
+        <slice material = "CarbonFiber"    thickness = "Ecal_fiber_thickness_slabAbs"        vis="Invisible" />
+        <slice material = "G4_W"           thickness = "Ecal_radiator_layers_set1_thickness" vis="BlueVis"   radiator="yes"/>
+        <slice material = "CarbonFiber"    thickness = "Ecal_fiber_thickness_slabAbs"        vis="Invisible" />
+        <slice material = "GroundOrHVMix"  thickness = "Ecal_Slab_ground_thickness"          vis="Invisible" />
+        <slice material = "Si"             thickness = "Ecal_Si_thickness" sensitive = "yes" vis="Invisible" />
+        <slice material = "G4_POLYSTYRENE" thickness = "Ecal_Sc_thickness" sensitive = "yes" vis="CyanVis"   />
+	<slice material = "G4_Cu"          thickness = "Ecal_Slab_copper_thickness"          vis="Invisible" />
+	<slice material = "G4_Al"          thickness = "Ecal_Slab_shielding"                 vis="Invisible" />
+      </layer>
+
+      <layer repeat="(Ecal_nlayers2+1)/2" vis="SeeThrough">
+	<slice material = "G4_Al"          thickness = "Ecal_Slab_shielding"                 vis="Invisible" />
+	<slice material = "G4_Cu"          thickness = "Ecal_Slab_copper_thickness"          vis="Invisible" />
+        <slice material = "G4_POLYSTYRENE" thickness = "Ecal_Sc_thickness" sensitive = "yes" vis="CyanVis"   />
+        <slice material = "Si"             thickness = "Ecal_Si_thickness" sensitive = "yes" vis="Invisible" />
+        <slice material = "GroundOrHVMix"  thickness = "Ecal_Slab_ground_thickness"          vis="Invisible" />
+        <slice material = "CarbonFiber"    thickness = "Ecal_fiber_thickness_slabAbs"        vis="Invisible" />
+        <slice material = "G4_W"           thickness = "Ecal_radiator_layers_set2_thickness" vis="BlueVis"   radiator="yes"/>
+        <slice material = "CarbonFiber"    thickness = "Ecal_fiber_thickness_slabAbs"        vis="Invisible" />
+        <slice material = "GroundOrHVMix"  thickness = "Ecal_Slab_ground_thickness"          vis="Invisible" />
+        <slice material = "Si"             thickness = "Ecal_Si_thickness" sensitive = "yes" vis="Invisible" />
+        <slice material = "G4_POLYSTYRENE" thickness = "Ecal_Sc_thickness" sensitive = "yes" vis="CyanVis"   />
+	<slice material = "G4_Cu"          thickness = "Ecal_Slab_copper_thickness"          vis="Invisible" />
+	<slice material = "G4_Al"          thickness = "Ecal_Slab_shielding"                 vis="Invisible" />
+      </layer>
+    </detector>
+
+  </detectors>
+
+<readouts>
+  <readout name="EcalBarrelCollection">
+    <segmentation   type="MultiSegmentation"  key="slice">
+      <segmentation name="SiGrid_even" type="MegatileLayerGridXY"    key_value="3" common_nCellsX="16" common_nCellsY="16"/>
+      <segmentation name="SiGrid_odd"  type="MegatileLayerGridXY"    key_value="9" common_nCellsX="16" common_nCellsY="16" />
+
+      <segmentation name="ScGrid_even" type="MegatileLayerGridXY"    key_value="2"  common_nCellsX="2" common_nCellsY="16" />
+      <segmentation name="ScGrid_odd"  type="MegatileLayerGridXY"    key_value="10" common_nCellsX="16" common_nCellsY="2" />
+    </segmentation>
+
+    <hits_collections>
+      <hits_collection name="ECalBarrelSiHitsEven" key="slice" key_value="3" />
+      <hits_collection name="ECalBarrelSiHitsOdd"  key="slice" key_value="9" />
+
+      <hits_collection name="ECalBarrelScHitsEven" key="slice" key_value="2" />
+      <hits_collection name="ECalBarrelScHitsOdd"  key="slice" key_value="10" />
+
+    </hits_collections>
+    <!-- id>system:5,module:3,stave:4,tower:5,layer:6,slice:4,wafer:6,cellX:32:-16,cellY:-16</id -->
+    <id>system:5,module:3,stave:4,tower:3,layer:6,wafer:6,slice:4,cellX:32:-16,cellY:-16</id>   <!-- hmm, need to sort this out! -->
+  </readout>
+</readouts>
+
+  <plugins>
+    <plugin name="DD4hep_CaloFaceBarrelSurfacePlugin">
+      <argument value="EcalBarrel"/>
+      <argument value="length=2.*Ecal_half_length"    />
+      <argument value="radius=Ecal_inner_radius"  />
+      <argument value="phi0=0"    />
+      <argument value="symmetry=Ecal_symmetry"/>
+      <argument value="systemID=ILDDetID_ECAL"/>
+      <comment> <argument value="encoding=system:5,side:-2,layer:9,module:8,sensor:8"/> </comment>
+    </plugin>
+  </plugins>
+  
+
+</lccdd>

--- a/ILD/compact/ILD_common_v02/SEcal05_hybrid_Endcaps.xml
+++ b/ILD/compact/ILD_common_v02/SEcal05_hybrid_Endcaps.xml
@@ -1,0 +1,101 @@
+<lccdd>
+  <detectors>
+
+    <detector name="EcalEndcap" type="SEcal05_Endcaps" id="ILDDetID_ECAL_ENDCAP" readout="EcalEndcapsCollection" vis="BlueVis" >
+      <comment>EM Calorimeter Endcaps</comment>
+
+      <envelope vis="ILD_ECALVis">
+        <shape type="BooleanShape" operation="Subtraction" material="Air">
+          <shape type="BooleanShape" operation="Subtraction" material="Air">
+            <shape type="PolyhedraRegular"  numsides="EcalEndcap_symmetry" rmin="0"
+                   rmax="EcalEndcap_outer_radius + env_safety" dz="2.0*EcalEndcap_max_z + env_safety"/>
+            <shape type="PolyhedraRegular"  numsides="EcalEndcap_symmetry" rmin="0"
+                   rmax="EcalEndcap_outer_radius + 2.*env_safety" dz="2.0*EcalEndcap_min_z - env_safety"/>
+          </shape>
+          <shape type="Box" dx="EcalEndcap_inner_radius - env_safety"
+                 dy="EcalEndcap_inner_radius - env_safety" dz="(EcalEndcap_max_z + env_safety )"/>
+          <rotation x="0*deg" y="0*deg" z="-180*deg/EcalEndcap_symmetry"/>
+        </shape>
+        <rotation x="0*deg" y="0*deg" z="180*deg/EcalEndcap_symmetry"/>
+      </envelope>
+
+      <type_flags type=" DetType_CALORIMETER + DetType_ENDCAP + DetType_ELECTROMAGNETIC " />
+
+      <staves  material = "G4_W"  vis="BlueVis"/>
+
+      <!--  select which subsegmentation will be used to fill the DDRec:LayeredCalorimeterData cell dimensions -->
+      <subsegmentation key="slice" value="3 9"/>
+
+      <layer repeat="Ecal_nlayers1/2" vis="SeeThrough" >
+	<slice material = "G4_Al"          thickness = "Ecal_Slab_shielding"                 vis="Invisible" />
+	<slice material = "G4_Cu"          thickness = "Ecal_Slab_copper_thickness"          vis="Invisible" />
+        <slice material = "G4_POLYSTYRENE" thickness = "Ecal_Sc_thickness" sensitive = "yes" vis="CyanVis"   />
+        <slice material = "Si"             thickness = "Ecal_Si_thickness" sensitive = "yes" vis="Invisible" />
+        <slice material = "GroundOrHVMix"  thickness = "Ecal_Slab_ground_thickness"          vis="Invisible" />
+        <slice material = "CarbonFiber"    thickness = "Ecal_fiber_thickness_slabAbs"        vis="Invisible" />
+        <slice material = "G4_W"           thickness = "Ecal_radiator_layers_set1_thickness" vis="BlueVis"   radiator="yes"/>
+        <slice material = "CarbonFiber"    thickness = "Ecal_fiber_thickness_slabAbs"        vis="Invisible" />
+        <slice material = "GroundOrHVMix"  thickness = "Ecal_Slab_ground_thickness"          vis="Invisible" />
+        <slice material = "Si"             thickness = "Ecal_Si_thickness" sensitive = "yes" vis="Invisible" />
+        <slice material = "G4_POLYSTYRENE" thickness = "Ecal_Sc_thickness" sensitive = "yes" vis="CyanVis"   />
+	<slice material = "G4_Cu"          thickness = "Ecal_Slab_copper_thickness"          vis="Invisible" />
+	<slice material = "G4_Al"          thickness = "Ecal_Slab_shielding"                 vis="Invisible" />
+      </layer>
+
+      <layer repeat="(Ecal_nlayers2+1)/2" vis="SeeThrough">
+	<slice material = "G4_Al"          thickness = "Ecal_Slab_shielding"                 vis="Invisible" />
+	<slice material = "G4_Cu"          thickness = "Ecal_Slab_copper_thickness"          vis="Invisible" />
+        <slice material = "G4_POLYSTYRENE" thickness = "Ecal_Sc_thickness" sensitive = "yes" vis="CyanVis"   />
+        <slice material = "Si"             thickness = "Ecal_Si_thickness" sensitive = "yes" vis="Invisible" />
+        <slice material = "GroundOrHVMix"  thickness = "Ecal_Slab_ground_thickness"          vis="Invisible" />
+        <slice material = "CarbonFiber"    thickness = "Ecal_fiber_thickness_slabAbs"        vis="Invisible" />
+        <slice material = "G4_W"           thickness = "Ecal_radiator_layers_set2_thickness" vis="BlueVis"   radiator="yes"/>
+        <slice material = "CarbonFiber"    thickness = "Ecal_fiber_thickness_slabAbs"        vis="Invisible" />
+        <slice material = "GroundOrHVMix"  thickness = "Ecal_Slab_ground_thickness"          vis="Invisible" />
+        <slice material = "Si"             thickness = "Ecal_Si_thickness" sensitive = "yes" vis="Invisible" />
+        <slice material = "G4_POLYSTYRENE" thickness = "Ecal_Sc_thickness" sensitive = "yes" vis="CyanVis"   />
+	<slice material = "G4_Cu"          thickness = "Ecal_Slab_copper_thickness"          vis="Invisible" />
+	<slice material = "G4_Al"          thickness = "Ecal_Slab_shielding"                 vis="Invisible" />
+      </layer>
+    </detector>
+
+  </detectors>
+
+<readouts>
+  <readout name="EcalEndcapsCollection">
+    <segmentation   type="MultiSegmentation"  key="slice">
+      <segmentation name="SiGrid_even" type="MegatileLayerGridXY"    key_value="3" common_nCellsX="16" common_nCellsY="16"/>
+      <segmentation name="SiGrid_odd"  type="MegatileLayerGridXY"    key_value="9" common_nCellsX="16" common_nCellsY="16" />
+
+      <segmentation name="ScGrid_even" type="MegatileLayerGridXY"    key_value="2"  common_nCellsX="2" common_nCellsY="16" />
+      <segmentation name="ScGrid_odd"  type="MegatileLayerGridXY"    key_value="10" common_nCellsX="16" common_nCellsY="2" />
+    </segmentation>
+
+    <hits_collections>
+      <hits_collection name="ECalEndcapSiHitsEven" key="slice" key_value="3" />
+      <hits_collection name="ECalEndcapSiHitsOdd"  key="slice" key_value="9" />
+
+      <hits_collection name="ECalEndcapScHitsEven" key="slice" key_value="2" />
+      <hits_collection name="ECalEndcapScHitsOdd"  key="slice" key_value="10" />
+
+    </hits_collections>
+    <!-- id>system:5,module:3,stave:4,tower:5,layer:6,slice:4,wafer:6,cellX:32:-16,cellY:-16</id -->
+    <id>system:5,module:3,stave:4,tower:3,layer:6,wafer:6,slice:4,cellX:32:-16,cellY:-16</id>   <!-- hmm, need to sort this out! -->
+  </readout>
+</readouts>
+
+
+  <plugins>
+    <plugin name="DD4hep_CaloFaceEndcapSurfacePlugin">
+      <argument value="EcalEndcap"/>
+      <argument value="zpos=EcalEndcap_min_z"    />
+      <argument value="radius=EcalEndcap_outer_radius"  />
+      <argument value="phi0=0"    />
+      <argument value="symmetry=EcalEndcap_symmetry"/>
+      <argument value="systemID=ILDDetID_ECAL_ENDCAP"/>
+      <comment> <argument value="encoding=system:5,side:-2,layer:9,module:8,sensor:8"/> </comment>
+    </plugin>
+  </plugins>
+
+  
+</lccdd>

--- a/ILD/compact/ILD_common_v02/ecal_defs.xml
+++ b/ILD/compact/ILD_common_v02/ecal_defs.xml
@@ -38,8 +38,10 @@
   <constant name="Ecal_layer_pattern" type="string" value="0"/>
   <constant name="Ecal_end_of_slab_strategy" value="1"/>
   <constant name="Ecal_cells_across_megatile" value="18"/>
-  <constant name="Ecal_strips_across_megatile" value="1"/>
-  <constant name="Ecal_strips_along_megatile" value="1"/>
+
+  <constant name="Ecal_strips_across_megatile" value="18"/>
+  <constant name="Ecal_strips_along_megatile" value="4"/>
+
   <constant name="Ecal_Endcap_Preshower" value="0"/>
 
   <!-- constant name="Ecal_cables_gap" value="100.*mm"/ -->
@@ -50,8 +52,10 @@
   <!-- needed only for ecal ring driver... -->
   <constant name="Ecal_cells_size" value="5.*mm"/>
   <constant name="Ecal_Sc_reflector_thickness" value="0.057*mm"/>
-  <constant name="Ecal_Sc_thickness" value="2.0*mm"/>
   <constant name="Ecal_Slab_Sc_PCB_thickness" value="0.8*mm"/>
+
+  <!-- for hybrid, replace asic + pcb + air gaps with sc -->
+  <constant name="Ecal_Sc_thickness" value="Ecal_Slab_ASIC_thickness+Ecal_Slab_PCB_thickness+2*Ecal_Slab_glue_gap+Ecal_Alveolus_Air_Gap/2."/>
 
 </define>
 

--- a/ILD/compact/ILD_common_v02/hcal_defs.xml
+++ b/ILD/compact/ILD_common_v02/hcal_defs.xml
@@ -73,8 +73,8 @@
   <constant name="AHCal_cell_size" value="3.0*cm"/>
   <constant name="SDHCal_cell_size" value="1.0*cm"/>
   <!-- barrel and endcvap constructors use the slices in reversed order ! -->
-  <constant name="Hcal_readout_segmentation_slice_barrel" value="4"/>
-  <constant name="Hcal_readout_segmentation_slice_endcap" value="0"/>
+  <constant name="Hcal_readout_segmentation_slice_barrel" value="1"/>
+  <constant name="Hcal_readout_segmentation_slice_endcap" value="3"/>
 
 
 </define>

--- a/ILD/compact/ILD_l4_v02/ILD_l4_v02.xml
+++ b/ILD/compact/ILD_l4_v02/ILD_l4_v02.xml
@@ -32,15 +32,6 @@
     <include ref="../ILD_common_v02/services_defs.xml"/>
     <include ref="${DD4hepINSTALL}/DDDetectors/compact/detector_types.xml"/>
 
-    <!--
-	define the sensitive readout used for the reconstruction:
-	scint hcal: ( barrel==1 && encap==3)
-	sd hcal   : ( barrel==3 && encap==1)
-	( barrel and endcap constructors use the slices in reversed order ! )
-    -->
-    <constant name="Hcal_readout_segmentation_slice_barrel" value="1"/>
-    <constant name="Hcal_readout_segmentation_slice_endcap" value="3"/>
-
   </define>
 
   <limits>

--- a/ILD/compact/ILD_l5_v02/ILD_l5_v02.xml
+++ b/ILD/compact/ILD_l5_v02/ILD_l5_v02.xml
@@ -2,7 +2,7 @@
        xmlns:xs="http://www.w3.org/2001/XMLSchema"
        xs:noNamespaceSchemaLocation="http://www.lcsim.org/schemas/compact/1.0/compact.xsd">
 
-  <info name="ILD_l4_v02"
+  <info name="ILD_l5_v02"
         title="ILD multi-technology model used for the optimisation"
         author="F. Gaede, S.Lu, D.Jeans"
         url="http://ilcsoft.desy.de"

--- a/ILD/compact/ILD_l5_v02/ILD_l5_v02.xml
+++ b/ILD/compact/ILD_l5_v02/ILD_l5_v02.xml
@@ -1,0 +1,112 @@
+<lccdd xmlns:compact="http://www.lcsim.org/schemas/compact/1.0"
+       xmlns:xs="http://www.w3.org/2001/XMLSchema"
+       xs:noNamespaceSchemaLocation="http://www.lcsim.org/schemas/compact/1.0/compact.xsd">
+
+  <info name="ILD_l4_v02"
+        title="ILD multi-technology model used for the optimisation"
+        author="F. Gaede, S.Lu, D.Jeans"
+        url="http://ilcsoft.desy.de"
+        status="experimental"
+        version="v02">
+    <comment>ILD Mokka model used for the DBD - ported to DD4hep </comment>
+  </info>
+
+  <includes>
+    <gdmlFile  ref="../ILD_common_v02/elements.xml"/>
+    <gdmlFile  ref="../ILD_common_v02/materials.xml"/>
+  </includes>
+
+  <define>
+
+    <include ref="top_defs_ILD_l5_v02.xml"/>
+    <include ref="../ILD_common_v02/top_defs_common_v02.xml"/>
+    <include ref="../ILD_common_v02/basic_defs.xml"/>
+    <include ref="../ILD_common_v02/envelope_defs.xml"/>
+    <include ref="../ILD_common_v02/tube_defs.xml"/>
+    <include ref="../ILD_common_v02/misc_defs.xml"/>
+    <include ref="../ILD_common_v02/tracker_defs.xml"/>
+    <include ref="../ILD_common_v02/fcal_defs.xml"/>
+    <include ref="../ILD_common_v02/ecal_defs.xml"/>
+    <include ref="../ILD_common_v02/hcal_defs.xml"/>
+    <include ref="../ILD_common_v02/yoke_defs.xml"/>
+    <include ref="../ILD_common_v02/services_defs.xml"/>
+    <include ref="${DD4hepINSTALL}/DDDetectors/compact/detector_types.xml"/>
+
+    <!--
+	define the sensitive readout used for the reconstruction:
+	scint hcal: ( barrel==1 && encap==3)
+	sd hcal   : ( barrel==3 && encap==1)
+	( barrel and endcap constructors use the slices in reversed order ! )
+    -->
+<!--
+    <constant name="Hcal_readout_segmentation_slice_barrel" value="1"/>
+    <constant name="Hcal_readout_segmentation_slice_endcap" value="3"/>
+-->
+
+  </define>
+
+  <limits>
+    <limitset name="cal_limits">
+      <limit name="step_length_max" particles="*" value="5.0" unit="mm" />
+    </limitset>
+    <limitset name="TPC_limits">
+      <limit name="step_length_max" particles="*" value="10.0" unit="mm" />
+    </limitset>
+    <limitset name="Tracker_limits">
+      <limit name="step_length_max" particles="*" value="5.0" unit="mm" />
+    </limitset>
+  </limits>
+
+  <include ref="../ILD_common_v02/display.xml"/>
+
+  <comment>Trackers</comment>
+  <include ref="../ILD_common_v02/Beampipe_o1_v01_01.xml"/>
+  <include ref="../ILD_common_v02/vxd07.xml"/>
+  <include ref="../ILD_common_v02/ftd_simple_staggered_02.xml"/>
+  <include ref="../ILD_common_v02/sit_simple_pixel_sensors_01.xml"/>
+  <include ref="../ILD_common_v02/tpc10_01.xml"/>
+  <include ref="../ILD_common_v02/set_simple_planar_sensors_01.xml"/>  
+
+  <comment>Calorimeters</comment>
+  <include ref="../ILD_common_v02/SEcal05_hybrid_Barrel.xml"/>
+  <include ref="../ILD_common_v02/SEcal05_hybrid_Endcaps.xml"/>
+  <include ref="../ILD_common_v02/SEcal05_siw_ECRing.xml"/>
+  <include ref="../ILD_common_v02/SHcalSc04_Barrel_v04.xml"/>
+  <include ref="../ILD_common_v02/SHcalSc04_Endcaps_v01_LARGE.xml"/>
+  <include ref="../ILD_common_v02/SHcalSc04_EndcapRing_v01.xml"/>
+  <include ref="../ILD_common_v02/Yoke05_Barrel.xml"/>
+  <include ref="../ILD_common_v02/Yoke05_Endcaps.xml"/>
+  <include ref="../ILD_common_v02/LumiCal.xml"/> 
+  <include ref="../ILD_common_v02/LHCal01.xml"/>
+  <include ref="../ILD_common_v02/BeamCal08.xml"/>
+  <include ref="../ILD_common_v02/coil03.xml"/>
+  <include ref="../ILD_common_v02/SServices00.xml"/>
+
+  <plugins>
+    <plugin name="DD4hepVolumeManager"/>
+    <plugin name="InstallSurfaceManager"/>
+  </plugins>
+
+  <fields>
+    <field type="solenoid" name="GlobalSolenoid" inner_field="Field_nominal_value"
+           outer_field="outerField_nominal_value" zmax="Coil_half_length"
+           inner_radius="Coil_inner_radius"
+           outer_radius="world_side" />
+
+    <!-- <field name="DetectorMap" type="FieldBrBz" -->
+         <!--        filename="${lcgeo_DIR}/fieldmaps/ILDMap_KB_20150204_BRhoZ.root" -->
+         <!--        tree="fieldmap:rho:z:Brho:Bz" -->
+         <!--        rScale = "1.0" -->
+         <!--        zScale = "1.0" -->
+         <!--        bScale = "3.5/4.12841" -->
+         <!--        rhoMin = "5*mm" -->
+         <!--        zMin = "5*mm" -->
+         <!--        rhoMax = "7005*mm" -->
+         <!--        zMax = "7005*mm" -->
+         <!--        nRho = "701" -->
+         <!--        nZ = "701" -->
+         <!--        > -->
+         <!-- </field> -->
+
+  </fields>
+</lccdd>

--- a/ILD/compact/ILD_l5_v02/top_defs_ILD_l5_v02.xml
+++ b/ILD/compact/ILD_l5_v02/top_defs_ILD_l5_v02.xml
@@ -1,0 +1,12 @@
+<define>
+
+<comment> 
+all hardcoded overall dimensions which differ between large and small models
+</comment>
+
+  <constant name="Field_nominal_value" value="3.5*tesla"/>
+  <constant name="top_TPC_outer_radius"    value="1769.8*mm"/>
+  <constant name="Ecal_endcap_extra_size" value="67.84*mm"/>
+  <constant name="Ecal_endcap_number_of_towers" type="string" value="3 3 3"/>
+
+</define>

--- a/ILD/compact/ILD_s4_v02/ILD_s4_v02.xml
+++ b/ILD/compact/ILD_s4_v02/ILD_s4_v02.xml
@@ -32,15 +32,6 @@
     <include ref="../ILD_common_v02/services_defs.xml"/>
     <include ref="${DD4hepINSTALL}/DDDetectors/compact/detector_types.xml"/>
 
-    <!--
-	define the sensitive readout used for the reconstruction:
-	scint hcal: ( barrel==1 && encap==3)
-	sd hcal   : ( barrel==3 && encap==1)
-	( barrel and endcap constructors use the slices in reversed order ! )
-    -->
-    <constant name="Hcal_readout_segmentation_slice_barrel" value="1"/>
-    <constant name="Hcal_readout_segmentation_slice_endcap" value="3"/>
-
   </define>
 
   <limits>

--- a/ILD/compact/ILD_s5_v02/ILD_s5_v02.xml
+++ b/ILD/compact/ILD_s5_v02/ILD_s5_v02.xml
@@ -18,7 +18,7 @@
 
   <define>
 
-    <include ref="top_defs_ILD_s4_v02.xml"/>
+    <include ref="top_defs_ILD_s5_v02.xml"/>
     <include ref="../ILD_common_v02/top_defs_common_v02.xml"/>
     <include ref="../ILD_common_v02/basic_defs.xml"/>
     <include ref="../ILD_common_v02/envelope_defs.xml"/>

--- a/ILD/compact/ILD_s5_v02/ILD_s5_v02.xml
+++ b/ILD/compact/ILD_s5_v02/ILD_s5_v02.xml
@@ -1,0 +1,101 @@
+<lccdd xmlns:compact="http://www.lcsim.org/schemas/compact/1.0"
+       xmlns:xs="http://www.w3.org/2001/XMLSchema"
+       xs:noNamespaceSchemaLocation="http://www.lcsim.org/schemas/compact/1.0/compact.xsd">
+
+  <info name="ILD_s5_v02"
+        title="ILD multi-technology model used for the optimisation"
+        author="F. Gaede, S.Lu, D.Jeans"
+        url="http://ilcsoft.desy.de"
+        status="experimental"
+        version="v02">
+    <comment>ILD Mokka model used for the DBD - ported to DD4hep </comment>
+  </info>
+
+  <includes>
+    <gdmlFile  ref="../ILD_common_v02/elements.xml"/>
+    <gdmlFile  ref="../ILD_common_v02/materials.xml"/>
+  </includes>
+
+  <define>
+
+    <include ref="top_defs_ILD_s4_v02.xml"/>
+    <include ref="../ILD_common_v02/top_defs_common_v02.xml"/>
+    <include ref="../ILD_common_v02/basic_defs.xml"/>
+    <include ref="../ILD_common_v02/envelope_defs.xml"/>
+    <include ref="../ILD_common_v02/tube_defs.xml"/>
+    <include ref="../ILD_common_v02/misc_defs.xml"/>
+    <include ref="../ILD_common_v02/tracker_defs.xml"/>
+    <include ref="../ILD_common_v02/fcal_defs.xml"/>
+    <include ref="../ILD_common_v02/ecal_defs.xml"/>
+    <include ref="../ILD_common_v02/hcal_defs.xml"/>
+    <include ref="../ILD_common_v02/yoke_defs.xml"/>
+    <include ref="../ILD_common_v02/services_defs.xml"/>
+    <include ref="${DD4hepINSTALL}/DDDetectors/compact/detector_types.xml"/>
+
+  </define>
+
+  <limits>
+    <limitset name="cal_limits">
+      <limit name="step_length_max" particles="*" value="5.0" unit="mm" />
+    </limitset>
+    <limitset name="TPC_limits">
+      <limit name="step_length_max" particles="*" value="10.0" unit="mm" />
+    </limitset>
+    <limitset name="Tracker_limits">
+      <limit name="step_length_max" particles="*" value="5.0" unit="mm" />
+    </limitset>
+  </limits>
+
+  <include ref="../ILD_common_v02/display.xml"/>
+
+  <comment>Trackers</comment>
+  <include ref="../ILD_common_v02/Beampipe_o1_v01_01.xml"/>
+  <include ref="../ILD_common_v02/vxd07.xml"/>
+  <include ref="../ILD_common_v02/ftd_simple_staggered_02.xml"/>
+  <include ref="../ILD_common_v02/sit_simple_pixel_sensors_01.xml"/>
+  <include ref="../ILD_common_v02/tpc10_01.xml"/>
+  <include ref="../ILD_common_v02/set_simple_planar_sensors_01.xml"/>  
+
+  <comment>Calorimeters</comment>
+  <include ref="../ILD_common_v02/SEcal05_hybrid_Barrel.xml"/>
+  <include ref="../ILD_common_v02/SEcal05_hybrid_Endcaps.xml"/>
+  <include ref="../ILD_common_v02/SEcal05_siw_ECRing.xml"/>
+  <include ref="../ILD_common_v02/SHcalSc04_Barrel_v04.xml"/>
+  <include ref="../ILD_common_v02/SHcalSc04_Endcaps_v01_SMALL.xml"/>
+  <include ref="../ILD_common_v02/SHcalSc04_EndcapRing_v01.xml"/>
+  <include ref="../ILD_common_v02/Yoke05_Barrel.xml"/>
+  <include ref="../ILD_common_v02/Yoke05_Endcaps.xml"/>
+  <include ref="../ILD_common_v02/LumiCal.xml"/> 
+  <include ref="../ILD_common_v02/LHCal01.xml"/>
+  <include ref="../ILD_common_v02/BeamCal08.xml"/>
+  <include ref="../ILD_common_v02/coil03.xml"/>
+  <include ref="../ILD_common_v02/SServices00.xml"/>
+
+  <plugins>
+    <plugin name="DD4hepVolumeManager"/>
+    <plugin name="InstallSurfaceManager"/>
+  </plugins>
+
+  <fields>
+    <field type="solenoid" name="GlobalSolenoid" inner_field="Field_nominal_value"
+           outer_field="outerField_nominal_value" zmax="Coil_half_length"
+           inner_radius="Coil_inner_radius"
+           outer_radius="world_side" />
+
+    <!-- <field name="DetectorMap" type="FieldBrBz" -->
+         <!--        filename="${lcgeo_DIR}/fieldmaps/ILDMap_KB_20150204_BRhoZ.root" -->
+         <!--        tree="fieldmap:rho:z:Brho:Bz" -->
+         <!--        rScale = "1.0" -->
+         <!--        zScale = "1.0" -->
+         <!--        bScale = "3.5/4.12841" -->
+         <!--        rhoMin = "5*mm" -->
+         <!--        zMin = "5*mm" -->
+         <!--        rhoMax = "7005*mm" -->
+         <!--        zMax = "7005*mm" -->
+         <!--        nRho = "701" -->
+         <!--        nZ = "701" -->
+         <!--        > -->
+         <!-- </field> -->
+
+  </fields>
+</lccdd>

--- a/ILD/compact/ILD_s5_v02/top_defs_ILD_s5_v02.xml
+++ b/ILD/compact/ILD_s5_v02/top_defs_ILD_s5_v02.xml
@@ -1,0 +1,12 @@
+<define>
+
+<comment> 
+all hardcoded overall dimensions which differ between large and small models
+</comment>
+
+  <constant name="Field_nominal_value" value="4.0*tesla"/>
+  <constant name="top_TPC_outer_radius"    value="1426.8*mm"/>
+  <constant name="Ecal_endcap_extra_size" value="32.92*mm"/>
+  <constant name="Ecal_endcap_number_of_towers" type="string" value="4 3"/>
+
+</define>

--- a/detector/calorimeter/SEcal05_Helpers.h
+++ b/detector/calorimeter/SEcal05_Helpers.h
@@ -15,6 +15,7 @@
 #include "DDSegmentation/MegatileLayerGridXY.h"
 
 #include "DDSegmentation/WaferGridXY.h"
+#include "DDSegmentation/MultiSegmentation.h"
 
 #include <iostream>
 
@@ -241,6 +242,7 @@ class SEcal05_Helpers {
 			bool isFinal=false
 			);
 
+  const dd4hep::DDSegmentation::Segmentation* getSliceSegmentation( dd4hep::DDSegmentation::MultiSegmentation* multiSeg , int slice_number );
 
   dd4hep::Segmentation* _geomseg;
 


### PR DESCRIPTION
ILD_?5_v02 models require update to MegatileLayerGridXY class in DD4hep/segmentations (for which I have just made a pull request)

BEGINRELEASENOTES
- first implementation of ILD_?5_v02 models, which have a hybrid readout ECAL structure with both silicon and scintillator layers. Otherwise, should be indentical to the ILD_?4_v02 models.
- removed a duplicated definition of Hcal_readout_segmentation_slice_* (was in both ILD_*xml and hcal_defs.xml; now only in the latter). It gave correct results before, but was confusing.
ENDRELEASENOTES