### PR TITLE
make Hcal endcap more flexible.

### DIFF
--- a/ILD/compact/ILD_common_v01/hcal_defs.xml
+++ b/ILD/compact/ILD_common_v01/hcal_defs.xml
@@ -14,6 +14,7 @@
   <constant name="Hcal_PCB_thickness" value="0.7*mm"/>
   <constant name="Hcal_scintillator_thickness" value="3.0*mm"/>
   <constant name="Hcal_cells_size" value="30*mm"/>
+  <constant name="Hcal_endcap_lateral_structure_thickness" value="5.0*mm"/>
   <constant name="Hcal_endcap_layer_air_gap" value="2.5*mm"/>
   <constant name="Hcal_endcap_nlayers" value="48"/> <!-- needed for ring only? -->
 

--- a/ILD/compact/ILD_common_v02/hcal_defs.xml
+++ b/ILD/compact/ILD_common_v02/hcal_defs.xml
@@ -15,6 +15,7 @@
   <constant name="Hcal_PCB_thickness" value="0.7*mm"/>
   <constant name="Hcal_scintillator_thickness" value="3.0*mm"/>
   <constant name="Hcal_cells_size" value="30*mm"/>
+  <constant name="Hcal_endcap_lateral_structure_thickness" value="5.0*mm"/>
   <constant name="Hcal_endcap_layer_air_gap" value="2.5*mm"/>
   <constant name="Hcal_endcap_nlayers" value="48"/> <!-- needed for ring only? -->
 

--- a/detector/calorimeter/SHcalSc04_Endcaps.cpp
+++ b/detector/calorimeter/SHcalSc04_Endcaps.cpp
@@ -91,7 +91,7 @@ static Ref_t create_detector(Detector& theDetector, xml_h element, SensitiveDete
  
   // The way to reaad constant from XML/Detector file.
   double      Hcal_radiator_thickness          = theDetector.constant<double>("Hcal_radiator_thickness");
-  double      Hcal_lateral_structure_thickness = theDetector.constant<double>("Hcal_lateral_structure_thickness");
+  double      Hcal_endcap_lateral_structure_thickness = theDetector.constant<double>("Hcal_endcap_lateral_structure_thickness");
   double      Hcal_endcap_layer_air_gap        = theDetector.constant<double>("Hcal_endcap_layer_air_gap");
 
   //double      Hcal_cells_size                  = theDetector.constant<double>("Hcal_cells_size");
@@ -229,13 +229,13 @@ static Ref_t create_detector(Detector& theDetector, xml_h element, SensitiveDete
 	DetElement  layer(stave_det,layer_name,det_id);
 	
 	// Active Layer box & volume
-	double active_layer_dim_x = box_half_x - Hcal_lateral_structure_thickness/2.0 - Hcal_endcap_layer_air_gap/2.0;
+	double active_layer_dim_x = box_half_x - Hcal_endcap_lateral_structure_thickness - Hcal_endcap_layer_air_gap;
 	double active_layer_dim_y = layer_thickness/2.0;
-	double active_layer_dim_z = box_half_z;// - Hcal_lateral_structure_thickness - Hcal_endcap_layer_air_gap;
+	double active_layer_dim_z = box_half_z;
 	
 	// Build chamber including air gap
 	// The Layer will be filled with slices, 
-	Volume layer_vol(layer_name, Box((active_layer_dim_x + Hcal_endcap_layer_air_gap/2.0),
+	Volume layer_vol(layer_name, Box((active_layer_dim_x + Hcal_endcap_layer_air_gap),
 					 active_layer_dim_y,active_layer_dim_z), air);
 
 	LayeredCalorimeterData::Layer caloLayer ;

--- a/detector/calorimeter/SHcalSc04_Endcaps_v01.cpp
+++ b/detector/calorimeter/SHcalSc04_Endcaps_v01.cpp
@@ -95,7 +95,7 @@ static Ref_t create_detector(Detector& theDetector, xml_h element, SensitiveDete
  
   // The way to reaad constant from XML/Detector file.
   double      Hcal_radiator_thickness          = theDetector.constant<double>("Hcal_radiator_thickness");
-  double      Hcal_lateral_structure_thickness = theDetector.constant<double>("Hcal_lateral_structure_thickness");
+  double      Hcal_endcap_lateral_structure_thickness = theDetector.constant<double>("Hcal_endcap_lateral_structure_thickness");
   double      Hcal_endcap_layer_air_gap        = theDetector.constant<double>("Hcal_endcap_layer_air_gap");
 
   //double      Hcal_cells_size                  = theDetector.constant<double>("Hcal_cells_size");
@@ -264,13 +264,13 @@ static Ref_t create_detector(Detector& theDetector, xml_h element, SensitiveDete
 	DetElement  layer(stave_det,layer_name,det_id);
 	
 	// Active Layer box & volume
-	double active_layer_dim_x = box_half_x - Hcal_lateral_structure_thickness/2.0 - Hcal_endcap_layer_air_gap/2.0;
+	double active_layer_dim_x = box_half_x - Hcal_endcap_lateral_structure_thickness - Hcal_endcap_layer_air_gap;
 	double active_layer_dim_y = box_half_y;
 	double active_layer_dim_z = layer_thickness/2.0;
 	
 	// Build chamber including air gap
 	// The Layer will be filled with slices, 
-	Volume layer_vol(layer_name, Box((active_layer_dim_x + Hcal_endcap_layer_air_gap/2.0),
+	Volume layer_vol(layer_name, Box((active_layer_dim_x + Hcal_endcap_layer_air_gap),
 					 active_layer_dim_y,active_layer_dim_z), air);
 
 


### PR DESCRIPTION




BEGINRELEASENOTES
- Added one independent parameter "Hcal_endcap_lateral_structure_thickness"
    - to make Hcal endcap more flexible.
    - tower: |5mm|2.5mm|360mm|2.5mm|5mm|
    - tower: |LateralStructure|AirGap|Active(HBU)|AirGap|LateralStructure|
    - user may update them from compact file.

ENDRELEASENOTES