### PR TITLE
ILD_?5_v02 models: move max step limit definitions to common directory

### DIFF
--- a/ILD/compact/ILD_common_v02/limits.xml
+++ b/ILD/compact/ILD_common_v02/limits.xml
@@ -1,0 +1,11 @@
+<define>
+  <constant name="cal_steplimit_val" value="5.0"/>
+  <constant name="cal_steplimit_unit" value="mm"/>
+
+  <constant name="tpc_steplimit_val" value="10.0"/>
+  <constant name="tpc_steplimit_unit" value="mm"/>
+
+  <constant name="tracker_steplimit_val" value="5.0"/>
+  <constant name="tracker_steplimit_unit" value="mm"/>
+</define>
+

--- a/ILD/compact/ILD_l5_v02/ILD_l5_o1_v02.xml
+++ b/ILD/compact/ILD_l5_v02/ILD_l5_o1_v02.xml
@@ -31,6 +31,7 @@
     <include ref="../ILD_common_v02/yoke_defs.xml"/>
     <include ref="../ILD_common_v02/services_defs.xml"/>
     <include ref="${DD4hepINSTALL}/DDDetectors/compact/detector_types.xml"/>
+    <include ref="../ILD_common_v02/limits.xml"/>
 
     <!-- Readout slice in ecal for reconstruction (SiWEcal) -->
     <constant name="Ecal_readout_segmentation_slice0" value="4"/>
@@ -38,18 +39,17 @@
     <!-- Readout slice in hcal for reconstruction (AHcal) -->
     <constant name="Hcal_readout_segmentation_slice" value="3"/>
 
-
   </define>
 
   <limits>
     <limitset name="cal_limits">
-      <limit name="step_length_max" particles="*" value="5.0" unit="mm" />
+      <limit name="step_length_max" particles="*" value="cal_steplimit_val" unit="cal_steplimit_unit" />
     </limitset>
     <limitset name="TPC_limits">
-      <limit name="step_length_max" particles="*" value="10.0" unit="mm" />
+      <limit name="step_length_max" particles="*" value="tpc_steplimit_val" unit="tpc_steplimit_unit" />
     </limitset>
     <limitset name="Tracker_limits">
-      <limit name="step_length_max" particles="*" value="5.0" unit="mm" />
+      <limit name="step_length_max" particles="*" value="tracker_steplimit_val" unit="tracker_steplimit_unit" />
     </limitset>
   </limits>
 

--- a/ILD/compact/ILD_l5_v02/ILD_l5_o2_v02.xml
+++ b/ILD/compact/ILD_l5_v02/ILD_l5_o2_v02.xml
@@ -31,6 +31,7 @@
     <include ref="../ILD_common_v02/yoke_defs.xml"/>
     <include ref="../ILD_common_v02/services_defs.xml"/>
     <include ref="${DD4hepINSTALL}/DDDetectors/compact/detector_types.xml"/>
+    <include ref="../ILD_common_v02/limits.xml"/>
 
     <!-- Readout slice in ecal for reconstruction (SiWEcal) -->
     <constant name="Ecal_readout_segmentation_slice0" value="4"/>
@@ -38,18 +39,17 @@
     <!-- Readout slice in hcal for reconstruction (SDHCAL) -->
     <constant name="Hcal_readout_segmentation_slice" value="1"/>
 
-
   </define>
 
   <limits>
     <limitset name="cal_limits">
-      <limit name="step_length_max" particles="*" value="5.0" unit="mm" />
+      <limit name="step_length_max" particles="*" value="cal_steplimit_val" unit="cal_steplimit_unit" />
     </limitset>
     <limitset name="TPC_limits">
-      <limit name="step_length_max" particles="*" value="10.0" unit="mm" />
+      <limit name="step_length_max" particles="*" value="tpc_steplimit_val" unit="tpc_steplimit_unit" />
     </limitset>
     <limitset name="Tracker_limits">
-      <limit name="step_length_max" particles="*" value="5.0" unit="mm" />
+      <limit name="step_length_max" particles="*" value="tracker_steplimit_val" unit="tracker_steplimit_unit" />
     </limitset>
   </limits>
 

--- a/ILD/compact/ILD_l5_v02/ILD_l5_o3_v02.xml
+++ b/ILD/compact/ILD_l5_v02/ILD_l5_o3_v02.xml
@@ -31,6 +31,7 @@
     <include ref="../ILD_common_v02/yoke_defs.xml"/>
     <include ref="../ILD_common_v02/services_defs.xml"/>
     <include ref="${DD4hepINSTALL}/DDDetectors/compact/detector_types.xml"/>
+    <include ref="../ILD_common_v02/limits.xml"/>
 
     <!-- Readout slice in ecal for reconstruction (ScEcal) -->
     <constant name="Ecal_readout_segmentation_slice0" value="3"/>
@@ -38,18 +39,17 @@
     <!-- Readout slice in hcal for reconstruction (AHcal) -->
     <constant name="Hcal_readout_segmentation_slice" value="3"/>
 
-
   </define>
 
   <limits>
     <limitset name="cal_limits">
-      <limit name="step_length_max" particles="*" value="5.0" unit="mm" />
+      <limit name="step_length_max" particles="*" value="cal_steplimit_val" unit="cal_steplimit_unit" />
     </limitset>
     <limitset name="TPC_limits">
-      <limit name="step_length_max" particles="*" value="10.0" unit="mm" />
+      <limit name="step_length_max" particles="*" value="tpc_steplimit_val" unit="tpc_steplimit_unit" />
     </limitset>
     <limitset name="Tracker_limits">
-      <limit name="step_length_max" particles="*" value="5.0" unit="mm" />
+      <limit name="step_length_max" particles="*" value="tracker_steplimit_val" unit="tracker_steplimit_unit" />
     </limitset>
   </limits>
 

--- a/ILD/compact/ILD_l5_v02/ILD_l5_o4_v02.xml
+++ b/ILD/compact/ILD_l5_v02/ILD_l5_o4_v02.xml
@@ -31,6 +31,7 @@
     <include ref="../ILD_common_v02/yoke_defs.xml"/>
     <include ref="../ILD_common_v02/services_defs.xml"/>
     <include ref="${DD4hepINSTALL}/DDDetectors/compact/detector_types.xml"/>
+    <include ref="../ILD_common_v02/limits.xml"/>
 
     <!-- Readout slice in ecal for reconstruction (ScEcal) -->
     <constant name="Ecal_readout_segmentation_slice0" value="3"/>
@@ -38,18 +39,17 @@
     <!-- Readout slice in hcal for reconstruction (SDHCAL) -->
     <constant name="Hcal_readout_segmentation_slice" value="1"/>
 
-
   </define>
 
   <limits>
     <limitset name="cal_limits">
-      <limit name="step_length_max" particles="*" value="5.0" unit="mm" />
+      <limit name="step_length_max" particles="*" value="cal_steplimit_val" unit="cal_steplimit_unit" />
     </limitset>
     <limitset name="TPC_limits">
-      <limit name="step_length_max" particles="*" value="10.0" unit="mm" />
+      <limit name="step_length_max" particles="*" value="tpc_steplimit_val" unit="tpc_steplimit_unit" />
     </limitset>
     <limitset name="Tracker_limits">
-      <limit name="step_length_max" particles="*" value="5.0" unit="mm" />
+      <limit name="step_length_max" particles="*" value="tracker_steplimit_val" unit="tracker_steplimit_unit" />
     </limitset>
   </limits>
 

--- a/ILD/compact/ILD_l5_v02/ILD_l5_v02.xml
+++ b/ILD/compact/ILD_l5_v02/ILD_l5_v02.xml
@@ -31,6 +31,7 @@
     <include ref="../ILD_common_v02/yoke_defs.xml"/>
     <include ref="../ILD_common_v02/services_defs.xml"/>
     <include ref="${DD4hepINSTALL}/DDDetectors/compact/detector_types.xml"/>
+    <include ref="../ILD_common_v02/limits.xml"/>
 
     <!-- Readout slice in ecal for reconstruction -->
     <constant name="Ecal_readout_segmentation_slice0" value="4"/>
@@ -38,18 +39,17 @@
     <!-- Readout slice in hcal for reconstruction -->
     <constant name="Hcal_readout_segmentation_slice" value="3"/>
 
-
   </define>
 
   <limits>
     <limitset name="cal_limits">
-      <limit name="step_length_max" particles="*" value="5.0" unit="mm" />
+      <limit name="step_length_max" particles="*" value="cal_steplimit_val" unit="cal_steplimit_unit" />
     </limitset>
     <limitset name="TPC_limits">
-      <limit name="step_length_max" particles="*" value="10.0" unit="mm" />
+      <limit name="step_length_max" particles="*" value="tpc_steplimit_val" unit="tpc_steplimit_unit" />
     </limitset>
     <limitset name="Tracker_limits">
-      <limit name="step_length_max" particles="*" value="5.0" unit="mm" />
+      <limit name="step_length_max" particles="*" value="tracker_steplimit_val" unit="tracker_steplimit_unit" />
     </limitset>
   </limits>
 

--- a/ILD/compact/ILD_s5_v02/ILD_s5_o1_v02.xml
+++ b/ILD/compact/ILD_s5_v02/ILD_s5_o1_v02.xml
@@ -31,6 +31,7 @@
     <include ref="../ILD_common_v02/yoke_defs.xml"/>
     <include ref="../ILD_common_v02/services_defs.xml"/>
     <include ref="${DD4hepINSTALL}/DDDetectors/compact/detector_types.xml"/>
+    <include ref="../ILD_common_v02/limits.xml"/>
 
     <!-- Readout slice in ecal for reconstruction (SiWEcal) -->
     <constant name="Ecal_readout_segmentation_slice0" value="4"/>
@@ -38,18 +39,17 @@
     <!-- Readout slice in hcal for reconstruction (AHcal) -->
     <constant name="Hcal_readout_segmentation_slice" value="3"/>
 
-
   </define>
 
   <limits>
     <limitset name="cal_limits">
-      <limit name="step_length_max" particles="*" value="5.0" unit="mm" />
+      <limit name="step_length_max" particles="*" value="cal_steplimit_val" unit="cal_steplimit_unit" />
     </limitset>
     <limitset name="TPC_limits">
-      <limit name="step_length_max" particles="*" value="10.0" unit="mm" />
+      <limit name="step_length_max" particles="*" value="tpc_steplimit_val" unit="tpc_steplimit_unit" />
     </limitset>
     <limitset name="Tracker_limits">
-      <limit name="step_length_max" particles="*" value="5.0" unit="mm" />
+      <limit name="step_length_max" particles="*" value="tracker_steplimit_val" unit="tracker_steplimit_unit" />
     </limitset>
   </limits>
 

--- a/ILD/compact/ILD_s5_v02/ILD_s5_o2_v02.xml
+++ b/ILD/compact/ILD_s5_v02/ILD_s5_o2_v02.xml
@@ -31,25 +31,24 @@
     <include ref="../ILD_common_v02/yoke_defs.xml"/>
     <include ref="../ILD_common_v02/services_defs.xml"/>
     <include ref="${DD4hepINSTALL}/DDDetectors/compact/detector_types.xml"/>
+    <include ref="../ILD_common_v02/limits.xml"/>
 
     <!-- Readout slice in ecal for reconstruction (SiWEcal) -->
     <constant name="Ecal_readout_segmentation_slice0" value="4"/>
     <constant name="Ecal_readout_segmentation_slice1" value="10"/>
     <!-- Readout slice in hcal for reconstruction (SDHCAL) -->
     <constant name="Hcal_readout_segmentation_slice" value="1"/>
-
-
   </define>
 
   <limits>
     <limitset name="cal_limits">
-      <limit name="step_length_max" particles="*" value="5.0" unit="mm" />
+      <limit name="step_length_max" particles="*" value="cal_steplimit_val" unit="cal_steplimit_unit" />
     </limitset>
     <limitset name="TPC_limits">
-      <limit name="step_length_max" particles="*" value="10.0" unit="mm" />
+      <limit name="step_length_max" particles="*" value="tpc_steplimit_val" unit="tpc_steplimit_unit" />
     </limitset>
     <limitset name="Tracker_limits">
-      <limit name="step_length_max" particles="*" value="5.0" unit="mm" />
+      <limit name="step_length_max" particles="*" value="tracker_steplimit_val" unit="tracker_steplimit_unit" />
     </limitset>
   </limits>
 

--- a/ILD/compact/ILD_s5_v02/ILD_s5_o3_v02.xml
+++ b/ILD/compact/ILD_s5_v02/ILD_s5_o3_v02.xml
@@ -31,6 +31,7 @@
     <include ref="../ILD_common_v02/yoke_defs.xml"/>
     <include ref="../ILD_common_v02/services_defs.xml"/>
     <include ref="${DD4hepINSTALL}/DDDetectors/compact/detector_types.xml"/>
+    <include ref="../ILD_common_v02/limits.xml"/>
 
     <!-- Readout slice in ecal for reconstruction (ScEcal) -->
     <constant name="Ecal_readout_segmentation_slice0" value="3"/>
@@ -38,18 +39,17 @@
     <!-- Readout slice in hcal for reconstruction (AHcal) -->
     <constant name="Hcal_readout_segmentation_slice" value="3"/>
 
-
   </define>
 
   <limits>
     <limitset name="cal_limits">
-      <limit name="step_length_max" particles="*" value="5.0" unit="mm" />
+      <limit name="step_length_max" particles="*" value="cal_steplimit_val" unit="cal_steplimit_unit" />
     </limitset>
     <limitset name="TPC_limits">
-      <limit name="step_length_max" particles="*" value="10.0" unit="mm" />
+      <limit name="step_length_max" particles="*" value="tpc_steplimit_val" unit="tpc_steplimit_unit" />
     </limitset>
     <limitset name="Tracker_limits">
-      <limit name="step_length_max" particles="*" value="5.0" unit="mm" />
+      <limit name="step_length_max" particles="*" value="tracker_steplimit_val" unit="tracker_steplimit_unit" />
     </limitset>
   </limits>
 

--- a/ILD/compact/ILD_s5_v02/ILD_s5_o4_v02.xml
+++ b/ILD/compact/ILD_s5_v02/ILD_s5_o4_v02.xml
@@ -31,6 +31,7 @@
     <include ref="../ILD_common_v02/yoke_defs.xml"/>
     <include ref="../ILD_common_v02/services_defs.xml"/>
     <include ref="${DD4hepINSTALL}/DDDetectors/compact/detector_types.xml"/>
+    <include ref="../ILD_common_v02/limits.xml"/>
 
     <!-- Readout slice in ecal for reconstruction (ScEcal) -->
     <constant name="Ecal_readout_segmentation_slice0" value="3"/>
@@ -38,18 +39,17 @@
     <!-- Readout slice in hcal for reconstruction (SDHCAL) -->
     <constant name="Hcal_readout_segmentation_slice" value="1"/>
 
-
   </define>
 
   <limits>
     <limitset name="cal_limits">
-      <limit name="step_length_max" particles="*" value="5.0" unit="mm" />
+      <limit name="step_length_max" particles="*" value="cal_steplimit_val" unit="cal_steplimit_unit" />
     </limitset>
     <limitset name="TPC_limits">
-      <limit name="step_length_max" particles="*" value="10.0" unit="mm" />
+      <limit name="step_length_max" particles="*" value="tpc_steplimit_val" unit="tpc_steplimit_unit" />
     </limitset>
     <limitset name="Tracker_limits">
-      <limit name="step_length_max" particles="*" value="5.0" unit="mm" />
+      <limit name="step_length_max" particles="*" value="tracker_steplimit_val" unit="tracker_steplimit_unit" />
     </limitset>
   </limits>
 

--- a/ILD/compact/ILD_s5_v02/ILD_s5_v02.xml
+++ b/ILD/compact/ILD_s5_v02/ILD_s5_v02.xml
@@ -31,6 +31,7 @@
     <include ref="../ILD_common_v02/yoke_defs.xml"/>
     <include ref="../ILD_common_v02/services_defs.xml"/>
     <include ref="${DD4hepINSTALL}/DDDetectors/compact/detector_types.xml"/>
+    <include ref="../ILD_common_v02/limits.xml"/>
 
     <!-- Readout slice in ecal for reconstruction -->
     <constant name="Ecal_readout_segmentation_slice0" value="4"/>
@@ -38,18 +39,17 @@
     <!-- Readout slice in hcal for reconstruction -->
     <constant name="Hcal_readout_segmentation_slice" value="3"/>
 
-
   </define>
 
   <limits>
     <limitset name="cal_limits">
-      <limit name="step_length_max" particles="*" value="5.0" unit="mm" />
+      <limit name="step_length_max" particles="*" value="cal_steplimit_val" unit="cal_steplimit_unit" />
     </limitset>
     <limitset name="TPC_limits">
-      <limit name="step_length_max" particles="*" value="10.0" unit="mm" />
+      <limit name="step_length_max" particles="*" value="tpc_steplimit_val" unit="tpc_steplimit_unit" />
     </limitset>
     <limitset name="Tracker_limits">
-      <limit name="step_length_max" particles="*" value="5.0" unit="mm" />
+      <limit name="step_length_max" particles="*" value="tracker_steplimit_val" unit="tracker_steplimit_unit" />
     </limitset>
   </limits>
 


### PR DESCRIPTION

BEGINRELEASENOTES
- to ensure that consistent maximum step lengths are used in all models, moved their definition to common directory
ENDRELEASENOTES