### PR TITLE
Fix ECAL LayeredCalorimeterData (SEcal06, SEcal05). Bug fix for SEcal05_ECRing

### DIFF
--- a/detector/calorimeter/SEcal05_Helpers.cpp
+++ b/detector/calorimeter/SEcal05_Helpers.cpp
@@ -24,6 +24,7 @@ SEcal05_Helpers::SEcal05_Helpers() {
 
   _caloLayer.absorberThickness = -999;
   _caloLayer.sensitive_thickness = -999;
+  _caloLayer.distance = 0;
 
   _totThick=0;
 
@@ -255,6 +256,12 @@ void SEcal05_Helpers::updateCaloLayers(double thickness,
     _layer_thickness=0;
     _layer_nRadiationLengths=0;
     _layer_nInteractionLengths=0;
+
+    // update the calolayer.distance ( DJeans 12 sep 2017)
+    // here this is distance from ECAL start to the layer start; the Barrel and Endcap drivers add the distance from IP
+    _caloLayer.distance += _caloLayer.inner_thickness+_caloLayer.outer_thickness;
+
+
   }
 
   if (!isFinal) {
@@ -272,8 +279,6 @@ void SEcal05_Helpers::updateCaloLayers(double thickness,
       _caloLayer.inner_nRadiationLengths   = _layer_nRadiationLengths ;
       _caloLayer.inner_nInteractionLengths = _layer_nInteractionLengths ;
       _caloLayer.inner_thickness           = _layer_thickness ;
-
-      _caloLayer.distance  = _totThick + thickness/2.; // distance from front face
 
       // reset layer thicknesses
       _layer_thickness=0;

--- a/detector/calorimeter/SEcal06_Helpers.cpp
+++ b/detector/calorimeter/SEcal06_Helpers.cpp
@@ -30,6 +30,7 @@ SEcal06_Helpers::SEcal06_Helpers() {
 
   _caloLayer.absorberThickness = -999;
   _caloLayer.sensitive_thickness = -999;
+  _caloLayer.distance = 0;
 
   _totThick=0;
 
@@ -281,8 +282,6 @@ void SEcal06_Helpers::updateCaloLayers(double thickness,
       _caloLayer.inner_nInteractionLengths = _layer_nInteractionLengths ;
       _caloLayer.inner_thickness           = _layer_thickness ;
 
-      _caloLayer.distance  = _totThick + thickness/2.; // distance from front face
-
       // reset layer thicknesses
       _layer_thickness=0;
       _layer_nRadiationLengths=0;
@@ -293,6 +292,12 @@ void SEcal06_Helpers::updateCaloLayers(double thickness,
     _layer_thickness           += (thickness/2.);
     _layer_nRadiationLengths   += (thickness/2.)/mat.radLength() ;
     _layer_nInteractionLengths += (thickness/2.)/mat.intLength() ;
+
+
+    // update the calolayer.distance ( DJeans 12 sep 2017)
+    // here this is distance from ECAL start to the layer start; the Barrel and Endcap drivers add the distance from IP
+    _caloLayer.distance += _caloLayer.inner_thickness+_caloLayer.outer_thickness;
+
   }
 
   _totThick+=thickness;


### PR DESCRIPTION

BEGINRELEASENOTES
Fix the filling of dd4hep::rec::LayeredCalorimeterData::Layer data for SEcal05, SEcal06 models:
- layer.distance now defined as the distance to the *start* of a calo layer (at the start of the absorber, except in the case of the 1st layer, in which it's the start of the ECAL).
Some additional fixes to SEcal05_ECRing: 
- use correct absorber thickness in stack transitions (previously not guaranteed to be correct)
- use CarbonFibre when calculating material properties for LayeredCalorimeterData (previously using air for structural material)
- cosmetic changes: indentations, commented-out code, ...
ENDRELEASENOTES