### PR TITLE
New hybrid scint ecal

### DIFF
--- a/ILD/compact/ILD_common_v02/SEcal06_hybrid_Barrel.xml
+++ b/ILD/compact/ILD_common_v02/SEcal06_hybrid_Barrel.xml
@@ -19,11 +19,12 @@
 
 
       <!--  select which subsegmentation will be used to fill the DDRec:LayeredCalorimeterData cell dimensions -->
-      <subsegmentation key="slice" value="3 9"/>
+      <subsegmentation key="slice" value="4 10"/>
 
       <layer repeat="Ecal_nlayers1/2" vis="SeeThrough" >
 	<slice material = "G4_Al"          thickness = "Ecal_Slab_shielding"                 vis="Invisible" />
 	<slice material = "G4_Cu"          thickness = "Ecal_Slab_copper_thickness"          vis="Invisible" />
+	<slice material = "G4_AIR"         thickness = "Ecal_HybridExtraGap_thickness"       vis="Invisible" />
         <slice material = "G4_POLYSTYRENE" thickness = "Ecal_Sc_thickness" sensitive = "yes" vis="CyanVis"   />
         <slice material = "Si"             thickness = "Ecal_Si_thickness" sensitive = "yes" vis="Invisible" />
         <slice material = "GroundOrHVMix"  thickness = "Ecal_Slab_ground_thickness"          vis="Invisible" />
@@ -33,6 +34,7 @@
         <slice material = "GroundOrHVMix"  thickness = "Ecal_Slab_ground_thickness"          vis="Invisible" />
         <slice material = "Si"             thickness = "Ecal_Si_thickness" sensitive = "yes" vis="Invisible" />
         <slice material = "G4_POLYSTYRENE" thickness = "Ecal_Sc_thickness" sensitive = "yes" vis="CyanVis"   />
+	<slice material = "G4_AIR"         thickness = "Ecal_HybridExtraGap_thickness"       vis="Invisible" />
 	<slice material = "G4_Cu"          thickness = "Ecal_Slab_copper_thickness"          vis="Invisible" />
 	<slice material = "G4_Al"          thickness = "Ecal_Slab_shielding"                 vis="Invisible" />
       </layer>
@@ -40,6 +42,7 @@
       <layer repeat="(Ecal_nlayers2+1)/2" vis="SeeThrough">
 	<slice material = "G4_Al"          thickness = "Ecal_Slab_shielding"                 vis="Invisible" />
 	<slice material = "G4_Cu"          thickness = "Ecal_Slab_copper_thickness"          vis="Invisible" />
+	<slice material = "G4_AIR"         thickness = "Ecal_HybridExtraGap_thickness"       vis="Invisible" />
         <slice material = "G4_POLYSTYRENE" thickness = "Ecal_Sc_thickness" sensitive = "yes" vis="CyanVis"   />
         <slice material = "Si"             thickness = "Ecal_Si_thickness" sensitive = "yes" vis="Invisible" />
         <slice material = "GroundOrHVMix"  thickness = "Ecal_Slab_ground_thickness"          vis="Invisible" />
@@ -49,6 +52,7 @@
         <slice material = "GroundOrHVMix"  thickness = "Ecal_Slab_ground_thickness"          vis="Invisible" />
         <slice material = "Si"             thickness = "Ecal_Si_thickness" sensitive = "yes" vis="Invisible" />
         <slice material = "G4_POLYSTYRENE" thickness = "Ecal_Sc_thickness" sensitive = "yes" vis="CyanVis"   />
+	<slice material = "G4_AIR"         thickness = "Ecal_HybridExtraGap_thickness"       vis="Invisible" />
 	<slice material = "G4_Cu"          thickness = "Ecal_Slab_copper_thickness"          vis="Invisible" />
 	<slice material = "G4_Al"          thickness = "Ecal_Slab_shielding"                 vis="Invisible" />
       </layer>
@@ -59,19 +63,19 @@
 <readouts>
   <readout name="EcalBarrelCollection">
     <segmentation   type="MultiSegmentation"  key="slice">
-      <segmentation name="SiGrid_even" type="MegatileLayerGridXY"    key_value="3" common_nCellsX="16" common_nCellsY="16"/>
-      <segmentation name="SiGrid_odd"  type="MegatileLayerGridXY"    key_value="9" common_nCellsX="16" common_nCellsY="16" />
+      <segmentation name="SiGrid_even" type="MegatileLayerGridXY"    key_value="4" common_nCellsX="16" common_nCellsY="16"/>
+      <segmentation name="SiGrid_odd"  type="MegatileLayerGridXY"    key_value="10" common_nCellsX="16" common_nCellsY="16" />
 
-      <segmentation name="ScGrid_even" type="MegatileLayerGridXY"    key_value="2"  common_nCellsX="2" common_nCellsY="16" />
-      <segmentation name="ScGrid_odd"  type="MegatileLayerGridXY"    key_value="10" common_nCellsX="16" common_nCellsY="2" />
+      <segmentation name="ScGrid_even" type="MegatileLayerGridXY"    key_value="3"  common_nCellsX="2" common_nCellsY="16" />
+      <segmentation name="ScGrid_odd"  type="MegatileLayerGridXY"    key_value="11" common_nCellsX="16" common_nCellsY="2" />
     </segmentation>
 
     <hits_collections>
-      <hits_collection name="ECalBarrelSiHitsEven" key="slice" key_value="3" />
-      <hits_collection name="ECalBarrelSiHitsOdd"  key="slice" key_value="9" />
+      <hits_collection name="ECalBarrelSiHitsEven" key="slice" key_value="4" />
+      <hits_collection name="ECalBarrelSiHitsOdd"  key="slice" key_value="10" />
 
-      <hits_collection name="ECalBarrelScHitsEven" key="slice" key_value="2" />
-      <hits_collection name="ECalBarrelScHitsOdd"  key="slice" key_value="10" />
+      <hits_collection name="ECalBarrelScHitsEven" key="slice" key_value="3" />
+      <hits_collection name="ECalBarrelScHitsOdd"  key="slice" key_value="11" />
 
     </hits_collections>
 

--- a/ILD/compact/ILD_common_v02/SEcal06_hybrid_Barrel.xml
+++ b/ILD/compact/ILD_common_v02/SEcal06_hybrid_Barrel.xml
@@ -63,11 +63,11 @@
 <readouts>
   <readout name="EcalBarrelCollection">
     <segmentation   type="MultiSegmentation"  key="slice">
-      <segmentation name="SiGrid_even" type="MegatileLayerGridXY"    key_value="4" common_nCellsX="16" common_nCellsY="16"/>
-      <segmentation name="SiGrid_odd"  type="MegatileLayerGridXY"    key_value="10" common_nCellsX="16" common_nCellsY="16" />
+      <segmentation name="SiGrid_even" type="MegatileLayerGridXY"    key_value="4" common_nCellsX="Ecal_cells_across_megatile" common_nCellsY="Ecal_cells_across_megatile"/>
+      <segmentation name="SiGrid_odd"  type="MegatileLayerGridXY"    key_value="10" common_nCellsX="Ecal_cells_across_megatile" common_nCellsY="Ecal_cells_across_megatile" />
 
-      <segmentation name="ScGrid_even" type="MegatileLayerGridXY"    key_value="3"  common_nCellsX="2" common_nCellsY="16" />
-      <segmentation name="ScGrid_odd"  type="MegatileLayerGridXY"    key_value="11" common_nCellsX="16" common_nCellsY="2" />
+      <segmentation name="ScGrid_even" type="MegatileLayerGridXY"    key_value="3"  common_nCellsX="Ecal_strips_along_megatile" common_nCellsY="Ecal_strips_across_megatile" />
+      <segmentation name="ScGrid_odd"  type="MegatileLayerGridXY"    key_value="11" common_nCellsX="Ecal_strips_across_megatile" common_nCellsY="Ecal_strips_along_megatile" />
     </segmentation>
 
     <hits_collections>

--- a/ILD/compact/ILD_common_v02/SEcal06_hybrid_Endcaps.xml
+++ b/ILD/compact/ILD_common_v02/SEcal06_hybrid_Endcaps.xml
@@ -24,11 +24,12 @@
       <staves  material = "G4_W"  vis="BlueVis"/>
 
       <!--  select which subsegmentation will be used to fill the DDRec:LayeredCalorimeterData cell dimensions -->
-      <subsegmentation key="slice" value="3 9"/>
+      <subsegmentation key="slice" value="4 10"/>
 
       <layer repeat="Ecal_nlayers1/2" vis="SeeThrough" >
 	<slice material = "G4_Al"          thickness = "Ecal_Slab_shielding"                 vis="Invisible" />
 	<slice material = "G4_Cu"          thickness = "Ecal_Slab_copper_thickness"          vis="Invisible" />
+	<slice material = "G4_AIR"         thickness = "Ecal_HybridExtraGap_thickness"       vis="Invisible" />
         <slice material = "G4_POLYSTYRENE" thickness = "Ecal_Sc_thickness" sensitive = "yes" vis="CyanVis"   />
         <slice material = "Si"             thickness = "Ecal_Si_thickness" sensitive = "yes" vis="Invisible" />
         <slice material = "GroundOrHVMix"  thickness = "Ecal_Slab_ground_thickness"          vis="Invisible" />
@@ -38,6 +39,7 @@
         <slice material = "GroundOrHVMix"  thickness = "Ecal_Slab_ground_thickness"          vis="Invisible" />
         <slice material = "Si"             thickness = "Ecal_Si_thickness" sensitive = "yes" vis="Invisible" />
         <slice material = "G4_POLYSTYRENE" thickness = "Ecal_Sc_thickness" sensitive = "yes" vis="CyanVis"   />
+	<slice material = "G4_AIR"         thickness = "Ecal_HybridExtraGap_thickness"       vis="Invisible" />
 	<slice material = "G4_Cu"          thickness = "Ecal_Slab_copper_thickness"          vis="Invisible" />
 	<slice material = "G4_Al"          thickness = "Ecal_Slab_shielding"                 vis="Invisible" />
       </layer>
@@ -45,6 +47,7 @@
       <layer repeat="(Ecal_nlayers2+1)/2" vis="SeeThrough">
 	<slice material = "G4_Al"          thickness = "Ecal_Slab_shielding"                 vis="Invisible" />
 	<slice material = "G4_Cu"          thickness = "Ecal_Slab_copper_thickness"          vis="Invisible" />
+	<slice material = "G4_AIR"         thickness = "Ecal_HybridExtraGap_thickness"       vis="Invisible" />
         <slice material = "G4_POLYSTYRENE" thickness = "Ecal_Sc_thickness" sensitive = "yes" vis="CyanVis"   />
         <slice material = "Si"             thickness = "Ecal_Si_thickness" sensitive = "yes" vis="Invisible" />
         <slice material = "GroundOrHVMix"  thickness = "Ecal_Slab_ground_thickness"          vis="Invisible" />
@@ -54,6 +57,7 @@
         <slice material = "GroundOrHVMix"  thickness = "Ecal_Slab_ground_thickness"          vis="Invisible" />
         <slice material = "Si"             thickness = "Ecal_Si_thickness" sensitive = "yes" vis="Invisible" />
         <slice material = "G4_POLYSTYRENE" thickness = "Ecal_Sc_thickness" sensitive = "yes" vis="CyanVis"   />
+	<slice material = "G4_AIR"         thickness = "Ecal_HybridExtraGap_thickness"       vis="Invisible" />
 	<slice material = "G4_Cu"          thickness = "Ecal_Slab_copper_thickness"          vis="Invisible" />
 	<slice material = "G4_Al"          thickness = "Ecal_Slab_shielding"                 vis="Invisible" />
       </layer>
@@ -64,19 +68,19 @@
 <readouts>
   <readout name="EcalEndcapsCollection">
     <segmentation   type="MultiSegmentation"  key="slice">
-      <segmentation name="SiGrid_even" type="MegatileLayerGridXY"    key_value="3" common_nCellsX="16" common_nCellsY="16"/>
-      <segmentation name="SiGrid_odd"  type="MegatileLayerGridXY"    key_value="9" common_nCellsX="16" common_nCellsY="16" />
+      <segmentation name="SiGrid_even" type="MegatileLayerGridXY"    key_value="4" common_nCellsX="16" common_nCellsY="16"/>
+      <segmentation name="SiGrid_odd"  type="MegatileLayerGridXY"    key_value="10" common_nCellsX="16" common_nCellsY="16" />
 
-      <segmentation name="ScGrid_even" type="MegatileLayerGridXY"    key_value="2"  common_nCellsX="2" common_nCellsY="16" />
-      <segmentation name="ScGrid_odd"  type="MegatileLayerGridXY"    key_value="10" common_nCellsX="16" common_nCellsY="2" />
+      <segmentation name="ScGrid_even" type="MegatileLayerGridXY"    key_value="3"  common_nCellsX="2" common_nCellsY="16" />
+      <segmentation name="ScGrid_odd"  type="MegatileLayerGridXY"    key_value="11" common_nCellsX="16" common_nCellsY="2" />
     </segmentation>
 
     <hits_collections>
-      <hits_collection name="ECalEndcapSiHitsEven" key="slice" key_value="3" />
-      <hits_collection name="ECalEndcapSiHitsOdd"  key="slice" key_value="9" />
+      <hits_collection name="ECalEndcapSiHitsEven" key="slice" key_value="4" />
+      <hits_collection name="ECalEndcapSiHitsOdd"  key="slice" key_value="10" />
 
-      <hits_collection name="ECalEndcapScHitsEven" key="slice" key_value="2" />
-      <hits_collection name="ECalEndcapScHitsOdd"  key="slice" key_value="10" />
+      <hits_collection name="ECalEndcapScHitsEven" key="slice" key_value="3" />
+      <hits_collection name="ECalEndcapScHitsOdd"  key="slice" key_value="11" />
 
     </hits_collections>
 

--- a/ILD/compact/ILD_common_v02/SEcal06_hybrid_Endcaps.xml
+++ b/ILD/compact/ILD_common_v02/SEcal06_hybrid_Endcaps.xml
@@ -68,11 +68,11 @@
 <readouts>
   <readout name="EcalEndcapsCollection">
     <segmentation   type="MultiSegmentation"  key="slice">
-      <segmentation name="SiGrid_even" type="MegatileLayerGridXY"    key_value="4" common_nCellsX="16" common_nCellsY="16"/>
-      <segmentation name="SiGrid_odd"  type="MegatileLayerGridXY"    key_value="10" common_nCellsX="16" common_nCellsY="16" />
+      <segmentation name="SiGrid_even" type="MegatileLayerGridXY"    key_value="4" common_nCellsX="Ecal_cells_across_megatile" common_nCellsY="Ecal_cells_across_megatile"/>
+      <segmentation name="SiGrid_odd"  type="MegatileLayerGridXY"    key_value="10" common_nCellsX="Ecal_cells_across_megatile" common_nCellsY="Ecal_cells_across_megatile" />
 
-      <segmentation name="ScGrid_even" type="MegatileLayerGridXY"    key_value="3"  common_nCellsX="2" common_nCellsY="16" />
-      <segmentation name="ScGrid_odd"  type="MegatileLayerGridXY"    key_value="11" common_nCellsX="16" common_nCellsY="2" />
+      <segmentation name="ScGrid_even" type="MegatileLayerGridXY"    key_value="3"  common_nCellsX="Ecal_strips_along_megatile" common_nCellsY="Ecal_strips_across_megatile" />
+      <segmentation name="ScGrid_odd"  type="MegatileLayerGridXY"    key_value="11" common_nCellsX="Ecal_strips_across_megatile" common_nCellsY="Ecal_strips_along_megatile" />
     </segmentation>
 
     <hits_collections>

--- a/ILD/compact/ILD_common_v02/ecal_hybrid_defs.xml
+++ b/ILD/compact/ILD_common_v02/ecal_hybrid_defs.xml
@@ -43,7 +43,7 @@
   <constant name="Ecal_cells_across_megatile" value="18"/>
 
   <constant name="Ecal_strips_across_megatile" value="18"/>
-  <constant name="Ecal_strips_along_megatile" value="4"/>
+  <constant name="Ecal_strips_along_megatile" value="2"/>
 
   <constant name="Ecal_Endcap_Preshower" value="0"/>
 

--- a/ILD/compact/ILD_common_v02/ecal_hybrid_defs.xml
+++ b/ILD/compact/ILD_common_v02/ecal_hybrid_defs.xml
@@ -25,9 +25,12 @@
   <constant name="Ecal_Slab_H_fiber_thickness" value="0.55*mm"/>
   <constant name="Ecal_Slab_ASIC_thickness" value="0.7*mm"/>
   <constant name="Ecal_Slab_PCB_thickness" value="1.0*mm"/>
-  <constant name="Ecal_Slab_copper_thickness" value="0.40*mm"/>
+
+  <constant name="Ecal_Slab_copper_thickness" value="0.4*mm"/>
+
   <constant name="Ecal_Slab_glue_gap" value="0.1*mm"/>
   <constant name="Ecal_Slab_ground_thickness" value="0.1*mm"/>
+
   <constant name="Ecal_Slab_shielding" value="0.1*mm"/>
 
   <constant name="Ecal_guard_ring_size" value="0.5*mm"/>
@@ -54,8 +57,9 @@
   <constant name="Ecal_Sc_reflector_thickness" value="0.057*mm"/>
   <constant name="Ecal_Slab_Sc_PCB_thickness" value="0.8*mm"/>
 
-  <!-- for hybrid, replace asic + pcb + air gaps with sc -->
-  <constant name="Ecal_Sc_thickness" value="Ecal_Slab_ASIC_thickness+Ecal_Slab_PCB_thickness+2*Ecal_Slab_glue_gap+Ecal_Alveolus_Air_Gap/2."/>
+  <!-- for hybrid, replace asic + pcb + air gaps with sc+air : adjust air to give exactly same thickness as si-only model -->
+  <constant name="Ecal_Sc_thickness" value="1.5*mm"/>
+  <constant name="Ecal_HybridExtraGap_thickness" value="Ecal_Slab_ASIC_thickness+Ecal_Slab_PCB_thickness+2*Ecal_Slab_glue_gap+Ecal_Alveolus_Air_Gap/2.-Ecal_Sc_thickness"/>
 
 </define>
 


### PR DESCRIPTION

BEGINRELEASENOTES
- adjust parameters of hybrid ECAL model: reduce scintillator 2 -> 1.5 mm, add 0.5mm air gap
- take hybrid ECAL segmentation from parameters (not hard-coded numbers)
ENDRELEASENOTES