### PR TITLE
revert https://github.com/iLCSoft/lcgeo/pull/219

### DIFF
--- a/DDSim/DDSim/DD4hepSimulation.py
+++ b/DDSim/DDSim/DD4hepSimulation.py
@@ -279,12 +279,12 @@ class DD4hepSimulation(object):
     import ROOT
     ROOT.PyConfig.IgnoreCommandLineOptions = True
 
-    import DDG4, dd4hep
+    import DDG4, DD4hep
 
     self.printLevel = getOutputLevel(self.printLevel)
 
     kernel = DDG4.Kernel()
-    dd4hep.setPrintLevel(self.printLevel)
+    DD4hep.setPrintLevel(self.printLevel)
     #kernel.setOutputLevel('Compact',1)
 
     kernel.loadGeometry("file:"+ self.compactFile )
@@ -479,7 +479,7 @@ class DD4hepSimulation(object):
     ph.addPhysicsConstructor('G4StepLimiterPhysics')
     _phys.add(ph)
 
-    dd4hep.setPrintLevel(self.printLevel)
+    DD4hep.setPrintLevel(self.printLevel)
 
     kernel.configure()
     kernel.initialize()

--- a/doc/ReleaseNotes.md
+++ b/doc/ReleaseNotes.md
@@ -1,3 +1,11 @@
+# v00-16-03
+
+* 2018-06-26 Frank Gaede ([PR#224](https://github.com/iLCSoft/lcgeo/pull/224)
+  - make lcgeo (v00-16-03 and higher) compatible w/ DD4hep v01-17-0X releases
+  -  revert https://github.com/iLCSoft/lcgeo/pull/219
+       - use DD4hep rather than dd4hep in ddsim python
+
+
 # v00-16-02
 
 * 2018-06-25 Frank Gaede ([PR#223](https://github.com/ilcsoft/lcgeo/pull/223))


### PR DESCRIPTION
BEGINRELEASENOTES
 - make lcgeo (v00-16-03 and higher) compatible w/ DD4hep v01-17-0X releases
 -  revert https://github.com/iLCSoft/lcgeo/pull/219
      - use `DD4hep` rather than `dd4hep` in ddsim python

ENDRELEASENOTES