### PR TITLE
Improve DDSim defaults

### DIFF
--- a/DDSim/DDSim/Helper/MagneticField.py
+++ b/DDSim/DDSim/Helper/MagneticField.py
@@ -6,12 +6,12 @@ class MagneticField( ConfigHelper ):
   """Configuration for the magnetic field (stepper)"""
   def __init__( self ):
     super(MagneticField, self).__init__()
-    self.stepper = "HelixSimpleRunge"
+    self.stepper = "G4ClassicalRK4"
     self.equation = "Mag_UsualEqRhs"
     self.eps_min = 5e-05*mm
     self.eps_max = 0.001*mm
     self.min_chord_step = 0.01*mm
     self.delta_chord = 0.25*mm
-    self.delta_intersection = 1e-05*mm
-    self.delta_one_step = 1e-04*mm
+    self.delta_intersection = 0.001*mm
+    self.delta_one_step = 0.01*mm
     self.largest_step = 10*m


### PR DESCRIPTION
BEGINRELEASENOTES
- Set DDSim defaults to Geant4 defaults and retain `largest_step = 10 * m` as recommended in the Geant4 manual (~ detector size). This improves simulation time for single muons approximately a factor 2 and for single pi+ for 25%

ENDRELEASENOTES

I have made a comparison between what @gaede recommended in AIDASoft/DD4hep#266

```py
SIM.field.delta_chord = 1e-05
SIM.field.delta_intersection = 1e-05
SIM.field.delta_one_step = .5e-03*mm
SIM.field.eps_max = 1e-04
SIM.field.eps_min = 1e-05
SIM.field.equation = "Mag_UsualEqRhs"
SIM.field.largest_step = 10.*m
SIM.field.min_chord_step = 1.e-2*mm
SIM.field.stepper = "HelixSimpleRunge"
```

and the values in this PR. For simulating 10k single muon events I need 13m with the ILD config and 7m with the new defaults. 