### PR TITLE
Correct the collections key_value.

### DIFF
--- a/ILD/compact/ILD_common_v02/SHcalSc04_Barrel_v04.xml
+++ b/ILD/compact/ILD_common_v02/SHcalSc04_Barrel_v04.xml
@@ -39,8 +39,8 @@
         <segmentation name="Scigrid" type="TiledLayerGridXY"  key_value="3"  grid_size_x="3" grid_size_y="3.03248"/>
       </segmentation>
       <hits_collections>
-        <hits_collection name="HCalBarrelRPCHits"  key="slice" key_value="3"/>
-        <hits_collection name="HcalBarrelRegCollection"  key="slice" key_value="1"/>
+        <hits_collection name="HCalBarrelRPCHits"  key="slice" key_value="1"/>
+        <hits_collection name="HcalBarrelRegCollection"  key="slice" key_value="3"/>
       </hits_collections>
       <id>system:5,module:3,stave:4,tower:5,layer:6,slice:4,x:32:-16,y:-16</id>
     </readout>


### PR DESCRIPTION

BEGINRELEASENOTES
- Fix ILD_l4_v02 Hybird model collections key_value.
    - follow the update of the slice placement and correct the collections key_value.
    - the segmentation and collection should use the same key_value for both SDHCAL and  AHcal.

ENDRELEASENOTES