### PR TITLE
Add vis attribute for better visualisation of TrackerEndcap_o1_v02

### DIFF
--- a/detector/tracker/TrackerEndcap_o1_v02_geo.cpp
+++ b/detector/tracker/TrackerEndcap_o1_v02_geo.cpp
@@ -193,7 +193,7 @@ static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector s
     zDiskPetalsData->angleStrip  = 0;
     
     
-    
+    sdet.setAttributes(theDetector,envelope,x_det.regionStr(),x_det.limitsStr(),x_det.visStr());
     sdet.addExtension< ZDiskPetalsData >( zDiskPetalsData ) ;
     
     


### PR DESCRIPTION
BEGINRELEASENOTES
- Add vis attribute for better visualisation of `TrackerEndcap_o1_v02`

ENDRELEASENOTES

This is needed for propper propagation of colours in CEDViewer