### PR TITLE
fix inconsistency and duplication in HCAL multi-readout specification

### DIFF
--- a/ILD/compact/ILD_common_v02/hcal_defs.xml
+++ b/ILD/compact/ILD_common_v02/hcal_defs.xml
@@ -73,8 +73,8 @@
   <constant name="AHCal_cell_size" value="3.0*cm"/>
   <constant name="SDHCal_cell_size" value="1.0*cm"/>
   <!-- barrel and endcvap constructors use the slices in reversed order ! -->
-  <constant name="Hcal_readout_segmentation_slice_barrel" value="4"/>
-  <constant name="Hcal_readout_segmentation_slice_endcap" value="0"/>
+  <constant name="Hcal_readout_segmentation_slice_barrel" value="1"/>
+  <constant name="Hcal_readout_segmentation_slice_endcap" value="3"/>
 
 
 </define>

--- a/ILD/compact/ILD_l4_v02/ILD_l4_v02.xml
+++ b/ILD/compact/ILD_l4_v02/ILD_l4_v02.xml
@@ -32,15 +32,6 @@
     <include ref="../ILD_common_v02/services_defs.xml"/>
     <include ref="${DD4hepINSTALL}/DDDetectors/compact/detector_types.xml"/>
 
-    <!--
-	define the sensitive readout used for the reconstruction:
-	scint hcal: ( barrel==1 && encap==3)
-	sd hcal   : ( barrel==3 && encap==1)
-	( barrel and endcap constructors use the slices in reversed order ! )
-    -->
-    <constant name="Hcal_readout_segmentation_slice_barrel" value="1"/>
-    <constant name="Hcal_readout_segmentation_slice_endcap" value="3"/>
-
   </define>
 
   <limits>

--- a/ILD/compact/ILD_s4_v02/ILD_s4_v02.xml
+++ b/ILD/compact/ILD_s4_v02/ILD_s4_v02.xml
@@ -32,15 +32,6 @@
     <include ref="../ILD_common_v02/services_defs.xml"/>
     <include ref="${DD4hepINSTALL}/DDDetectors/compact/detector_types.xml"/>
 
-    <!--
-	define the sensitive readout used for the reconstruction:
-	scint hcal: ( barrel==1 && encap==3)
-	sd hcal   : ( barrel==3 && encap==1)
-	( barrel and endcap constructors use the slices in reversed order ! )
-    -->
-    <constant name="Hcal_readout_segmentation_slice_barrel" value="1"/>
-    <constant name="Hcal_readout_segmentation_slice_endcap" value="3"/>
-
   </define>
 
   <limits>


### PR DESCRIPTION
Hi @gaede 
This change does touch the existing l/s4 model code, but should not change it's behaviour.
It's to do with the hybrid HCAL only.
I leave it up to you if you want to accept it.
Cheers,
Daniel.

BEGINRELEASENOTES
- Hcal_readout_segmentation_slice_barrel/endcap paramters were specified in both the ILD_?v_v02.xml and hcal_defs.xml files, to inconsistent values. the values in ILD_?v_v02.xml were correct, and were used. The values in hcal_defs.xml were wrong, but were not used. 
I have corrected values in hcal_defs.xml, removed duplicate definitions in ILD_?v_v02.xml.
ENDRELEASENOTES