### PR TITLE
Adopt for cleaning of DD4hep

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,7 +37,7 @@ option(CMAKE_MACOSX_RPATH "Build with rpath on macos" ON)
 #++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 
-find_package(DD4hep REQUIRED COMPONENTS DDSegmentation DDRec DDG4 DDParsers)
+find_package(DD4hep REQUIRED COMPONENTS DDRec DDG4 DDParsers)
 dd4hep_set_compiler_flags()
 
 SET( DD4hep_REDUCED_COMPONENT ${DD4hep_COMPONENT_LIBRARIES} )


### PR DESCRIPTION
needed for AIDASoft/DD4hep#345
BEGINRELEASENOTES
- Fix for the removal of DDSurfaces which have been merged into DDRec 
  -  includes from `DDSurfaces` -> `DDRec`
  - namespace `DDSurfaces` -> `dd4hep::rec`

ENDRELEASENOTES