### PR TITLE
Change the names of original SimCalorimeterHit collections of SDHCAL to the same ones as introduced by hybrid models, i.e. to HCalBarrelRPCHits, HCalEndcapRPCHits,HCalECRingRPCHits.…

### DIFF
--- a/ILD/compact/ILD_common_v02/Hcal_Barrel_SD_v01.xml
+++ b/ILD/compact/ILD_common_v02/Hcal_Barrel_SD_v01.xml
@@ -1,7 +1,7 @@
 <lccdd>
 
   <detectors>
-    <detector name="HcalBarrel" type="Hcal_Barrel_SD_v01" id="ILDDetID_HCAL" readout="HcalBarrelRegCollection" vis="GreenVis" insideTrackingVolume="false" >
+    <detector name="HcalBarrel" type="Hcal_Barrel_SD_v01" id="ILDDetID_HCAL" readout="HCalBarrelRPCHits" vis="GreenVis" insideTrackingVolume="false" >
       <comment>Hadron Calorimeter Barrel</comment>
 
       <envelope vis="ILD_HCALVis">
@@ -38,7 +38,7 @@
   </detectors>
 
   <readouts>
-    <readout name="HcalBarrelRegCollection">
+    <readout name="HCalBarrelRPCHits">
       <segmentation type="CartesianGridXY" grid_size_x="HcalSD_cells_size" grid_size_y="HcalSD_cells_size"/>
       <id>system:5,module:3,stave:3,tower:5,layer:6,slice:4,x:32:-16,y:-16</id>
     </readout>

--- a/ILD/compact/ILD_common_v02/Hcal_Barrel_SD_v02.xml
+++ b/ILD/compact/ILD_common_v02/Hcal_Barrel_SD_v02.xml
@@ -1,7 +1,7 @@
 <lccdd>
 
   <detectors>
-    <detector name="HcalBarrel" type="Hcal_Barrel_SD_v02" id="ILDDetID_HCAL" readout="HcalBarrelRegCollection" vis="GreenVis" insideTrackingVolume="false" >
+    <detector name="HcalBarrel" type="Hcal_Barrel_SD_v02" id="ILDDetID_HCAL" readout="HCalBarrelRPCHits" vis="GreenVis" insideTrackingVolume="false" >
       <comment>Hadron Calorimeter Barrel</comment>
 
       <envelope vis="ILD_HCALVis">
@@ -38,7 +38,7 @@
   </detectors>
 
   <readouts>
-    <readout name="HcalBarrelRegCollection">
+    <readout name="HCalBarrelRPCHits">
       <segmentation type="CartesianGridXY" grid_size_x="HcalSD_cells_size" grid_size_y="HcalSD_cells_size"/>
       <id>system:5,module:3,stave:3,tower:5,layer:6,slice:4,x:32:-16,y:-16</id>
     </readout>

--- a/ILD/compact/ILD_common_v02/Hcal_EndcapRing_SD_v01.xml
+++ b/ILD/compact/ILD_common_v02/Hcal_EndcapRing_SD_v01.xml
@@ -1,7 +1,7 @@
 <lccdd>
 
   <detectors>
-    <detector name="HcalRing" type="Hcal_EndcapRing_SD_v01" id="ILDDetID_HCAL_RING" readout="HcalEndcapRingCollection" vis="SeeThrough" insideTrackingVolume="false" >
+    <detector name="HcalRing" type="Hcal_EndcapRing_SD_v01" id="ILDDetID_HCAL_RING" readout="HCalECRingRPCHits" vis="SeeThrough" insideTrackingVolume="false" >
       <comment>Hadron Calorimeter EndcapRing</comment>
 
       <envelope vis="ILD_HCALVis">
@@ -46,7 +46,7 @@
   </detectors>
 
   <readouts>
-    <readout name="HcalEndcapRingCollection">
+    <readout name="HCalECRingRPCHits">
       <segmentation type="CartesianGridXY" grid_size_x="HcalSD_cells_size" grid_size_y="HcalSD_cells_size"/>
       <id>system:5,module:3,stave:4,tower:3,layer:6,x:32:-16,y:-16</id>
     </readout>

--- a/ILD/compact/ILD_common_v02/Hcal_Endcaps_SD_v01.xml
+++ b/ILD/compact/ILD_common_v02/Hcal_Endcaps_SD_v01.xml
@@ -1,7 +1,7 @@
 <lccdd>
 
 <detectors>
-<detector id="ILDDetID_HCAL_ENDCAP" name="HcalEndcap" type="Hcal_Endcaps_SD_v01" readout="HcalEndcapsCollection"  vis="SeeThrough" calorimeterType="HAD_ENDCAP">
+<detector id="ILDDetID_HCAL_ENDCAP" name="HcalEndcap" type="Hcal_Endcaps_SD_v01" readout="HCalEndcapRPCHits"  vis="SeeThrough" calorimeterType="HAD_ENDCAP">
  <comment>Hadron Calorimeter Endcap</comment>
 
 
@@ -44,7 +44,7 @@
 </detectors>
 
 <readouts>
-  <readout name="HcalEndcapsCollection">
+  <readout name="HCalEndcapRPCHits">
     <segmentation type="CartesianGridXY" grid_size_x="HcalSD_cells_size" grid_size_y="HcalSD_cells_size" offset_x="HcalSD_cells_size/2.0" offset_y="HcalSD_cells_size/2.0" />
     <id>system:5,module:3,stave:3,tower:5,layer:6,x:32:-16,y:-16</id>
   </readout>

--- a/ILD/compact/ILD_common_v02/Hcal_Endcaps_SD_v02.xml
+++ b/ILD/compact/ILD_common_v02/Hcal_Endcaps_SD_v02.xml
@@ -2,7 +2,7 @@
 
 <detectors>
 
-<detector id="ILDDetID_HCAL_ENDCAP" name="HcalEndcap" type="Hcal_Endcaps_SD_v02" readout="HcalEndcapsCollection"  vis="SeeThrough" calorimeterType="HAD_ENDCAP">
+<detector id="ILDDetID_HCAL_ENDCAP" name="HcalEndcap" type="Hcal_Endcaps_SD_v02" readout="HCalEndcapRPCHits"  vis="SeeThrough" calorimeterType="HAD_ENDCAP">
  <comment>Hadron Calorimeter Endcap</comment>
  <envelope vis="ILD_HCALVis">
        <shape type="BooleanShape" operation="Subtraction" material="Air">
@@ -54,7 +54,7 @@
 </detectors>
 
 <readouts>
-  <readout name="HcalEndcapsCollection">
+  <readout name="HCalEndcapRPCHits">
     <segmentation type="CartesianGridXY" grid_size_x="HcalSD_cells_size" grid_size_y="HcalSD_cells_size" offset_x="HcalSD_cells_size/2.0" offset_y="HcalSD_cells_size/2.0" />
     <id>system:5,module:3,stave:3,tower:5,layer:6,x:32:-16,y:-16</id>
   </readout>

--- a/ILD/compact/ILD_common_v02/Hcal_Endcaps_SD_v02_SMALL.xml
+++ b/ILD/compact/ILD_common_v02/Hcal_Endcaps_SD_v02_SMALL.xml
@@ -2,7 +2,7 @@
 
 <detectors>
 
-<detector id="ILDDetID_HCAL_ENDCAP" name="HcalEndcap" type="Hcal_Endcaps_SD_v02" readout="HcalEndcapsCollection"  vis="SeeThrough" calorimeterType="HAD_ENDCAP">
+<detector id="ILDDetID_HCAL_ENDCAP" name="HcalEndcap" type="Hcal_Endcaps_SD_v02" readout="HCalEndcapRPCHits"  vis="SeeThrough" calorimeterType="HAD_ENDCAP">
  <comment>Hadron Calorimeter Endcap</comment>
  <envelope vis="ILD_HCALVis">
        <shape type="BooleanShape" operation="Subtraction" material="Air">
@@ -53,7 +53,7 @@
 </detectors>
 
 <readouts>
-  <readout name="HcalEndcapsCollection">
+  <readout name="HCalEndcapRPCHits">
     <segmentation type="CartesianGridXY" grid_size_x="HcalSD_cells_size" grid_size_y="HcalSD_cells_size" offset_x="HcalSD_cells_size/2.0" offset_y="HcalSD_cells_size/2.0" />
     <id>system:5,module:3,stave:3,tower:5,layer:6,x:32:-16,y:-16</id>
   </readout>


### PR DESCRIPTION
BEGINRELEASENOTES
- update ILD models w/ SDHcal:
       - change the names of original SimCalorimeterHit collections of SDHCAL to the same ones as introduced in hybrid models, i.e. HCalBarrelRPCHits, HCalEndcapRPCHits,HCalECRingRPCHits

ENDRELEASENOTES