### PR TITLE
Update lcgeoTests for ILD to test ILD_l4/s4_v02.

### DIFF
--- a/lcgeoTests/CMakeLists.txt
+++ b/lcgeoTests/CMakeLists.txt
@@ -16,9 +16,14 @@ INSTALL(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/run_test_${PackageName}.sh
 
 #--------------------------------------------------
 # test(s) for ILD
-SET( test_name "test_ILD_l1_v01" )
+SET( test_name "test_ILD_l4_v02" )
 ADD_TEST( t_${test_name} "${CMAKE_INSTALL_PREFIX}/bin/run_test_${PackageName}.sh"
-  ddsim --compactFile=${CMAKE_SOURCE_DIR}/ILD/compact/ILD_l1_v01/ILD_l1_v01.xml --runType=batch -G -N=1 --outputFile=testILD.slcio )
+  ddsim --compactFile=${CMAKE_SOURCE_DIR}/ILD/compact/ILD_l4_v02/ILD_l4_v02.xml --runType=batch -G -N=1 --outputFile=testILD_l4_v02.slcio )
+SET_TESTS_PROPERTIES( t_${test_name} PROPERTIES FAIL_REGULAR_EXPRESSION  "Exception;EXCEPTION;ERROR;Error" )
+
+SET( test_name "test_ILD_s4_v02" )
+ADD_TEST( t_${test_name} "${CMAKE_INSTALL_PREFIX}/bin/run_test_${PackageName}.sh"
+  ddsim --compactFile=${CMAKE_SOURCE_DIR}/ILD/compact/ILD_s4_v02/ILD_s4_v02.xml --runType=batch -G -N=1 --outputFile=testILD_s4_v02.slcio )
 SET_TESTS_PROPERTIES( t_${test_name} PROPERTIES FAIL_REGULAR_EXPRESSION  "Exception;EXCEPTION;ERROR;Error" )
 
 #--------------------------------------------------


### PR DESCRIPTION

BEGINRELEASENOTES
- Update lcgeoTests for ILD.
  - ILD_l4/s4_v02 are the current optimisation models.
  - Remove test of ILD_l1_v01, and added tests for ILD_l4/s4_v02.

ENDRELEASENOTES