### PR TITLE
Fix Hcal_readout_segmentation_slice_barrel for ILD_l4_v02.

### DIFF
--- a/ILD/compact/ILD_common_v02/hcal_defs.xml
+++ b/ILD/compact/ILD_common_v02/hcal_defs.xml
@@ -73,7 +73,7 @@
   <constant name="AHCal_cell_size" value="3.0*cm"/>
   <constant name="SDHCal_cell_size" value="1.0*cm"/>
   <!-- barrel and endcvap constructors use the slices in reversed order ! -->
-  <constant name="Hcal_readout_segmentation_slice_barrel" value="1"/>
+  <constant name="Hcal_readout_segmentation_slice_barrel" value="3"/>
   <constant name="Hcal_readout_segmentation_slice_endcap" value="3"/>
 
 


### PR DESCRIPTION

BEGINRELEASENOTES
- Fix ILD_l4_v02 target readout slice number for AHCAL.
  - after re-order the Hybird HCAL layers, we should also update Hcal_readout_segmentation_slice_barrel to "3" as "Hcal_readout_segmentation_slice_endcap" now.

ENDRELEASENOTES