### PR TITLE
Fix ILD SDHCal endcaps segmentation offset.

### DIFF
--- a/ILD/compact/ILD_common_v02/SHcalSc04_Endcaps_v01_LARGE.xml
+++ b/ILD/compact/ILD_common_v02/SHcalSc04_Endcaps_v01_LARGE.xml
@@ -55,7 +55,7 @@
   <readouts>
     <readout name="HcalEndcapsReadout">
       <segmentation   type="MultiSegmentation"  key="slice">
-        <segmentation name="RPCgrid" type="CartesianGridXY"    key_value="1"    grid_size_x="SDHCal_cell_size" grid_size_y="SDHCal_cell_size" />
+        <segmentation name="RPCgrid" type="CartesianGridXY"    key_value="1"    grid_size_x="SDHCal_cell_size" grid_size_y="SDHCal_cell_size" offset_x="SDHCal_cell_size/2.0" offset_y="SDHCal_cell_size/2.0" />
         <segmentation name="Scigrid"  type="CartesianGridXY"  key_value="3"  grid_size_x="AHCal_cell_size" grid_size_y="AHCal_cell_size" offset_x="AHCal_cell_size/2.0" offset_y="AHCal_cell_size/2.0" />
       </segmentation>
       <hits_collections>

--- a/ILD/compact/ILD_common_v02/SHcalSc04_Endcaps_v01_SMALL.xml
+++ b/ILD/compact/ILD_common_v02/SHcalSc04_Endcaps_v01_SMALL.xml
@@ -53,7 +53,7 @@
   <readouts>
     <readout name="HcalEndcapsReadout">
       <segmentation   type="MultiSegmentation"  key="slice">
-        <segmentation name="RPCgrid" type="CartesianGridXY"    key_value="1"    grid_size_x="SDHCal_cell_size" grid_size_y="SDHCal_cell_size" />
+        <segmentation name="RPCgrid" type="CartesianGridXY"    key_value="1"    grid_size_x="SDHCal_cell_size" grid_size_y="SDHCal_cell_size" offset_x="SDHCal_cell_size/2.0" offset_y="SDHCal_cell_size/2.0" />
         <segmentation name="Scigrid"  type="CartesianGridXY"  key_value="3"  grid_size_x="AHCal_cell_size" grid_size_y="AHCal_cell_size" offset_x="AHCal_cell_size/2.0" offset_y="AHCal_cell_size/2.0" />
       </segmentation>
       <hits_collections>


### PR DESCRIPTION

BEGINRELEASENOTES
- Fix ILD SDHCal endcaps segmentation offset.
    - use half of SDHCal_cell_size offset to make sure that cells equally distributed in the sensitive area from the center to the left, to the right, to the top and to the bottom.
    - to avoid the cell to be placed at (0,0) in xy-plane, then generate the fragmentation cell at the boundary.

ENDRELEASENOTES