### PR TITLE
ILD: missing file for small model's anti-DID map

### DIFF
--- a/ILD/compact/ILD_common_v02/Field_AntiDID_Map_s.xml
+++ b/ILD/compact/ILD_common_v02/Field_AntiDID_Map_s.xml
@@ -1,0 +1,1 @@
+Field_AntiDID_Map_l.xml


### PR DESCRIPTION
The anti-DID for small models was missing from my last PR.
This PR assumes that we should be using the same anti-DID map for large and small ILD models.
I guess this is a reasonable assumption?

BEGINRELEASENOTES
- apply anti-DID field map to small ILD models. (assume same anti-DID field as for large models)
ENDRELEASENOTES