### PR TITLE
SortingPolicyPlugin

### DIFF
--- a/CLIC/compact/CLIC_o3_v14/CLIC_o3_v14.xml
+++ b/CLIC/compact/CLIC_o3_v14/CLIC_o3_v14.xml
@@ -250,9 +250,20 @@
         <plugin name="DD4hepVolumeManager"/>
         <plugin name="InstallSurfaceManager"/>
         <plugin name="lcgeo_LinearSortingPolicy">
+
+          <argument value="/InnerTrackerEndcapSupport_layer8" />
+          <argument value="InnerTracker_Barrel_half_length_0" />
+          <argument value="InnerTracker_Barrel_radius_0+0.5*mm" />
+          <argument value="0" />
+
+          <argument value="/InnerTrackerEndcapSupport_layer9" />
+          <argument value="InnerTracker_Barrel_half_length_0" />
+          <argument value="InnerTracker_Barrel_radius_1+0.5*mm" />
+          <argument value="0" />
+
           <argument value="/InnerTrackerEndcapSupport" />
           <argument value="InnerTracker_Barrel_half_length_0" />
-          <argument value="InnerTracker_Barrel_radius_1" />
+          <argument value="InnerTracker_Barrel_radius_1+0.5*mm" />
           <argument value="(InnerTracker_outer_radius-InnerTracker_Barrel_radius_1)/(InnerTracker_half_length-InnerTracker_Barrel_half_length_0)" />
 
           <argument value="/InnerTrackerEndcap/" />
@@ -265,9 +276,19 @@
           <argument value="OuterTracker_Barrel_radius_1" />
           <argument value="(OuterTracker_Endcap_radius_2-OuterTracker_Barrel_radius_1)/(OuterTracker_half_length-OuterTracker_Barrel_half_length)" />
 
+          <argument value="/OuterTrackerEndcapSupport_layer4" />
+          <argument value="OuterTracker_Barrel_half_length" />
+          <argument value="OuterTracker_Barrel_radius_0+0.5*cm" />
+          <argument value="0.0" />
+
+          <argument value="/OuterTrackerEndcapSupport_layer5" />
+          <argument value="OuterTracker_Barrel_half_length" />
+          <argument value="OuterTracker_Barrel_radius_1+0.5*cm" />
+          <argument value="0.0" />
+
           <argument value="/OuterTrackerEndcapSupport" />
           <argument value="OuterTracker_Barrel_half_length" />
-          <argument value="OuterTracker_Barrel_radius_1" />
+          <argument value="OuterTracker_Barrel_radius_1+3*cm" />
           <argument value="(OuterTracker_Endcap_radius_2-OuterTracker_Barrel_radius_1)/(OuterTracker_half_length-OuterTracker_Barrel_half_length)" />
 
         </plugin>

--- a/CLIC/compact/CLIC_o3_v14/CLIC_o3_v14.xml
+++ b/CLIC/compact/CLIC_o3_v14/CLIC_o3_v14.xml
@@ -291,6 +291,15 @@
           <argument value="OuterTracker_Barrel_radius_1+3*cm" />
           <argument value="(OuterTracker_Endcap_radius_2-OuterTracker_Barrel_radius_1)/(OuterTracker_half_length-OuterTracker_Barrel_half_length)" />
 
+          <argument value="/VertexEndcap/" />
+          <argument value="VertexEndcap_zmin" />
+          <argument value="VertexBarrel_r3+1*cm" />
+          <argument value="(VertexEndcap_rmax-VertexBarrel_r3+1*cm)/(VertexEndcap_zmax-VertexEndcap_zmin)" />
+
+          <argument value="/VertexVerticalCable" />
+          <argument value="0" />
+          <argument value="VertexBarrel_r3+0.5*cm" />
+          <argument value="0" />
         </plugin>
 
     </plugins>

--- a/CLIC/compact/CLIC_o3_v14/CLIC_o3_v14.xml
+++ b/CLIC/compact/CLIC_o3_v14/CLIC_o3_v14.xml
@@ -249,6 +249,29 @@
     <plugins>
         <plugin name="DD4hepVolumeManager"/>
         <plugin name="InstallSurfaceManager"/>
+        <plugin name="lcgeo_LinearSortingPolicy">
+          <argument value="/InnerTrackerEndcapSupport" />
+          <argument value="InnerTracker_Barrel_half_length_0" />
+          <argument value="InnerTracker_Barrel_radius_1" />
+          <argument value="(InnerTracker_outer_radius-InnerTracker_Barrel_radius_1)/(InnerTracker_half_length-InnerTracker_Barrel_half_length_0)" />
+
+          <argument value="/InnerTrackerEndcap/" />
+          <argument value="InnerTracker_Barrel_half_length_0" />
+          <argument value="InnerTracker_Barrel_radius_1" />
+          <argument value="(InnerTracker_outer_radius-InnerTracker_Barrel_radius_1)/(InnerTracker_half_length-InnerTracker_Barrel_half_length_0)" />
+
+          <argument value="/OuterTrackerEndcap/" />
+          <argument value="OuterTracker_Barrel_half_length" />
+          <argument value="OuterTracker_Barrel_radius_1" />
+          <argument value="(OuterTracker_Endcap_radius_2-OuterTracker_Barrel_radius_1)/(OuterTracker_half_length-OuterTracker_Barrel_half_length)" />
+
+          <argument value="/OuterTrackerEndcapSupport" />
+          <argument value="OuterTracker_Barrel_half_length" />
+          <argument value="OuterTracker_Barrel_radius_1" />
+          <argument value="(OuterTracker_Endcap_radius_2-OuterTracker_Barrel_radius_1)/(OuterTracker_half_length-OuterTracker_Barrel_half_length)" />
+
+        </plugin>
+
     </plugins>
 
 

--- a/CLIC/compact/CLIC_o3_v14/InnerTracker_o2_v06_01.xml
+++ b/CLIC/compact/CLIC_o3_v14/InnerTracker_o2_v06_01.xml
@@ -350,10 +350,15 @@
             <layer id="6" inner_r="InnerTracker_Endcap_radius_6" inner_z="InnerTracker_Endcap_z_6-1*cm" outer_r="555*mm" vis="SupportVis">
                 <slice material="CarbonFiber" thickness="0.369/3.5959*cm" />
             </layer>
-            <layer id="7" inner_r="InnerTracker_Barrel_radius_0" inner_z="InnerTracker_Barrel_half_length_1+2*cm" outer_r="InnerTracker_Barrel_radius_2-2*cm" vis="InterlinkVis">
+            <layer id="7" inner_r="InnerTracker_Barrel_radius_2-2*cm+0.6/3.5959*cm" inner_z="InnerTracker_Barrel_half_length_2+2*cm" outer_r="InnerTracker_outer_radius-1*cm" vis="InterlinkVis">
                 <slice material="CarbonFiber" thickness="0.6/3.5959*cm" />
             </layer>
-            <layer id="8" inner_r="InnerTracker_Barrel_radius_2-2*cm+0.6/3.5959*cm" inner_z="InnerTracker_Barrel_half_length_2+2*cm" outer_r="InnerTracker_outer_radius-1*cm" vis="InterlinkVis">
+
+            <!-- the material between inner tracker barrel and inner tracker endcaps -->
+            <layer id="8" inner_r="InnerTracker_Barrel_radius_0" inner_z="InnerTracker_Barrel_half_length_1+2*cm" outer_r="InnerTracker_Barrel_radius_1" vis="InterlinkVis">
+                <slice material="CarbonFiber" thickness="0.6/3.5959*cm" />
+            </layer>
+            <layer id="9" inner_r="InnerTracker_Barrel_radius_1" inner_z="InnerTracker_Barrel_half_length_1+2*cm" outer_r="InnerTracker_Barrel_radius_2-2*cm" vis="InterlinkVis">
                 <slice material="CarbonFiber" thickness="0.6/3.5959*cm" />
             </layer>
         </detector>

--- a/CLIC/compact/CLIC_o3_v14/OuterTracker_o2_v06_01.xml
+++ b/CLIC/compact/CLIC_o3_v14/OuterTracker_o2_v06_01.xml
@@ -180,7 +180,10 @@
            <layer id="3" inner_r="OuterTracker_inner_radius" inner_z="OuterTracker_Endcap_z_3-1*cm" outer_r="OuterTracker_Endcap_outer_radius" vis="SupportVis">
 	           <slice material="CarbonFiber" thickness="0.365/3.5959*cm" />
            </layer>
-           <layer id="4" inner_r="OuterTracker_Barrel_radius_0-1*cm" inner_z="OuterTracker_Barrel_half_length+2*cm" outer_r="OuterTracker_outer_radius" vis="OuterTrackerInterlinkVis">
+           <layer id="4" inner_r="OuterTracker_Barrel_radius_0-1*cm" inner_z="OuterTracker_Barrel_half_length+2*cm" outer_r="OuterTracker_Barrel_radius_1-0.5*cm" vis="OuterTrackerInterlinkVis">
+	           <slice material="CarbonFiber" thickness="0.6/3.5959*cm" />
+           </layer>
+           <layer id="5" inner_r="OuterTracker_Barrel_radius_1-0.5*cm" inner_z="OuterTracker_Barrel_half_length+2*cm" outer_r="OuterTracker_outer_radius" vis="OuterTrackerInterlinkVis">
 	           <slice material="CarbonFiber" thickness="0.6/3.5959*cm" />
            </layer>                    
         </detector>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,6 +74,7 @@ file(GLOB sources
   ./detector/other/*.cpp 
   ./detector/CaloTB/*.cpp 
   ./FCalTB/setup/*.cpp
+  ./plugins/LinearSortingPolicy.cpp
   )
 
 file(GLOB G4sources

--- a/detector/other/TrackerEndcapSupport_o1_v01.cpp
+++ b/detector/other/TrackerEndcapSupport_o1_v01.cpp
@@ -70,6 +70,9 @@ static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector)
     Tube    l_tub(rmin, rmax, layerWidth, 2 * M_PI);
     Volume  l_vol(l_nam, l_tub, air);
     l_vol.setVisAttributes(theDetector, x_layer.visStr());
+
+    DetElement layer_pos(sdet, l_nam + "_pos", l_num);
+
     for (xml_coll_t j(x_layer, _U(slice)); j; ++j, ++s_num)  {
       xml_comp_t x_slice = j;
       double thick = x_slice.thickness();
@@ -83,9 +86,8 @@ static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector)
       Vector3D ocyl(  0., mid_r ,  0. );
       Vector3D u(1.,0.,0.), v(0.,1.,0.), n(0.,0.,1.);      
 
-	  VolSurfaceHandle<VolPlaneImpl> cylSurf1( s_vol , SurfaceType( SurfaceType::Helper ) , 0.5*thick  , 0.5*thick , u, v, n, ocyl );
-
-	  volSurfaceList( sdet )->push_back( cylSurf1 );
+      VolSurfaceHandle<VolPlaneImpl> cylSurf1( s_vol , SurfaceType( SurfaceType::Helper ) , 0.5*thick  , 0.5*thick , u, v, n, ocyl );
+      volSurfaceList( layer_pos )->push_back( cylSurf1 );
 	   
 
       s_vol.setAttributes(theDetector, x_slice.regionStr(), x_slice.limitsStr(), x_slice.visStr());
@@ -93,14 +95,14 @@ static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector)
       pv.addPhysVolID("sensor", s_num);
     }
 
-    DetElement layer_pos(sdet, l_nam + "_pos", l_num);
     pv = envelope.placeVolume(l_vol, Position(0, 0, zmin + layerWidth / 2.));
     pv.addPhysVolID("layer", l_num);
     pv.addPhysVolID("barrel", 1);
     layer_pos.setPlacement(pv);
-    
+
     if (reflect)  {
-	  Tube    l_tub2(rmin, rmax, layerWidth, 2 * M_PI);
+      DetElement layer_neg(sdet, l_nam + "_neg", l_num);
+      Tube    l_tub2(rmin, rmax, layerWidth, 2 * M_PI);
       Volume  l_vol2(l_nam, l_tub2, air);
       l_vol2.setVisAttributes(theDetector, x_layer.visStr());
       for (xml_coll_t j(x_layer, _U(slice)); j; ++j, ++s_num)  {
@@ -116,21 +118,18 @@ static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector)
         Vector3D ocyl(  0., mid_r , 0. );
         Vector3D u(1.,0.,0.), v(0.,1.,0.), n(0.,0.,1.);      
 
-	    VolSurfaceHandle<VolPlaneImpl> cylSurf2( s_vol2 , SurfaceType( SurfaceType::Helper ) , 0.5*thick  , 0.5*thick , u, v, -1.*n, -1.*ocyl );
-
-	    volSurfaceList( sdet )->push_back( cylSurf2 );
-	   
+        VolSurfaceHandle<VolPlaneImpl> cylSurf2( s_vol2 , SurfaceType( SurfaceType::Helper ) , 0.5*thick  , 0.5*thick , u, v, -1.*n, -1.*ocyl );
+        volSurfaceList( layer_neg )->push_back( cylSurf2 );
 
         s_vol2.setAttributes(theDetector, x_slice.regionStr(), x_slice.limitsStr(), x_slice.visStr());
         pv = l_vol2.placeVolume(s_vol2, Position(0, 0, -1.*(z - zmin - layerWidth / 2 + thick / 2)));
         pv.addPhysVolID("sensor", s_num);
       }
+      pv = envelope.placeVolume(l_vol2, Position(0, 0, -1.*(zmin + layerWidth / 2.)));
+      pv.addPhysVolID("layer", l_num);
+      pv.addPhysVolID("barrel", 2);
+      layer_neg.setPlacement(pv);
 
-    DetElement layer_neg(sdet, l_nam + "_neg", l_num);
-    pv = envelope.placeVolume(l_vol2, Position(0, 0, -1.*(zmin + layerWidth / 2.)));
-    pv.addPhysVolID("layer", l_num);
-    pv.addPhysVolID("barrel", 2);
-    layer_neg.setPlacement(pv);
     }
   }
 

--- a/plugins/LinearSortingPolicy.cpp
+++ b/plugins/LinearSortingPolicy.cpp
@@ -1,0 +1,119 @@
+//==========================================================================
+// iLCSoft - linear collider geometry
+//--------------------------------------------------------------------------
+//
+// For the licensing terms see lcgeo/LICENSE.
+//
+// Author     : A. Sailer
+//
+//==========================================================================
+//
+// Linear Sorting Policy Extension
+//
+// Adds the sorting policy variable to surface DetElements following a
+// linear function, surfaces are selected depending on the placement path
+// of their DetElement
+//
+//==========================================================================
+
+#include <DD4hep/DetElement.h>
+#include <DD4hep/Detector.h>
+#include <DD4hep/Factories.h>
+#include <DD4hep/Printout.h>
+
+#include <DDRec/DetectorData.h>
+#include <DDRec/SurfaceHelper.h>
+
+#include <map>
+#include <string>
+#include <tuple>
+#include <vector>
+
+using dd4hep::DetElement;
+using dd4hep::PrintLevel;
+
+
+
+namespace {
+
+  /** Plugin for adding the SortingPolicy parameter to surface
+   * 
+   * The sorting policy is calculated from the z Position of the surface and a first order polynomial
+   *  sp = p[2] * (zPosition - p[0]) + p[1]
+   * Arguments are:
+   *  - Path indentifying the DetElement
+   *  - zOffset for the function
+   *  - rOffset for the function
+   *  - Slope for the function
+   *
+   * any number of these four arguments can be given. The evaluation order is in the order the
+   * four-tuple is provided, the first match will be used to calculate the sorting policy
+   *
+   * @author A.Sailer, CERN
+   */
+  static long addSortingPolicy(dd4hep::Detector& description, int argc, char** argv) {
+    const std::string LOG_SOURCE("SortingPolicyPlugin");
+
+    // use a vector to keep the same order as in the arguments given
+    std::vector<std::pair<std::string, std::vector<double>>> pathToLinear;
+
+    {
+      std::string path = "";
+      for(int i=0; i<argc; ++i)  {
+        if(i % 4 == 0){
+          path = std::string(argv[i]);
+          dd4hep::printout(PrintLevel::DEBUG, LOG_SOURCE, "argument[%d]: %s", i, argv[i]);
+          pathToLinear.emplace_back(path, std::vector<double>(3, 0.0));
+        } else {
+          const int variableID = (i % 4) - 1;
+          pathToLinear.back().second[variableID] = dd4hep::_toDouble(argv[i]);
+          dd4hep::printout(PrintLevel::DEBUG, LOG_SOURCE, "argument[%d]: %s --> %3.5f", i, argv[i],
+                           pathToLinear.back().second[variableID]);
+        }
+      }
+    }
+
+    auto world = description.world();
+
+    dd4hep::rec::SurfaceHelper ds( world );
+    dd4hep::rec::SurfaceList const& detSL = ds.surfaceList();
+    for(dd4hep::rec::ISurface* surf: detSL){
+      dd4hep::Volume volume = ((dd4hep::rec::Surface*)surf)->volume();
+      auto* ddsurf  = ((dd4hep::rec::Surface*)surf);
+      auto const volumeName = std::string(volume->GetName());
+      if(not ddsurf->detElement().isValid()) continue;
+      std::string path = ddsurf->detElement().path();
+      for (auto const& pathAndValues : pathToLinear) {
+        if(path.find(pathAndValues.first) != std::string::npos) {
+          std::vector<double> const& parameters = pathAndValues.second;
+          double zPosition = std::fabs(surf->origin()[2]);
+          double rValue = parameters.at(2) * (zPosition-parameters.at(0)) + parameters.at(1);
+
+          dd4hep::rec::DoubleParameters* para = nullptr;
+          try { // use existing map, or create a new one
+            para = ddsurf->detElement().extension<dd4hep::rec::DoubleParameters>();
+            para->doubleParameters["SortingPolicy"] = rValue;
+          } catch(...){
+            para = new dd4hep::rec::DoubleParameters;
+            para->doubleParameters["SortingPolicy"] = rValue;
+            ddsurf->detElement().addExtension<dd4hep::rec::DoubleParameters>(para);
+          }
+          printout(PrintLevel::DEBUG, LOG_SOURCE, "Added extension to %s, matching %s "
+                   " path %s, type %s, zPos %3.5f, value %3.5f",
+                   volumeName.c_str(), pathAndValues.first.c_str(),
+                   ddsurf->detElement().path().c_str(),
+                   ddsurf->detElement().type().c_str(),
+                   zPosition, para->doubleParameters["SortingPolicy"]);
+          break;
+        }
+      }// for all paths
+    }
+
+    return 0;
+  }
+
+
+} // namespace
+
+
+DECLARE_APPLY(lcgeo_LinearSortingPolicy, ::addSortingPolicy)


### PR DESCRIPTION

BEGINRELEASENOTES
- Plugin: lcgeo_LinearSortingPolicy : new plugin to set the sorting policy for surfaces identified by placement path based on their z position and a linear function, requires AIDASoft/DD4hep#486
- CLIC_o3_v14: add use of lcgeo_LinearSortingPolicy for TrackerEndcaps
- TrackerEndcapSupport_o1_v01: attach support volumes to different DetElements so we can attach different extensions to them

ENDRELEASENOTES