### PR TITLE
Remove gaps and overlaps that were not detected in CLIC_o3_v12

### DIFF
--- a/CLIC/compact/CLIC_o3_v12/InnerTracker_o2_v06_01.xml
+++ b/CLIC/compact/CLIC_o3_v12/InnerTracker_o2_v06_01.xml
@@ -5,9 +5,9 @@
         <constant name="InnerTracker_Barrel_radius_1" value="340*mm"/>
         <constant name="InnerTracker_Barrel_radius_2" value="554*mm"/>
 
-        <constant name="InnerTracker_Barrel_half_length_0" value="482*mm"/>
-        <constant name="InnerTracker_Barrel_half_length_1" value="482*mm"/>
-        <constant name="InnerTracker_Barrel_half_length_2" value="692*mm"/>
+        <constant name="InnerTracker_Barrel_half_length_0" value="481.6*mm"/>
+        <constant name="InnerTracker_Barrel_half_length_1" value="481.6*mm"/>
+        <constant name="InnerTracker_Barrel_half_length_2" value="692.3*mm"/>
 
         <constant name="InnerTracker_Endcap_z_0" value="524*mm"/>
         <constant name="InnerTracker_Endcap_z_1" value="808*mm"/>


### PR DESCRIPTION
Same as in outert racker iLCSoft/lcgeo#141
32 modules times 30.1 cm gives starting position of 481.6 mm instead of 482 mm
46 modules times 30.1 cm gives starting position of 692.3 mm instead of 692 mm

This means that there was an overlap in the third inner tracker layer that was not detector by the geant overlap check, even increasing resolution of the overlap check did not help.

BEGINRELEASENOTES
- Change starting position of inner tracker barrel to remove gaps and overlaps in CLIC_o3_v12

ENDRELEASENOTES