### PR TITLE
 Fix ILD_l4_v02 Barrel MultiSegmentation slice number.

### DIFF
--- a/ILD/compact/ILD_common_v02/SHcalSc04_Barrel_v04.xml
+++ b/ILD/compact/ILD_common_v02/SHcalSc04_Barrel_v04.xml
@@ -23,7 +23,6 @@
       <subsegmentation key="slice" value="Hcal_readout_segmentation_slice_barrel"/>
 
       <layer repeat="Hcal_nlayers" vis="SeeThrough">
-
         <slice material="FloatGlass" thickness="HcalSD_glass_anode_thickness" vis="Invisible"/>
         <slice material="RPCGAS2"    thickness="HcalSD_sensitive_gas_gap" sensitive="yes" limits="cal_limits" vis="YellowVis"/>
         <slice material="FloatGlass" thickness="HcalSD_glass_cathode_thickness" vis="Invisible"/>
@@ -36,8 +35,8 @@
   <readouts>
     <readout name="HcalBarrelReadout">
       <segmentation   type="MultiSegmentation"  key="slice">
-        <segmentation name="RPCgrid" type="CartesianGridXY"    key_value="3"    grid_size_x="SDHCal_cell_size" grid_size_y="SDHCal_cell_size" />
-        <segmentation name="Scigrid"  type="TiledLayerGridXY"  key_value="1"  grid_size_x="3" grid_size_y="3.03248"/>
+        <segmentation name="RPCgrid" type="CartesianGridXY"   key_value="1"  grid_size_x="SDHCal_cell_size" grid_size_y="SDHCal_cell_size" />
+        <segmentation name="Scigrid" type="TiledLayerGridXY"  key_value="3"  grid_size_x="3" grid_size_y="3.03248"/>
       </segmentation>
       <hits_collections>
         <hits_collection name="HCalBarrelRPCHits"  key="slice" key_value="3"/>


### PR DESCRIPTION


BEGINRELEASENOTES
-  Fix ILD_l4_v02 Barrel MultiSegmentation slice number for different technology.
   - After change the order of slice, the segmentation slice should be updated too.
   - ILD_s4_v02 use the same compact file, should be fine.

ENDRELEASENOTES