### PR TITLE
Update delta_chord of MagneticField.py

### DIFF
--- a/DDSim/DDSim/Helper/MagneticField.py
+++ b/DDSim/DDSim/Helper/MagneticField.py
@@ -11,7 +11,7 @@ class MagneticField( ConfigHelper ):
     self.eps_min = 5e-05*mm
     self.eps_max = 0.001*mm
     self.min_chord_step = 0.01*mm
-    self.delta_chord = 0.25*mm
+    self.delta_chord = 0.025*mm
     self.delta_intersection = 0.001*mm
     self.delta_one_step = 0.01*mm
     self.largest_step = 10*m


### PR DESCRIPTION
When running ddsim, there is a serious error that the SiD Optimization Group has encountered that prevents any simulation from completing successfully.

The error is:
 
-------- EEEE ------- G4Exception-START -------- EEEE -------
*** G4Exception : GeomNav0003
      issued by : G4PropagatorInField::ComputeStep()
Curve length mis-match between original state and proposed endpoint of propagation.
  The curve length of the endpoint should be: 5.5556
  and it is instead: 5.57737.
  A difference of: -0.0217712
  Original state =  (  X= -1555.27986 2054.74222 -340.167973  P= 0.188818107 -0.00981737627 0.0186048752  Pmag= 0.189986315 Ekin= 0.034175086 l= 0 m0= 0.510999 (Pdir-1)= 0 t_lab= 11.8935 t_proper= 0 PolV= (0,0,0)  )
  Proposed state =  (  X= -1555.27705 2054.7421 -339.621795  P= 0.188990046 -0.00560544107 0.0186048752  Pmag= 0.189986315 Ekin= 0.034175086 l= 5.57737210176 m0= 0.510999 (Pdir-1)= 0 t_lab= 0 t_proper= 0 PolV= (0,0,0)  )
*** Fatal Exception *** core dump ***
-------- EEEE -------- G4Exception-END --------- EEEE -------
 
 
*** G4Exception: Aborting execution ***
Aborted (core dumped)
 
This error usually happens after one or more of the following warnings:
 
 
-------- WWWW ------- G4Exception-START -------- WWWW -------
*** G4Exception : GeomField0003
      issued by : G4ChordFinder::FindNextChord()
Exceeded maximum number of trials= 75
Current sagita dist= 0.252272
Step sizes (actual and proposed):
Last trial =         0.891419
Next trial =         0.869648
Proposed for chord = 0.869648
 
*** This is just a warning message. ***
-------- WWWW -------- G4Exception-END --------- WWWW -------
 
The steps to produce this error are as follows (on an SLC6 machine with CVMFS):
 
git clone https://github.com/iLCSoft/lcgeo.git
cd lcgeo
mkdir build 
cd build
source /cvmfs/ilc.desy.de/sw/x86_64_gcc49_sl6/v01-19-05/init_ilcsoft.sh
cmake -DCMAKE_CXX_COMPILER=`which g++` -DCMAKE_C_COMPILER=`which gcc` -C $ILCSOFT/ILCSoft.cmake ..
make -w -j4 install
cd example/
export PYTHONPATH=${LCIO}/src/python:${ROOTSYS}/lib:$PYTHONPATH
python lcio_particle_gun.py
ddsim --compactFile ../SiD/compact/SiD_o3_v02/SiD_o3_v02.xml --inputFiles mcparticles.slcio -N 1000 --outputFile simple_lcio.slcio
 
Looking into what the cause of this error might be, when we switched from v01-19-04 to v01-19-05 we changed Geant4 versions from 10.02.p02 to 10.03.p02.
 
There are two seemingly relevant changes between these two versions:
 
G4PropagatorInField: fix to pass accuracy values to Intersection Locator after re-evaluating epsilon.
G4Navigator: in ComputeStep() force abortion of event if track gets really stuck, but avoid check for overlaps if push-verbosity is set to false. Extended printout for stuck tracks, to show also local coordinates.
 
If there was a bug previously that prevented accuracy values from being passed, and that bug is now fixed, then that might be why we're all of a sudden seeing this error when we've never seen it before, though this is a guess at the cause of this error.

The error occurs independent of input particle type, momenta, or theta/phi.

Research into past occurrences of this error revealed that this may happen due to the presence of our high magnetic field. After investigating the Geant4 code responsible for producing this error, we decreased the value of delta_chord by an order of magnitude, and the error has not reoccurred (though we have had one instance of the warning occurring, we do not believe it to be malignant).

It is our assumption that this change will not result in any detrimental effects besides a possible increase in computational intensity, but our simulations performed since making this change have not demonstrated any increased time to run the simulation as compared to before the change.

However, we would appreciate the opinions of @andresailer @gaede and Akiya Miyamoto on the appropriateness of this change or any other suggestions.



BEGINRELEASENOTES
- Decrease in value of delta_chord from 0.25*mm to 0.025*mm needed due to updated Geant4 version in ILCSoft v01-19-05 fixing a bug which propagated an accuracy error.
ENDRELEASENOTES