### PR TITLE
Minor corrections to SiD_o2_v03

### DIFF
--- a/SiD/compact/SiD_o2_v03/BeamCal_o2_v03.xml
+++ b/SiD/compact/SiD_o2_v03/BeamCal_o2_v03.xml
@@ -12,7 +12,7 @@
       
       <comment>SiD Beam Calorimeter</comment>
       
-      <type_flags type=" DetType_CALORIMETER + DetType_ELECTROMAGNETIC + DetType_ENDCAP + DetType_FORWARD + DetType_AUXILIARY "/>
+      <type_flags type=" DetType_CALORIMETER + DetType_ELECTROMAGNETIC + DetType_ENDCAP + DetType_FORWARD "/>
       
       <dimensions outer_r="BeamCal_rmax" inner_r="BeamCal_rmin" inner_z="BeamCal_zmin" outer_z="BeamCal_zmax" dz="BeamCal_dz"/>
       
@@ -24,6 +24,7 @@
 	</shape>
       </envelope>
       
+      <!-- this is not used with the above driver -->	    
       <beampipe crossing_angle="0.014" outgoing_r="15.5*mm" incoming_r="10.5*mm" />
       
       <layer repeat="50">

--- a/SiD/compact/SiD_o2_v03/BeamCal_o2_v03.xml
+++ b/SiD/compact/SiD_o2_v03/BeamCal_o2_v03.xml
@@ -14,7 +14,7 @@
       
       <type_flags type=" DetType_CALORIMETER + DetType_ELECTROMAGNETIC + DetType_ENDCAP + DetType_FORWARD "/>
       
-      <dimensions outer_r="BeamCal_rmax" inner_r="BeamCal_rmin" inner_z="BeamCal_zmin" outer_z="BeamCal_zmax" dz="BeamCal_dz"/>
+      <dimensions inner_r="BeamCal_rmin" outer_r="BeamCal_rmax" inner_z="BeamCal_zmin" outer_z="BeamCal_zmax"/>
       
       <!-- default envelope created by driver has no relation to this definition, needs update! -->
       <envelope vis="BeamCalVis">

--- a/SiD/compact/SiD_o2_v03/LumiCal_o2_v03.xml
+++ b/SiD/compact/SiD_o2_v03/LumiCal_o2_v03.xml
@@ -2,7 +2,7 @@
   
   <readouts>
     <readout name="LumiCalHits">
-      <segmentation type="CartesianGridXY" grid_size_x="ECal_cell_size" grid_size_y="ECal_cell_size" />
+      <segmentation type="CartesianGridXY" grid_size_x="LumiCal_cell_size" grid_size_y="LumiCal_cell_size" />
       <id>${GlobalCalorimeterReadoutID}</id>
     </readout>
   </readouts>

--- a/SiD/compact/SiD_o2_v03/SiD_o2_v03.xml
+++ b/SiD/compact/SiD_o2_v03/SiD_o2_v03.xml
@@ -124,7 +124,7 @@
     <constant name="MuonEndcap_end_angle" value="30.*deg" />
 
     <constant name="BeamCal_cell_size" value="3.5*mm"/>
-    <constant name="BeamCal_rmin" value="0.0*mm" />
+    <constant name="BeamCal_rmin" value="15.5*mm" />
     <constant name="BeamCal_rmax" value="129.6*mm" />
     <constant name="BeamCal_zmin" value="3039.0*mm" />
     <constant name="BeamCal_zmax" value="3399.0*mm" />


### PR DESCRIPTION
Minor corrections to SiD_o2_v03

BEGINRELEASENOTES
Minor corrections to SiD_o2_v03:
- Corrected LumiCal grid size parameters
- Added hole in the BeamCal (beam pipe parameters not used with the current driver)
- Removed DetType_AUXILIARY flag from BeamCal
- Removed some unused parameters

ENDRELEASENOTES