### PR TITLE
ddsim: print start up and time per event

### DIFF
--- a/DDSim/DDSim/DD4hepSimulation.py
+++ b/DDSim/DDSim/DD4hepSimulation.py
@@ -492,12 +492,18 @@ class DD4hepSimulation(object):
 
     #DDG4.setPrintLevel(Output.DEBUG)
 
+    startUpTime, _sysTime, _cuTime, _csTime, _elapsedTime = os.times()
+
     kernel.run()
     kernel.terminate()
 
-    userTime, sysTime,_cuTime, _csTime, _elapsedTime = os.times()
+    totalTimeUser, totalTimeSys, _cuTime, _csTime, _elapsedTime = os.times()
     if self.printLevel <= 3:
-      print "DDSim            INFO  Execution Time: %3.2f s (User), %3.2f s (System)"% (userTime, sysTime)
+      eventTime = totalTimeUser - startUpTime
+      perEventTime =  eventTime / float(self.numberOfEvents)
+      print "DDSim            INFO  Total Time:   %3.2f s (User), %3.2f s (System)"% (totalTimeUser, totalTimeSys)
+      print "DDSim            INFO  StartUp Time: %3.2f s, Event Processing: %3.2f s (%3.2f s/Event) " \
+        % (startUpTime, eventTime, perEventTime)
 
 
   def __setMagneticFieldOptions(self, simple):


### PR DESCRIPTION

BEGINRELEASENOTES
- DDSim: Print the startUp and event processing time separately in addition to total runtime

ENDRELEASENOTES
E.g.:
```
DDSim            INFO  Total Execution Time: 8.94 s (User), 0.37 s (System)
DDSim            INFO  StartUp Time: 4.68 s, Event Processing: 4.26 s (0.43 s/Event)
```