### PR TITLE
ILD Ecal segmentation in l/s5 models

### DIFF
--- a/ILD/compact/ILD_common_v02/SEcal06_hybrid_Barrel.xml
+++ b/ILD/compact/ILD_common_v02/SEcal06_hybrid_Barrel.xml
@@ -19,7 +19,7 @@
 
 
       <!--  select which subsegmentation will be used to fill the DDRec:LayeredCalorimeterData cell dimensions -->
-      <subsegmentation key="slice" value="Ecal_readout_segmentation_slice"/>
+      <subsegmentation key="slice" value0="Ecal_readout_segmentation_slice0" value1="Ecal_readout_segmentation_slice1"/>
 
       <layer repeat="Ecal_nlayers1/2" vis="SeeThrough" >
 	<slice material = "G4_Al"          thickness = "Ecal_Slab_shielding"                 vis="Invisible" />

--- a/ILD/compact/ILD_common_v02/SEcal06_hybrid_Endcaps.xml
+++ b/ILD/compact/ILD_common_v02/SEcal06_hybrid_Endcaps.xml
@@ -24,7 +24,7 @@
       <staves  material = "G4_W"  vis="BlueVis"/>
 
       <!--  select which subsegmentation will be used to fill the DDRec:LayeredCalorimeterData cell dimensions -->
-      <subsegmentation key="slice" value="Ecal_readout_segmentation_slice"/>
+      <subsegmentation key="slice" value0="Ecal_readout_segmentation_slice0" value1="Ecal_readout_segmentation_slice1"/>
 
       <layer repeat="Ecal_nlayers1/2" vis="SeeThrough" >
 	<slice material = "G4_Al"          thickness = "Ecal_Slab_shielding"                 vis="Invisible" />

--- a/ILD/compact/ILD_l5_v02/ILD_l5_o1_v02.xml
+++ b/ILD/compact/ILD_l5_v02/ILD_l5_o1_v02.xml
@@ -33,7 +33,8 @@
     <include ref="${DD4hepINSTALL}/DDDetectors/compact/detector_types.xml"/>
 
     <!-- Readout slice in ecal for reconstruction (SiWEcal) -->
-    <constant name="Ecal_readout_segmentation_slice" value="4 10"/>
+    <constant name="Ecal_readout_segmentation_slice0" value="4"/>
+    <constant name="Ecal_readout_segmentation_slice1" value="10"/>
     <!-- Readout slice in hcal for reconstruction (AHcal) -->
     <constant name="Hcal_readout_segmentation_slice" value="3"/>
 

--- a/ILD/compact/ILD_l5_v02/ILD_l5_o2_v02.xml
+++ b/ILD/compact/ILD_l5_v02/ILD_l5_o2_v02.xml
@@ -33,7 +33,8 @@
     <include ref="${DD4hepINSTALL}/DDDetectors/compact/detector_types.xml"/>
 
     <!-- Readout slice in ecal for reconstruction (SiWEcal) -->
-    <constant name="Ecal_readout_segmentation_slice" value="4 10"/>
+    <constant name="Ecal_readout_segmentation_slice0" value="4"/>
+    <constant name="Ecal_readout_segmentation_slice1" value="10"/>
     <!-- Readout slice in hcal for reconstruction (SDHCAL) -->
     <constant name="Hcal_readout_segmentation_slice" value="1"/>
 

--- a/ILD/compact/ILD_l5_v02/ILD_l5_o3_v02.xml
+++ b/ILD/compact/ILD_l5_v02/ILD_l5_o3_v02.xml
@@ -33,7 +33,8 @@
     <include ref="${DD4hepINSTALL}/DDDetectors/compact/detector_types.xml"/>
 
     <!-- Readout slice in ecal for reconstruction (ScEcal) -->
-    <constant name="Ecal_readout_segmentation_slice" value="3 11"/>
+    <constant name="Ecal_readout_segmentation_slice0" value="3"/>
+    <constant name="Ecal_readout_segmentation_slice1" value="11"/>
     <!-- Readout slice in hcal for reconstruction (AHcal) -->
     <constant name="Hcal_readout_segmentation_slice" value="3"/>
 

--- a/ILD/compact/ILD_l5_v02/ILD_l5_o4_v02.xml
+++ b/ILD/compact/ILD_l5_v02/ILD_l5_o4_v02.xml
@@ -33,7 +33,8 @@
     <include ref="${DD4hepINSTALL}/DDDetectors/compact/detector_types.xml"/>
 
     <!-- Readout slice in ecal for reconstruction (ScEcal) -->
-    <constant name="Ecal_readout_segmentation_slice" value="3 11"/>
+    <constant name="Ecal_readout_segmentation_slice0" value="3"/>
+    <constant name="Ecal_readout_segmentation_slice1" value="11"/>
     <!-- Readout slice in hcal for reconstruction (SDHCAL) -->
     <constant name="Hcal_readout_segmentation_slice" value="1"/>
 

--- a/ILD/compact/ILD_l5_v02/ILD_l5_v02.xml
+++ b/ILD/compact/ILD_l5_v02/ILD_l5_v02.xml
@@ -33,7 +33,8 @@
     <include ref="${DD4hepINSTALL}/DDDetectors/compact/detector_types.xml"/>
 
     <!-- Readout slice in ecal for reconstruction -->
-    <constant name="Ecal_readout_segmentation_slice" value="4 10"/>
+    <constant name="Ecal_readout_segmentation_slice0" value="4"/>
+    <constant name="Ecal_readout_segmentation_slice1" value="10"/>
     <!-- Readout slice in hcal for reconstruction -->
     <constant name="Hcal_readout_segmentation_slice" value="3"/>
 

--- a/ILD/compact/ILD_s5_v02/ILD_s5_o1_v02.xml
+++ b/ILD/compact/ILD_s5_v02/ILD_s5_o1_v02.xml
@@ -33,7 +33,8 @@
     <include ref="${DD4hepINSTALL}/DDDetectors/compact/detector_types.xml"/>
 
     <!-- Readout slice in ecal for reconstruction (SiWEcal) -->
-    <constant name="Ecal_readout_segmentation_slice" value="4 10"/>
+    <constant name="Ecal_readout_segmentation_slice0" value="4"/>
+    <constant name="Ecal_readout_segmentation_slice1" value="10"/>
     <!-- Readout slice in hcal for reconstruction (AHcal) -->
     <constant name="Hcal_readout_segmentation_slice" value="3"/>
 

--- a/ILD/compact/ILD_s5_v02/ILD_s5_o2_v02.xml
+++ b/ILD/compact/ILD_s5_v02/ILD_s5_o2_v02.xml
@@ -33,7 +33,8 @@
     <include ref="${DD4hepINSTALL}/DDDetectors/compact/detector_types.xml"/>
 
     <!-- Readout slice in ecal for reconstruction (SiWEcal) -->
-    <constant name="Ecal_readout_segmentation_slice" value="4 10"/>
+    <constant name="Ecal_readout_segmentation_slice0" value="4"/>
+    <constant name="Ecal_readout_segmentation_slice1" value="10"/>
     <!-- Readout slice in hcal for reconstruction (SDHCAL) -->
     <constant name="Hcal_readout_segmentation_slice" value="1"/>
 

--- a/ILD/compact/ILD_s5_v02/ILD_s5_o3_v02.xml
+++ b/ILD/compact/ILD_s5_v02/ILD_s5_o3_v02.xml
@@ -33,7 +33,8 @@
     <include ref="${DD4hepINSTALL}/DDDetectors/compact/detector_types.xml"/>
 
     <!-- Readout slice in ecal for reconstruction (ScEcal) -->
-    <constant name="Ecal_readout_segmentation_slice" value="3 11"/>
+    <constant name="Ecal_readout_segmentation_slice0" value="3"/>
+    <constant name="Ecal_readout_segmentation_slice1" value="11"/>
     <!-- Readout slice in hcal for reconstruction (AHcal) -->
     <constant name="Hcal_readout_segmentation_slice" value="3"/>
 

--- a/ILD/compact/ILD_s5_v02/ILD_s5_o4_v02.xml
+++ b/ILD/compact/ILD_s5_v02/ILD_s5_o4_v02.xml
@@ -33,7 +33,8 @@
     <include ref="${DD4hepINSTALL}/DDDetectors/compact/detector_types.xml"/>
 
     <!-- Readout slice in ecal for reconstruction (ScEcal) -->
-    <constant name="Ecal_readout_segmentation_slice" value="3 11"/>
+    <constant name="Ecal_readout_segmentation_slice0" value="3"/>
+    <constant name="Ecal_readout_segmentation_slice1" value="11"/>
     <!-- Readout slice in hcal for reconstruction (SDHCAL) -->
     <constant name="Hcal_readout_segmentation_slice" value="1"/>
 

--- a/ILD/compact/ILD_s5_v02/ILD_s5_v02.xml
+++ b/ILD/compact/ILD_s5_v02/ILD_s5_v02.xml
@@ -33,7 +33,8 @@
     <include ref="${DD4hepINSTALL}/DDDetectors/compact/detector_types.xml"/>
 
     <!-- Readout slice in ecal for reconstruction -->
-    <constant name="Ecal_readout_segmentation_slice" value="4 10"/>
+    <constant name="Ecal_readout_segmentation_slice0" value="4"/>
+    <constant name="Ecal_readout_segmentation_slice1" value="10"/>
     <!-- Readout slice in hcal for reconstruction -->
     <constant name="Hcal_readout_segmentation_slice" value="3"/>
 

--- a/detector/calorimeter/SEcal06_Helpers.cpp
+++ b/detector/calorimeter/SEcal06_Helpers.cpp
@@ -466,19 +466,14 @@ void SEcal06_Helpers::makeModule( dd4hep::Volume & mod_vol,  // the volume we'll
       // check if we have an entry for the subsegmentation to be used 
       xml_comp_t segxml = _x_det->child( _Unicode( subsegmentation ) ) ;
       std::string keyStr = segxml.attr<std::string>( _Unicode(key) ) ;
-      std::string keyVal = segxml.attr<std::string>( _Unicode(value) )  ;
-      int ntemp;
-      std::stringstream stream(keyVal);
-      while ( stream >> ntemp ) {
-	assert (ntemp>=0 && "error getting subsegmentation information! " );
-	multi_refSlices.push_back( ntemp );
-      }
-
-      assert( multi_refSlices.size()>0 && "no subsegmentation info found in multireadout??" );
+      int keyVal0 = segxml.attr<int>( _Unicode(value0) )  ;
+      int keyVal1 = segxml.attr<int>( _Unicode(value1) )  ;
+	    multi_refSlices.push_back( keyVal0 );
+      multi_refSlices.push_back( keyVal1 );
       
     } catch( std::runtime_error) {
       throw lcgeo::GeometryException(  "SEcal06_Helper: Error: MultiSegmentation specified but no "
-                                       " <subsegmentation key="" value=""/> element defined for detector ! " ) ;
+                                       " <subsegmentation key="" value0="" value1=""/> element defined for detector ! " ) ;
     }
 
 


### PR DESCRIPTION
BEGINRELEASENOTES
- Split ILD ecal segmentation selection into two values: value0 and value1 while parsing geometry for ILD_l/s5_* models. 
- Changed both drivers and compact xml files.

ENDRELEASENOTES