### PR TITLE
 For backward consistency, update all ILD AHCAL Barrel slice placement.

### DIFF
--- a/ILD/compact/ILD_common_v01/SHcalSc04_Barrel_v01.xml
+++ b/ILD/compact/ILD_common_v01/SHcalSc04_Barrel_v01.xml
@@ -18,9 +18,9 @@
     <!-- The layer structure reference on page 10 in the following paper-->
     <!-- https://bib-pubdb1.desy.de/record/139781/files/LC-TOOL-2012-082.pdf -->
     <layer repeat="Hcal_nlayers" vis="SeeThrough">
-        <slice material = "Air"            thickness = "Hcal_fiber_gap"                                 vis="YellowVis" />
-        <slice material = "Cu"             thickness = "Hcal_Cu_thickness"                              vis="Invisible" />
-        <slice material = "PCB"            thickness = "Hcal_PCB_thickness"                             vis="Invisible" />
         <slice material = "G4_POLYSTYRENE" thickness = "Hcal_scintillator_thickness" sensitive = "yes"  vis="CyanVis"   />
+        <slice material = "PCB"            thickness = "Hcal_PCB_thickness"                             vis="Invisible" />
+        <slice material = "Cu"             thickness = "Hcal_Cu_thickness"                              vis="Invisible" />
+        <slice material = "Air"            thickness = "Hcal_fiber_gap"                                 vis="YellowVis" />
     </layer>
 </detector>

--- a/ILD/compact/ILD_common_v02/SHcalSc04_Barrel_v01.xml
+++ b/ILD/compact/ILD_common_v02/SHcalSc04_Barrel_v01.xml
@@ -21,10 +21,10 @@
       <!-- The layer structure reference on page 10 in the following paper-->
       <!-- https://bib-pubdb1.desy.de/record/139781/files/LC-TOOL-2012-082.pdf -->
       <layer repeat="Hcal_nlayers" vis="SeeThrough">
-        <slice material = "Air"            thickness = "Hcal_fiber_gap"                                 vis="YellowVis" />
-        <slice material = "Cu"             thickness = "Hcal_Cu_thickness"                              vis="Invisible" />
-        <slice material = "PCB"            thickness = "Hcal_PCB_thickness"                             vis="Invisible" />
         <slice material = "G4_POLYSTYRENE" thickness = "Hcal_scintillator_thickness" sensitive = "yes"  vis="CyanVis"   />
+        <slice material = "PCB"            thickness = "Hcal_PCB_thickness"                             vis="Invisible" />
+        <slice material = "Cu"             thickness = "Hcal_Cu_thickness"                              vis="Invisible" />
+        <slice material = "Air"            thickness = "Hcal_fiber_gap"                                 vis="YellowVis" />
       </layer>
     </detector>
   </detectors>

--- a/ILD/compact/ILD_l4_v01/SHcalSc04_Barrel_v04.xml
+++ b/ILD/compact/ILD_l4_v01/SHcalSc04_Barrel_v04.xml
@@ -20,11 +20,10 @@
     <subsegmentation key="slice" value="Hcal_readout_segmentation_slice_barrel"/>
 
     <layer repeat="Hcal_nlayers" vis="SeeThrough">
-
-        <slice material="Air"      thickness="Hcal_chamber_thickness - ( HcalSD_glass_anode_thickness + HcalSD_sensitive_gas_gap + HcalSD_glass_cathode_thickness + Hcal_scintillator_thickness)" vis="Invisible" />
-        <slice material="G4_POLYSTYRENE" thickness = "Hcal_scintillator_thickness" sensitive = "yes"   limits="cal_limits"  vis="CyanVis"   />
 	<slice material="FloatGlass" thickness="HcalSD_glass_anode_thickness" vis="Invisible"/>
 	<slice material="RPCGAS2"    thickness="HcalSD_sensitive_gas_gap" sensitive="yes" limits="cal_limits" vis="YellowVis"/>
 	<slice material="FloatGlass" thickness="HcalSD_glass_cathode_thickness" vis="Invisible"/>
+        <slice material="G4_POLYSTYRENE" thickness = "Hcal_scintillator_thickness" sensitive = "yes"   limits="cal_limits"  vis="CyanVis"   />
+        <slice material="Air"      thickness="Hcal_chamber_thickness - ( HcalSD_glass_anode_thickness + HcalSD_sensitive_gas_gap + HcalSD_glass_cathode_thickness + Hcal_scintillator_thickness)" vis="Invisible" />
     </layer>
 </detector>

--- a/ILD/compact/ILD_o1_v05/SHcalSc04_Barrel_v01.xml
+++ b/ILD/compact/ILD_o1_v05/SHcalSc04_Barrel_v01.xml
@@ -18,9 +18,9 @@
     <!-- The layer structure reference on page 10 in the following paper-->
     <!-- https://bib-pubdb1.desy.de/record/139781/files/LC-TOOL-2012-082.pdf -->
     <layer repeat="Hcal_nlayers" vis="SeeThrough">
-        <slice material = "Air"            thickness = "Hcal_fiber_gap"                                 vis="YellowVis" />
-        <slice material = "Cu"             thickness = "Hcal_Cu_thickness"                              vis="Invisible" />
-        <slice material = "PCB"            thickness = "Hcal_PCB_thickness"                             vis="Invisible" />
         <slice material = "G4_POLYSTYRENE" thickness = "Hcal_scintillator_thickness" sensitive = "yes"  vis="CyanVis"   />
+        <slice material = "PCB"            thickness = "Hcal_PCB_thickness"                             vis="Invisible" />
+        <slice material = "Cu"             thickness = "Hcal_Cu_thickness"                              vis="Invisible" />
+        <slice material = "Air"            thickness = "Hcal_fiber_gap"                                 vis="YellowVis" />
     </layer>
 </detector>

--- a/ILD/compact/ILD_o1_v05/SHcalSc04_Barrel_v02.xml
+++ b/ILD/compact/ILD_o1_v05/SHcalSc04_Barrel_v02.xml
@@ -17,10 +17,10 @@
     <!-- The layer structure reference on page 10 in the following paper-->
     <!-- https://bib-pubdb1.desy.de/record/139781/files/LC-TOOL-2012-082.pdf -->
     <layer repeat="Hcal_nlayers" vis="SeeThrough">
-        <slice material = "Air"            thickness = "Hcal_fiber_gap"                                 vis="YellowVis" />
-        <slice material = "Cu"             thickness = "Hcal_Cu_thickness"                              vis="Invisible" />
-        <slice material = "PCB"            thickness = "Hcal_PCB_thickness"                             vis="Invisible" />
-        <slice material = "G4_POLYSTYRENE" thickness = "Hcal_scintillator_thickness" sensitive = "yes"  vis="CyanVis"   />
         <slice material = "Steel235"       thickness = "Hcal_radiator_thickness"                        vis="BlueVis"   />
+        <slice material = "G4_POLYSTYRENE" thickness = "Hcal_scintillator_thickness" sensitive = "yes"  vis="CyanVis"   />
+        <slice material = "PCB"            thickness = "Hcal_PCB_thickness"                             vis="Invisible" />
+        <slice material = "Cu"             thickness = "Hcal_Cu_thickness"                              vis="Invisible" />
+        <slice material = "Air"            thickness = "Hcal_fiber_gap"                                 vis="YellowVis" />
     </layer>
 </detector>

--- a/ILD/compact/ILD_o1_v05/SHcalSc04_Barrel_v03.xml
+++ b/ILD/compact/ILD_o1_v05/SHcalSc04_Barrel_v03.xml
@@ -18,9 +18,9 @@
     <!-- The layer structure reference on page 10 in the following paper-->
     <!-- https://bib-pubdb1.desy.de/record/139781/files/LC-TOOL-2012-082.pdf -->
     <layer repeat="Hcal_nlayers" vis="SeeThrough">
-        <slice material = "Air"            thickness = "Hcal_fiber_gap"                                 vis="YellowVis" />
-        <slice material = "Cu"             thickness = "Hcal_Cu_thickness"                              vis="Invisible" />
-        <slice material = "PCB"            thickness = "Hcal_PCB_thickness"                             vis="Invisible" />
         <slice material = "G4_POLYSTYRENE" thickness = "Hcal_scintillator_thickness" sensitive = "yes"  vis="CyanVis"   />
+        <slice material = "PCB"            thickness = "Hcal_PCB_thickness"                             vis="Invisible" />
+        <slice material = "Cu"             thickness = "Hcal_Cu_thickness"                              vis="Invisible" />
+        <slice material = "Air"            thickness = "Hcal_fiber_gap"                                 vis="YellowVis" />
     </layer>
 </detector>

--- a/ILD/compact/ILD_o2_v01/SHcalSc04_Barrel_v02.xml
+++ b/ILD/compact/ILD_o2_v01/SHcalSc04_Barrel_v02.xml
@@ -17,10 +17,10 @@
     <!-- The layer structure reference on page 10 in the following paper-->
     <!-- https://bib-pubdb1.desy.de/record/139781/files/LC-TOOL-2012-082.pdf -->
     <layer repeat="Hcal_nlayers" vis="SeeThrough">
-        <slice material = "Air"            thickness = "Hcal_fiber_gap"                                 vis="YellowVis" />
-        <slice material = "Cu"             thickness = "Hcal_Cu_thickness"                              vis="Invisible" />
-        <slice material = "PCB"            thickness = "Hcal_PCB_thickness"                             vis="Invisible" />
-        <slice material = "G4_POLYSTYRENE" thickness = "Hcal_scintillator_thickness" sensitive = "yes"  vis="CyanVis"   />
         <slice material = "Steel235"       thickness = "Hcal_radiator_thickness"                        vis="BlueVis"   />
+        <slice material = "G4_POLYSTYRENE" thickness = "Hcal_scintillator_thickness" sensitive = "yes"  vis="CyanVis"   />
+        <slice material = "PCB"            thickness = "Hcal_PCB_thickness"                             vis="Invisible" />
+        <slice material = "Cu"             thickness = "Hcal_Cu_thickness"                              vis="Invisible" />
+        <slice material = "Air"            thickness = "Hcal_fiber_gap"                                 vis="YellowVis" />
     </layer>
 </detector>

--- a/ILD/compact/extra_stuff/SHcalSc04_Barrel_v02.xml
+++ b/ILD/compact/extra_stuff/SHcalSc04_Barrel_v02.xml
@@ -17,10 +17,10 @@
     <!-- The layer structure reference on page 10 in the following paper-->
     <!-- https://bib-pubdb1.desy.de/record/139781/files/LC-TOOL-2012-082.pdf -->
     <layer repeat="Hcal_nlayers" vis="SeeThrough">
-        <slice material = "Air"            thickness = "Hcal_fiber_gap"                                 vis="YellowVis" />
-        <slice material = "Cu"             thickness = "Hcal_Cu_thickness"                              vis="Invisible" />
-        <slice material = "PCB"            thickness = "Hcal_PCB_thickness"                             vis="Invisible" />
-        <slice material = "G4_POLYSTYRENE" thickness = "Hcal_scintillator_thickness" sensitive = "yes"  vis="CyanVis"   />
         <slice material = "Steel235"       thickness = "Hcal_radiator_thickness"                        vis="BlueVis"   />
+        <slice material = "G4_POLYSTYRENE" thickness = "Hcal_scintillator_thickness" sensitive = "yes"  vis="CyanVis"   />
+        <slice material = "PCB"            thickness = "Hcal_PCB_thickness"                             vis="Invisible" />
+        <slice material = "Cu"             thickness = "Hcal_Cu_thickness"                              vis="Invisible" />
+        <slice material = "Air"            thickness = "Hcal_fiber_gap"                                 vis="YellowVis" />
     </layer>
 </detector>

--- a/ILD/compact/extra_stuff/SHcalSc04_Barrel_v03.xml
+++ b/ILD/compact/extra_stuff/SHcalSc04_Barrel_v03.xml
@@ -18,9 +18,9 @@
     <!-- The layer structure reference on page 10 in the following paper-->
     <!-- https://bib-pubdb1.desy.de/record/139781/files/LC-TOOL-2012-082.pdf -->
     <layer repeat="Hcal_nlayers" vis="SeeThrough">
-        <slice material = "Air"            thickness = "Hcal_fiber_gap"                                 vis="YellowVis" />
-        <slice material = "Cu"             thickness = "Hcal_Cu_thickness"                              vis="Invisible" />
-        <slice material = "PCB"            thickness = "Hcal_PCB_thickness"                             vis="Invisible" />
         <slice material = "G4_POLYSTYRENE" thickness = "Hcal_scintillator_thickness" sensitive = "yes"  vis="CyanVis"   />
+        <slice material = "PCB"            thickness = "Hcal_PCB_thickness"                             vis="Invisible" />
+        <slice material = "Cu"             thickness = "Hcal_Cu_thickness"                              vis="Invisible" />
+        <slice material = "Air"            thickness = "Hcal_fiber_gap"                                 vis="YellowVis" />
     </layer>
 </detector>

--- a/detector/calorimeter/SHcalSc04_Barrel_v01.cpp
+++ b/detector/calorimeter/SHcalSc04_Barrel_v01.cpp
@@ -463,7 +463,7 @@ static Ref_t create_detector(Detector& theDetector, xml_h element, SensitiveDete
       string layer_name      = det_name+_toString(layer_id,"_layer%d");
       
       // Create the slices (sublayers) within the Hcal Barrel Chamber.
-      double slice_pos_z = -(layer_thickness/2.);
+      double slice_pos_z = layer_thickness/2. ;
       int slice_number = 0;
 
       for(xml_coll_t k(x_layer,_U(slice)); k; ++k)  {
@@ -473,7 +473,7 @@ static Ref_t create_detector(Detector& theDetector, xml_h element, SensitiveDete
 	Material slice_material  = theDetector.material(x_slice.materialStr());
 	DetElement slice(layer_name,_toString(slice_number,"slice%d"),x_det.id());
 	
-	slice_pos_z += slice_thickness/2.;
+	slice_pos_z -= slice_thickness/2.;
 	
 	// Slice volume & box
 	Volume slice_vol(slice_name,Box(x_length,z_width,slice_thickness/2.),slice_material);
@@ -516,7 +516,7 @@ static Ref_t create_detector(Detector& theDetector, xml_h element, SensitiveDete
 	
 	slice.setPlacement(slice_phv);
 	// Increment x position for next slice.
-	slice_pos_z += slice_thickness/2.;
+	slice_pos_z -= slice_thickness/2.;
 	// Increment slice number.
 	++slice_number;             
       }

--- a/detector/calorimeter/SHcalSc04_Barrel_v02.cpp
+++ b/detector/calorimeter/SHcalSc04_Barrel_v02.cpp
@@ -242,7 +242,7 @@ static Ref_t create_detector(Detector& theDetector, xml_h element, SensitiveDete
       string layer_name      = det_name+_toString(layer_id,"_layer%d");
       
       // Create the slices (sublayers) within the Hcal Barrel Chamber.
-      double slice_pos_z = -(layer_thickness/2.);
+      double slice_pos_z = layer_thickness/2. ;
       int slice_number = 0;
 
       double nRadiationLengths=0.;
@@ -256,7 +256,7 @@ static Ref_t create_detector(Detector& theDetector, xml_h element, SensitiveDete
 	Material slice_material  = theDetector.material(x_slice.materialStr());
 	DetElement slice(layer_name,_toString(slice_number,"slice%d"),x_det.id());
 	
-	slice_pos_z += slice_thickness/2.;
+	slice_pos_z -= slice_thickness/2.;
 	
 	// Slice volume & box
 	Volume slice_vol(slice_name,Box((halfY - Hcal_layer_air_gap),halfZ,slice_thickness/2.),slice_material);
@@ -294,7 +294,7 @@ static Ref_t create_detector(Detector& theDetector, xml_h element, SensitiveDete
 	
 	slice.setPlacement(slice_phv);
 	// Increment x position for next slice.
-	slice_pos_z += slice_thickness/2.;
+	slice_pos_z -= slice_thickness/2.;
 	// Increment slice number.
 	++slice_number;             
       }

--- a/detector/calorimeter/SHcalSc04_Barrel_v03.cpp
+++ b/detector/calorimeter/SHcalSc04_Barrel_v03.cpp
@@ -451,7 +451,7 @@ static Ref_t create_detector(Detector& theDetector, xml_h element, SensitiveDete
       string layer_name      = det_name+_toString(layer_id,"_layer%d");
       
       // Create the slices (sublayers) within the Hcal Barrel Chamber.
-      double slice_pos_z = -(layer_thickness/2.);
+      double slice_pos_z = layer_thickness/2. ;
       int slice_number = 0;
 
       for(xml_coll_t k(x_layer,_U(slice)); k; ++k)  {
@@ -462,7 +462,7 @@ static Ref_t create_detector(Detector& theDetector, xml_h element, SensitiveDete
 	DetElement m1_slice(layer_name,_toString(slice_number,"m1_slice%d"),x_det.id());
 	DetElement m2_slice(layer_name,_toString(slice_number,"m2_slice%d"),x_det.id());
 	
-	slice_pos_z += slice_thickness/2.;
+	slice_pos_z -= slice_thickness/2.;
 	
 	// Slice volume & box
 	Volume m1_slice_vol(slice_name,Box(x_length,m1_z_width,slice_thickness/2.),slice_material);
@@ -511,7 +511,7 @@ static Ref_t create_detector(Detector& theDetector, xml_h element, SensitiveDete
 	m1_slice.setPlacement(m1_slice_phv);
 	m2_slice.setPlacement(m2_slice_phv);
 	// Increment x position for next slice.
-	slice_pos_z += slice_thickness/2.;
+	slice_pos_z -= slice_thickness/2.;
 	// Increment slice number.
 	++slice_number;             
       }


### PR DESCRIPTION


BEGINRELEASENOTES
- For backward consistency, update all ILD AHCAL Barrel slice placement.
    - update all ILD AHCAL Barrel drivers to place slice in the same consistent way.
    - update the slice order in all the ILD AHCAL Barrel compact files too.

ENDRELEASENOTES