### PR TITLE
Fix ILD Hybird Hcal RPC Anode and Cathode FloatGlass order

### DIFF
--- a/ILD/compact/ILD_common_v02/SHcalSc04_Barrel_v04.xml
+++ b/ILD/compact/ILD_common_v02/SHcalSc04_Barrel_v04.xml
@@ -24,11 +24,11 @@
 
       <layer repeat="Hcal_nlayers" vis="SeeThrough">
 
-        <slice material="Air"      thickness="Hcal_chamber_thickness - ( HcalSD_glass_anode_thickness + HcalSD_sensitive_gas_gap + HcalSD_glass_cathode_thickness + Hcal_scintillator_thickness)" vis="Invisible" />
-        <slice material="G4_POLYSTYRENE" thickness = "Hcal_scintillator_thickness" sensitive = "yes"   limits="cal_limits"  vis="CyanVis"   />
         <slice material="FloatGlass" thickness="HcalSD_glass_anode_thickness" vis="Invisible"/>
         <slice material="RPCGAS2"    thickness="HcalSD_sensitive_gas_gap" sensitive="yes" limits="cal_limits" vis="YellowVis"/>
         <slice material="FloatGlass" thickness="HcalSD_glass_cathode_thickness" vis="Invisible"/>
+        <slice material="G4_POLYSTYRENE" thickness = "Hcal_scintillator_thickness" sensitive = "yes"   limits="cal_limits"  vis="CyanVis"   />
+        <slice material="Air"      thickness="Hcal_chamber_thickness - ( HcalSD_glass_anode_thickness + HcalSD_sensitive_gas_gap + HcalSD_glass_cathode_thickness + Hcal_scintillator_thickness)" vis="Invisible" />
       </layer>
     </detector>
   </detectors>

--- a/ILD/compact/ILD_common_v02/SHcalSc04_EndcapRing_v01.xml
+++ b/ILD/compact/ILD_common_v02/SHcalSc04_EndcapRing_v01.xml
@@ -29,9 +29,9 @@
       <subsegmentation key="slice" value="Hcal_readout_segmentation_slice_endcap"/>
 
       <layer vis="SeeThrough">
-        <slice material="FloatGlass" thickness="HcalSD_glass_cathode_thickness" vis="Invisible"/>
-        <slice material="RPCGAS2"    thickness="HcalSD_sensitive_gas_gap" sensitive="yes" limits="cal_limits" vis="YellowVis"/>
         <slice material="FloatGlass" thickness="HcalSD_glass_anode_thickness" vis="Invisible"/>
+        <slice material="RPCGAS2"    thickness="HcalSD_sensitive_gas_gap" sensitive="yes" limits="cal_limits" vis="YellowVis"/>
+        <slice material="FloatGlass" thickness="HcalSD_glass_cathode_thickness" vis="Invisible"/>
         <slice material="G4_POLYSTYRENE" thickness = "Hcal_scintillator_thickness" sensitive = "yes"   limits="cal_limits"  vis="CyanVis"   />
         <slice material="Air"      thickness="Hcal_chamber_thickness - ( HcalSD_glass_anode_thickness + HcalSD_sensitive_gas_gap + HcalSD_glass_cathode_thickness + Hcal_scintillator_thickness)" vis="Invisible" />
       </layer>

--- a/ILD/compact/ILD_common_v02/SHcalSc04_Endcaps_v01_LARGE.xml
+++ b/ILD/compact/ILD_common_v02/SHcalSc04_Endcaps_v01_LARGE.xml
@@ -43,9 +43,9 @@
       <subsegmentation key="slice" value="Hcal_readout_segmentation_slice_endcap"/>
 
       <layer repeat="Hcal_nlayers" vis="SeeThrough">
-        <slice material="FloatGlass" thickness="HcalSD_glass_cathode_thickness" vis="Invisible"/>
-        <slice material="RPCGAS2"    thickness="HcalSD_sensitive_gas_gap" sensitive="yes" limits="cal_limits" vis="YellowVis"/>
         <slice material="FloatGlass" thickness="HcalSD_glass_anode_thickness" vis="Invisible"/>
+        <slice material="RPCGAS2"    thickness="HcalSD_sensitive_gas_gap" sensitive="yes" limits="cal_limits" vis="YellowVis"/>
+        <slice material="FloatGlass" thickness="HcalSD_glass_cathode_thickness" vis="Invisible"/>
         <slice material="G4_POLYSTYRENE" thickness = "Hcal_scintillator_thickness" sensitive = "yes"   limits="cal_limits"  vis="CyanVis"   />
         <slice material="Air"      thickness="Hcal_chamber_thickness - ( HcalSD_glass_anode_thickness + HcalSD_sensitive_gas_gap + HcalSD_glass_cathode_thickness + Hcal_scintillator_thickness)" vis="Invisible" />
       </layer>

--- a/ILD/compact/ILD_common_v02/SHcalSc04_Endcaps_v01_SMALL.xml
+++ b/ILD/compact/ILD_common_v02/SHcalSc04_Endcaps_v01_SMALL.xml
@@ -41,9 +41,9 @@
       <subsegmentation key="slice" value="Hcal_readout_segmentation_slice_endcap"/>
 
       <layer repeat="Hcal_nlayers" vis="SeeThrough">
-        <slice material="FloatGlass" thickness="HcalSD_glass_cathode_thickness" vis="Invisible"/>
-        <slice material="RPCGAS2"    thickness="HcalSD_sensitive_gas_gap" sensitive="yes" limits="cal_limits" vis="YellowVis"/>
         <slice material="FloatGlass" thickness="HcalSD_glass_anode_thickness" vis="Invisible"/>
+        <slice material="RPCGAS2"    thickness="HcalSD_sensitive_gas_gap" sensitive="yes" limits="cal_limits" vis="YellowVis"/>
+        <slice material="FloatGlass" thickness="HcalSD_glass_cathode_thickness" vis="Invisible"/>
         <slice material="G4_POLYSTYRENE" thickness = "Hcal_scintillator_thickness" sensitive = "yes"   limits="cal_limits"  vis="CyanVis"   />
         <slice material="Air"      thickness="Hcal_chamber_thickness - ( HcalSD_glass_anode_thickness + HcalSD_sensitive_gas_gap + HcalSD_glass_cathode_thickness + Hcal_scintillator_thickness)" vis="Invisible" />
       </layer>

--- a/detector/calorimeter/SHcalSc04_Barrel_v04.cpp
+++ b/detector/calorimeter/SHcalSc04_Barrel_v04.cpp
@@ -532,7 +532,7 @@ static Ref_t create_detector(Detector& theDetector, xml_h element, SensitiveDete
       string layer_name      = det_name+_toString(layer_id,"_layer%d");
       
       // Create the slices (sublayers) within the Hcal Barrel Chamber.
-      double slice_pos_z = -(layer_thickness/2.);
+      double slice_pos_z = layer_thickness/2.;
       int slice_number = 0;
 
       for(xml_coll_t k(x_layer,_U(slice)); k; ++k)  {
@@ -542,7 +542,7 @@ static Ref_t create_detector(Detector& theDetector, xml_h element, SensitiveDete
 	Material slice_material  = theDetector.material(x_slice.materialStr());
 	DetElement slice(layer_name,_toString(slice_number,"slice%d"),x_det.id());
 	
-	slice_pos_z += slice_thickness/2.;
+	slice_pos_z -= slice_thickness/2.;
 	
 	// Slice volume & box
 	Volume slice_vol(slice_name,Box(x_length,z_width,slice_thickness/2.),slice_material);
@@ -593,7 +593,7 @@ static Ref_t create_detector(Detector& theDetector, xml_h element, SensitiveDete
 	
 	slice.setPlacement(slice_phv);
 	// Increment x position for next slice.
-	slice_pos_z += slice_thickness/2.;
+	slice_pos_z -= slice_thickness/2.;
 	// Increment slice number.
 	++slice_number;             
       }


### PR DESCRIPTION
BEGINRELEASENOTES
- Fix the ILD_l4/s4_v02 Hybird Hcal RPC Anode and Cathode FloatGlass place order.
  - For the Hybird Hcal Endcaps and EndcapRing, they have been fixed inside compact file.
    - "SHcalSc04_EndcapRing_v01.xml" for both ILD_l4_v02 and ILD_s4_v02
    - "SHcalSc04_Endcaps_v01_LARGE.xml" for ILD_l4_v02
    - "SHcalSc04_Endcaps_v01_SMALL.xml" for ILD_s4_v02
  - For the Hybird Hcal Barrel, they have been fixed in both the driver and compact file
    - "SHcalSc04_Barrel_v04.xml" for both ILD_l4_v02 and ILD_s4_v02.
    - "SHcalSc04_Barrel_v04.cpp" the slices place order has been fixed to start from IP.
 - All the compact files are inside the "ILD_common_v02" folder, which are used by ILD_l5/s5_v02, too.
    - So both ILD_l5_v02 and ILD_s5_v02 have the updeted Hybird Hcal, too.
ENDRELEASENOTES