### PR TITLE
 Update ILD AHCAL collection name and ID in ILD_common_v02.

### DIFF
--- a/ILD/compact/ILD_common_v02/SHcalSc04_Barrel_v01.xml
+++ b/ILD/compact/ILD_common_v02/SHcalSc04_Barrel_v01.xml
@@ -2,7 +2,7 @@
 
 <lccdd>
   <detectors>
-    <detector name="HcalBarrel" type="SHcalSc04_Barrel_v01" id="ILDDetID_HCAL" readout="HcalBarrelRegCollection" vis="GreenVis" insideTrackingVolume="false" >
+    <detector name="HcalBarrel" type="SHcalSc04_Barrel_v01" id="ILDDetID_HCAL" readout="HCalBarrelScHits" vis="GreenVis" insideTrackingVolume="false" >
       <comment>Hadron Calorimeter Barrel</comment>
 
       <envelope vis="ILD_HCALVis">
@@ -30,7 +30,7 @@
   </detectors>
 
   <readouts>
-    <readout name="HcalBarrelRegCollection">
+    <readout name="HCalBarrelScHits">
       <segmentation type="TiledLayerGridXY" grid_size_x="3" grid_size_y="3.03248"/>
       <id>system:5,module:3,stave:4,tower:5,layer:6,x:32:-16,y:-16</id>
     </readout>

--- a/ILD/compact/ILD_common_v02/SHcalSc04_Barrel_v04.xml
+++ b/ILD/compact/ILD_common_v02/SHcalSc04_Barrel_v04.xml
@@ -40,7 +40,7 @@
       </segmentation>
       <hits_collections>
         <hits_collection name="HCalBarrelRPCHits"  key="slice" key_value="1"/>
-        <hits_collection name="HcalBarrelRegCollection"  key="slice" key_value="3"/>
+        <hits_collection name="HCalBarrelScHits"  key="slice" key_value="3"/>
       </hits_collections>
       <id>system:5,module:3,stave:4,tower:5,layer:6,slice:4,x:32:-16,y:-16</id>
     </readout>

--- a/ILD/compact/ILD_common_v02/SHcalSc04_EndcapRing.xml
+++ b/ILD/compact/ILD_common_v02/SHcalSc04_EndcapRing.xml
@@ -2,7 +2,7 @@
 
 <lccdd>
   <detectors>
-    <detector name="HcalRing" type="SHcalSc04_EndcapRing" id="ILDDetID_HCAL_RING" readout="HcalEndcapRingCollection" vis="GreenVis" insideTrackingVolume="false" >
+    <detector name="HcalRing" type="SHcalSc04_EndcapRing" id="ILDDetID_HCAL_RING" readout="HCalECRingScHits" vis="GreenVis" insideTrackingVolume="false" >
       <comment>Hadron Calorimeter EndcapRing</comment>
 
       <envelope vis="ILD_HCALVis">
@@ -40,9 +40,9 @@
   </detectors>
 
   <readouts>
-    <readout name="HcalEndcapRingCollection">
+    <readout name="HCalECRingScHits">
       <segmentation type="CartesianGridXY" grid_size_x="Hcal_cells_size" grid_size_y="Hcal_cells_size"/>
-      <id>system:5,module:3,stave:4,tower:3,layer:6,x:32:-16,y:-16</id>
+      <id>system:5,module:3,stave:4,tower:5,layer:6,x:32:-16,y:-16</id>
     </readout>
   </readouts>
 

--- a/ILD/compact/ILD_common_v02/SHcalSc04_EndcapRing_v01.xml
+++ b/ILD/compact/ILD_common_v02/SHcalSc04_EndcapRing_v01.xml
@@ -47,9 +47,9 @@
       </segmentation>
       <hits_collections>
         <hits_collection name="HCalECRingRPCHits"  key="slice" key_value="1"/>
-        <hits_collection name="HcalEndcapRingCollection"  key="slice" key_value="3"/>
+        <hits_collection name="HCalECRingScHits"  key="slice" key_value="3"/>
       </hits_collections>
-      <id>system:5,module:3,stave:4,tower:3,layer:6,slice:4,x:32:-16,y:-16</id>
+      <id>system:5,module:3,stave:4,tower:5,layer:6,slice:4,x:32:-16,y:-16</id>
     </readout>
   </readouts>
 

--- a/ILD/compact/ILD_common_v02/SHcalSc04_Endcaps_LARGE.xml
+++ b/ILD/compact/ILD_common_v02/SHcalSc04_Endcaps_LARGE.xml
@@ -2,7 +2,7 @@
 
 <lccdd>
   <detectors>
-    <detector id="ILDDetID_HCAL_ENDCAP" name="HcalEndcap" type="SHcalSc04_Endcaps" readout="HcalEndcapsCollection"  vis="GreenVis" calorimeterType="HAD_ENDCAP">
+    <detector id="ILDDetID_HCAL_ENDCAP" name="HcalEndcap" type="SHcalSc04_Endcaps" readout="HCalEndcapScHits"  vis="GreenVis" calorimeterType="HAD_ENDCAP">
       <comment>Hadron Calorimeter Endcap</comment>
 
       <envelope vis="ILD_HCALVis">
@@ -53,9 +53,9 @@
   </detectors>
 
   <readouts>
-    <readout name="HcalEndcapsCollection">
+    <readout name="HCalEndcapScHits">
       <segmentation type="CartesianGridXZ" grid_size_x="Hcal_cells_size" grid_size_z="Hcal_cells_size" offset_x="Hcal_cells_size/2.0" offset_z="Hcal_cells_size/2.0" />
-      <id>system:5,module:3,stave:3,tower:5,layer:6,x:32:-16,z:-16</id>
+      <id>system:5,module:3,stave:4,tower:5,layer:6,x:32:-16,z:-16</id>
     </readout>
   </readouts>
 

--- a/ILD/compact/ILD_common_v02/SHcalSc04_Endcaps_SMALL.xml
+++ b/ILD/compact/ILD_common_v02/SHcalSc04_Endcaps_SMALL.xml
@@ -2,7 +2,7 @@
 
 <lccdd>
   <detectors>
-    <detector id="ILDDetID_HCAL_ENDCAP" name="HcalEndcap" type="SHcalSc04_Endcaps" readout="HcalEndcapsCollection"  vis="GreenVis" calorimeterType="HAD_ENDCAP">
+    <detector id="ILDDetID_HCAL_ENDCAP" name="HcalEndcap" type="SHcalSc04_Endcaps" readout="HCalEndcapScHits"  vis="GreenVis" calorimeterType="HAD_ENDCAP">
       <comment>Hadron Calorimeter Endcap</comment>
 
       <envelope vis="ILD_HCALVis">
@@ -52,9 +52,9 @@
   </detectors>
 
   <readouts>
-    <readout name="HcalEndcapsCollection">
+    <readout name="HCalEndcapScHits">
       <segmentation type="CartesianGridXZ" grid_size_x="Hcal_cells_size" grid_size_z="Hcal_cells_size" offset_x="Hcal_cells_size/2.0" offset_z="Hcal_cells_size/2.0" />
-      <id>system:5,module:3,stave:3,tower:5,layer:6,x:32:-16,z:-16</id>
+      <id>system:5,module:3,stave:4,tower:5,layer:6,x:32:-16,z:-16</id>
     </readout>
   </readouts>
 

--- a/ILD/compact/ILD_common_v02/SHcalSc04_Endcaps_v01_LARGE.xml
+++ b/ILD/compact/ILD_common_v02/SHcalSc04_Endcaps_v01_LARGE.xml
@@ -60,9 +60,9 @@
       </segmentation>
       <hits_collections>
         <hits_collection name="HCalEndcapRPCHits"  key="slice" key_value="1"/>
-        <hits_collection name="HcalEndcapsCollection"  key="slice" key_value="3"/>
+        <hits_collection name="HCalEndcapScHits"  key="slice" key_value="3"/>
       </hits_collections>
-      <id>system:5,module:3,stave:3,tower:5,layer:6,slice:4,x:32:-16,y:-16</id>
+      <id>system:5,module:3,stave:4,tower:5,layer:6,slice:4,x:32:-16,y:-16</id>
     </readout>
   </readouts>
 

--- a/ILD/compact/ILD_common_v02/SHcalSc04_Endcaps_v01_SMALL.xml
+++ b/ILD/compact/ILD_common_v02/SHcalSc04_Endcaps_v01_SMALL.xml
@@ -58,9 +58,9 @@
       </segmentation>
       <hits_collections>
         <hits_collection name="HCalEndcapRPCHits"  key="slice" key_value="1"/>
-        <hits_collection name="HcalEndcapsCollection"  key="slice" key_value="3"/>
+        <hits_collection name="HCalEndcapScHits"  key="slice" key_value="3"/>
       </hits_collections>
-      <id>system:5,module:3,stave:3,tower:5,layer:6,slice:4,x:32:-16,y:-16</id>
+      <id>system:5,module:3,stave:4,tower:5,layer:6,slice:4,x:32:-16,y:-16</id>
     </readout>
   </readouts>
 


### PR DESCRIPTION

BEGINRELEASENOTES
- Update ILD AHCAL collection name and ID in ILD_common_v02.
    - to used the same name convention for the hybird ILD HCAL:
         - HCalBarrelRPCHits
         - HCalBarrelScHits
         - HCalEndcapRPCHits
         - HCalEndcapScHits
         - HCalECRingRPCHits
         - HCalECRingScHits
    - to use the identical ID for the hybird ILD HCAL Barrel, Endcap, ECRing:
         - <id>system:5,module:3,stave:4,tower:5,layer:6,x:32:-16,y:-16</id>

ENDRELEASENOTES