### PR TITLE
Create SiD_o2_v04

### DIFF
--- a/SiD/compact/SiD_o2_v04/BeamCal_o2_v04.xml
+++ b/SiD/compact/SiD_o2_v04/BeamCal_o2_v04.xml
@@ -1,0 +1,34 @@
+<lccdd>
+
+<readouts>
+    <readout name="BeamCalHits">
+      <segmentation type="CartesianGridXY" grid_size_x="BeamCal_cell_size" grid_size_y="BeamCal_cell_size" />
+      <id>${GlobalForwardCaloReadoutID}</id>
+    </readout>
+</readouts>
+
+<detectors>
+<detector id="DetID_BeamCal" name="BeamCal" reflect="true" type="DD4hep_ForwardDetector" readout="BeamCalHits" vis="BeamCalVis" calorimeterType="BEAM">
+
+  <comment>SiD Beam Calorimeter</comment>
+
+  <type_flags type=" DetType_CALORIMETER + DetType_ELECTROMAGNETIC + DetType_ENDCAP + DetType_FORWARD + DetType_AUXILIARY "/>
+  <dimensions outer_r="BeamCal_rmax" inner_r="BeamCal_rmin" inner_z="BeamCal_zmin" outer_z="BeamCal_zmax" dz="BeamCal_zmax - BeamCal_zmin"/>
+  <envelope vis="BeamCalVis">
+   <shape type="BooleanShape" operation="Subtraction" material="Air">
+     <shape type="Tube" rmin="BeamCal_rmin" rmax="BeamCal_rmax + env_safety" dz="2*BeamCal_zmax + 2*env_safety"/>
+     <shape type="Tube" rmin="BeamCal_rmin" rmax="BeamCal_rmax + env_safety" dz="2*BeamCal_zmin - 2*env_safety"/>
+   </shape>
+  </envelope>
+  <beampipe crossing_angle="0.014" outgoing_r="15.5*mm" incoming_r="10.5*mm" />
+  <layer repeat="50">
+    <slice material="TungstenDens24" thickness="2.71*mm" />
+    <slice material="Silicon" thickness="0.32*mm" sensitive="yes" />
+    <slice material="Copper" thickness="0.05*mm" />
+    <slice material="Kapton" thickness="0.30*mm" />
+    <slice material="Air" thickness="0.33*mm" />
+  </layer>
+</detector>
+</detectors>
+
+</lccdd>

--- a/SiD/compact/SiD_o2_v04/BeamPipe_o2_v04.xml
+++ b/SiD/compact/SiD_o2_v04/BeamPipe_o2_v04.xml
@@ -1,0 +1,29 @@
+<comment>Beampipe by Chris Potter (UOregon)</comment>
+<!-- See talk on 23-04-2022 https://agenda.linearcollider.org/event/9586/ -->
+
+<comment>Parameters from ILC TDR V4 7.4.2. (CP)</comment>
+<!-- (defined in main xml) constant name="bp_cone_slope" value="0.0570643"/ -->
+<constant name="bp_cone_dr" value="(20.50-6.25)*bp_cone_slope*cm"/>
+<constant name="steel_cone_slope" value="0.0932777"/>
+<constant name="steel_cone_dr" value="(120.0-20.5)*steel_cone_slope*cm"/>
+
+<detectors>
+ <comment>Be Beampipe and Be Cones</comment>
+ <detector name="Beampipe" type="DD4hep_PolyconeSupport" insideTrackingVolume="true" vis="BeampipeVis">
+  <material name="Beryllium"/>
+  <zplane rmin="bp_cone_dr+1.20*cm" rmax="bp_cone_dr+(1.20+0.07*1.0016)*cm" z="-20.50*cm"/>
+  <zplane rmin="1.20*cm" rmax="(1.20+0.04)*cm" z="-6.25*cm"/>
+  <zplane rmin="1.20*cm" rmax="(1.20+0.04)*cm" z="6.25*cm"/>
+  <zplane rmin="bp_cone_dr+1.20*cm" rmax="bp_cone_dr+(1.20+0.07*1.0016)*cm" z="20.50*cm"/>
+ </detector>
+<comment>Steel Beampipe Cones</comment>
+<detector name="ForwardSupportTube" type="DD4hep_PolyconeSupport" insideTrackingVolume="true" vis="BeampipeVis">
+  <material name="Steel235"/>
+  <zplane rmin="steel_cone_dr+bp_cone_dr+1.20*cm" rmax="steel_cone_dr+bp_cone_dr+(1.20+0.15*1.0043)*cm" z="-120.0*cm"/>
+  <zplane rmin="bp_cone_dr+1.20*cm" rmax="bp_cone_dr+(1.20+0.107*1.0043)*cm" z="-20.50*cm"/>
+  <zplane rmin="bp_cone_dr+1.20*cm" rmax="bp_cone_dr+(1.20+0.107*1.0043)*cm" z="20.50*cm"/>
+  <zplane rmin="steel_cone_dr+bp_cone_dr+1.20*cm" rmax="steel_cone_dr+bp_cone_dr+(1.20+0.15*1.0043)*cm" z="120.0*cm"/>
+</detector>
+</detectors>
+
+

--- a/SiD/compact/SiD_o2_v04/ECalBarrel_o2_v04.xml
+++ b/SiD/compact/SiD_o2_v04/ECalBarrel_o2_v04.xml
@@ -1,0 +1,68 @@
+<lccdd>
+
+  <readouts>
+    <readout name="ECalBarrelHits">
+      <segmentation type="CartesianGridXY" grid_size_x="ECal_cell_size" grid_size_y="ECal_cell_size" />
+      <id>${GlobalCalorimeterReadoutID}</id>
+    </readout>
+  </readouts>
+  
+  <detectors>
+    <detector id="DetID_ECal_Barrel" name="ECalBarrel" type="ECalBarrel_o2_v04" readout="ECalBarrelHits" vis="GreenVis" calorimeterType="EM_BARREL" gap="0.*cm">
+      
+      <comment>SiD EM Calorimeter Barrel</comment>
+      
+      <type_flags type=" DetType_CALORIMETER + DetType_ELECTROMAGNETIC + DetType_BARREL" />
+      
+      <dimensions numsides="ECalBarrel_symmetry" rmin="ECalBarrel_rmin" rmax="ECalBarrel_rmax" z="2*ECalBarrel_half_length" />
+      
+      <envelope vis="YellowVis">
+	<shape type="PolyhedraRegular" numsides="ECalBarrel_symmetry"  rmin="ECalBarrel_rmin - env_safety" rmax="ECalBarrel_rmax + 10*env_safety" dz="2*ECalBarrel_half_length + 2*env_safety"  material="Air"/>
+	<!-- Radii definitions as in http://cern.ch/go/r9mZ -->
+	<rotation x="0*deg" y="0*deg" z="90*deg-180*deg/ECalBarrel_symmetry"/>
+      </envelope>
+      
+      <parameter ecal_barrel_tolerance="env_safety" num_towers="1" num_rails="0" stacks_per_tower="1" TowersAirGap="0.0*mm" TowersFaceThickness="0.0*mm" supportRailCrossSection="0*0*mm*mm" AlveolusMaterial="CarbonFiber_25percent" supportRailMaterial="Steel235"/>
+      
+      <staves material="Air" vis="GreenVis"/>
+
+      <layer repeat="1" vis="MagentaVis">
+	<slice material = "Silicon" thickness = "0.032*cm" sensitive = "yes" limits="cal_limits" />
+	<slice material = "Copper"  thickness = "0.005*cm" />
+	<slice material = "Kapton"  thickness = "0.030*cm" />
+	<slice material = "Air"     thickness = "0.033*cm" />
+      </layer>
+
+      <layer repeat="20" vis="GrayVis">
+	<slice material = "TungstenDens24" thickness = "0.25*cm" />
+	<slice material = "Air"     thickness = "0.025*cm" />
+	<slice material = "Silicon" thickness = "0.032*cm" sensitive = "yes" limits="cal_limits" />
+	<slice material = "Copper"  thickness = "0.005*cm" />
+	<slice material = "Kapton"  thickness = "0.030*cm" />
+	<slice material = "Air"     thickness = "0.033*cm" />
+      </layer>
+
+      <layer repeat="10" vis="GreenVis">
+	<slice material = "TungstenDens24" thickness = "0.5*cm" />
+	<slice material = "Air"     thickness = "0.025*cm" />
+	<slice material = "Silicon" thickness = "0.032*cm" sensitive = "yes" limits="cal_limits" />
+	<slice material = "Copper"  thickness = "0.005*cm" />
+	<slice material = "Kapton"  thickness = "0.030*cm" />
+	<slice material = "Air"     thickness = "0.033*cm" />
+      </layer>
+
+    </detector>
+  </detectors>
+  
+  <plugins>
+    <plugin name="DD4hep_CaloFaceBarrelSurfacePlugin">
+      <argument value="ECalBarrel"/>
+      <argument value="length=2*ECalBarrel_half_length" />
+      <argument value="radius=ECalBarrel_rmin" />
+      <argument value="phi0=0" />
+      <argument value="symmetry=ECalBarrel_symmetry" />
+      <argument value="systemID=20" />
+    </plugin>
+  </plugins>
+  
+</lccdd>

--- a/SiD/compact/SiD_o2_v04/ECalEndcap_o2_v04.xml
+++ b/SiD/compact/SiD_o2_v04/ECalEndcap_o2_v04.xml
@@ -1,0 +1,65 @@
+<lccdd>
+
+<readouts>
+    <readout name="ECalEndcapHits">
+      <segmentation type="CartesianGridXY" grid_size_x="ECal_cell_size" grid_size_y="ECal_cell_size" />
+      <id>${GlobalCalorimeterReadoutID}</id>
+    </readout>
+</readouts>
+
+<detectors>
+ <detector id="DetID_ECal_Endcap" name="ECalEndcap" type="GenericCalEndcap_o1_v01" reflect="true" readout="ECalEndcapHits" vis="ECalEndcapVis" calorimeterType="EM_ENDCAP" gap="0.0*cm">
+
+  <comment>SiD EM Calorimeter Endcaps</comment>
+
+  <type_flags type=" DetType_CALORIMETER + DetType_ELECTROMAGNETIC + DetType_ENDCAP"/>
+
+  <dimensions numsides="ECalEndcap_outer_symmetry" zmin="ECalEndcap_zmin" rmin="ECalEndcap_rmin" rmax="ECalEndcap_rmax"  nsides_inner="ECalEndcap_inner_symmetry" nsides_outer="ECalEndcap_outer_symmetry" />
+
+  <envelope vis="ECalEndcapVis">
+    <shape type="BooleanShape" operation="Subtraction" material="Air">
+      <shape type="PolyhedraRegular"  numsides="ECalEndcap_outer_symmetry" rmin="ECalEndcap_rmin - env_safety" rmax="ECalEndcap_rmax + env_safety" dz="2*ECalEndcap_zmax + 2*env_safety" />
+      <shape type="PolyhedraRegular"  numsides="ECalEndcap_outer_symmetry" rmin="0" rmax="ECalEndcap_rmax + 2*env_safety" dz="2*ECalEndcap_zmin - 2*env_safety" />
+    </shape>
+    <rotation x="0*deg" y="0*deg" z="90*deg-180*deg/ECalEndcap_outer_symmetry" />
+  </envelope>
+  
+  <layer repeat="1">
+    <slice material = "Silicon" thickness = "0.032*cm" sensitive = "yes" limits="cal_limits" />
+    <slice material = "Copper"  thickness = "0.005*cm" />
+    <slice material = "Kapton"  thickness = "0.030*cm" />
+    <slice material = "Air"     thickness = "0.033*cm" />
+  </layer>
+  <layer repeat="20">
+    <slice material = "TungstenDens24" thickness = "0.25*cm" />
+    <slice material = "Air"     thickness = "0.025*cm" />
+    <slice material = "Silicon" thickness = "0.032*cm" sensitive = "yes" limits="cal_limits" />
+    <slice material = "Copper"  thickness = "0.005*cm" />
+    <slice material = "Kapton"  thickness = "0.030*cm" />
+    <slice material = "Air"     thickness = "0.033*cm" />
+  </layer>
+  <layer repeat="10">
+    <slice material = "TungstenDens24" thickness = "0.5*cm" />
+    <slice material = "Air"     thickness = "0.025*cm" />
+    <slice material = "Silicon" thickness = "0.032*cm" sensitive = "yes" limits="cal_limits" />
+    <slice material = "Copper"  thickness = "0.005*cm" />
+    <slice material = "Kapton"  thickness = "0.030*cm" />
+    <slice material = "Air"     thickness = "0.033*cm" />
+  </layer>
+
+ </detector>
+</detectors>
+
+<plugins>
+    <plugin name="DD4hep_CaloFaceEndcapSurfacePlugin">
+      <argument value="ECalEndcap" />
+      <argument value="zpos=ECalEndcap_zmin" />
+      <argument value="radius=ECalEndcap_rmax"  />
+      <argument value="phi0=0"    />
+      <argument value="symmetry=ECalEndcap_outer_symmetry"/>
+      <argument value="systemID=DetID_ECal_Endcap"/>
+      <!-- systemID was 29 for ECAL_ENDCAP to match UTIL::ILDDetID for MarlinTrk ... still needed? -->
+    </plugin>
+</plugins>
+
+</lccdd>

--- a/SiD/compact/SiD_o2_v04/HCalBarrel_o2_v04.xml
+++ b/SiD/compact/SiD_o2_v04/HCalBarrel_o2_v04.xml
@@ -1,0 +1,51 @@
+<lccdd>
+
+<!--
+   AHCal Barrel implementation of the layout from 70th SiD Optimization Meeting presentation 
+   from Ross - June 30, 2016
+   Updated by Ross on Nov 20, 2016
+   o2_v04 by protopop@cern.ch - Oct 18, 2017
+  -->
+
+<readouts>
+  <readout name="HCalBarrelHits">
+    <segmentation type="CartesianGridXY" grid_size_x="HCal_cell_size" grid_size_y="HCal_cell_size" />
+    <id>${GlobalCalorimeterReadoutID}</id>
+  </readout>
+</readouts>
+
+<detectors>
+  <detector id="DetID_HCAL_Barrel" name="HCalBarrel" type="GenericCalBarrel_o1_v01" readout="HCalBarrelHits" vis="HCalBarrelVis" calorimeterType="HAD_BARREL" gap="0.*cm" material="Steel235">
+    
+    <comment>SiD Hadron Calorimeter Barrel</comment>
+    
+    <type_flags type=" DetType_CALORIMETER + DetType_HADRONIC + DetType_BARREL"/>
+    
+    <dimensions numsides="HCalBarrel_symmetry" rmin="HCalBarrel_rmin" z="2*HCalBarrel_half_length"/>
+    
+    <envelope vis="HCalBarrelVis">
+      <shape type="PolyhedraRegular" numsides="HCalBarrel_symmetry"  rmin="HCalBarrel_rmin - env_safety" rmax="HCalBarrel_rmax + 5*env_safety" dz="2*HCalBarrel_half_length + 2*env_safety" material="Air"/>
+      <rotation x="0*deg" y="0*deg" z="90*deg-180*deg/HCalBarrel_symmetry"/>
+    </envelope>
+    
+    <staves />
+    <layer repeat="40">
+      <slice material = "Steel235"   thickness = "19.0*mm" />    <!-- Absorber -->
+      <slice material = "Air"        thickness =  "2.0*mm" />
+      <slice material = "Steel235"   thickness =  "0.5*mm" />    <!-- Top plate -->
+      <slice material = "Kapton"    thickness = "0.115*mm" />    <!-- Polyimide foil -->
+      <slice material = "Copper"    thickness = "0.068*mm" />
+      <slice material = "PCB"       thickness =   "1.0*mm" />    <!-- PCB made of FR4 -->
+      <slice material = "Polystyrole" thickness = "0.1*mm" />    <!-- Reflector foil -->
+      <slice material = "Polystyrene" thickness = "3.0*mm" sensitive="yes" limits="cal_limits" />
+      <slice material = "Polystyrole" thickness = "0.1*mm" />    <!-- Reflector foil -->
+      <slice material = "Steel235"    thickness = "0.5*mm" />    <!-- Bottom plate -->
+      <slice material = "Air"       thickness = "0.617*mm" />    <!-- Clearance gap between active layer and next absorber -->
+    </layer>
+    <!--layer repeat="1"-->
+    <!--slice material = "Steel235"   thickness = "19.0*mm" /--><!-- Terminator plate (if needed) -->
+    <!--/layer-->
+  </detector>
+</detectors>
+
+</lccdd>

--- a/SiD/compact/SiD_o2_v04/HCalEndcap_o2_v04.xml
+++ b/SiD/compact/SiD_o2_v04/HCalEndcap_o2_v04.xml
@@ -1,0 +1,49 @@
+<lccdd>
+	
+<!--
+     AHCal EndCap implementation updated by Ross, Nov 20, 2016
+     o2_v04 by protopop@cern.ch - Oct 18, 2017
+-->
+	
+<readouts>
+    <readout name="HCalEndcapHits">
+      <segmentation type="CartesianGridXY" grid_size_x="HCal_cell_size" grid_size_y="HCal_cell_size" />
+      <id>${GlobalCalorimeterReadoutID}</id>
+    </readout>
+</readouts>
+
+<detectors>
+  <detector id="DetID_HCAL_Endcap" name="HCalEndcap" type="GenericCalEndcap_o1_v01" readout="HCalEndcapHits" vis="HCalEndcapVis" calorimeterType="HAD_ENDCAP" reflect="true">
+    
+    <comment>SiD Hadron Calorimeter Endcaps</comment>
+    
+    <type_flags type=" DetType_CALORIMETER + DetType_HADRONIC + DetType_ENDCAP"/>
+    
+    <dimensions numsides="HCalEndcap_outer_symmetry" zmin="HCalEndcap_zmin" zmax="HCalEndcap_zmax" rmin="HCalEndcap_rmin" rmax="HCalEndcap_rmax" nsides_inner="HCalEndcap_inner_symmetry" nsides_outer="HCalEndcap_outer_symmetry" />
+    
+    <envelope vis="HCalEndcapVis">
+      <shape type="BooleanShape" operation="Subtraction" material="Air">
+	<shape type="PolyhedraRegular" numsides="HCalEndcap_outer_symmetry" rmin="HCalEndcap_rmin - env_safety" rmax="HCalEndcap_rmax + env_safety" dz="2*HCalEndcap_zmax + 2*env_safety" />
+	<shape type="PolyhedraRegular" numsides="HCalEndcap_outer_symmetry" rmin="0" rmax="HCalEndcap_rmax + 5*env_safety" dz="2*HCalEndcap_zmin - 2*env_safety"/>
+      </shape>
+      <rotation x="0*deg" y="0*deg" z="90*deg-180*deg/HCalEndcap_outer_symmetry"/>
+    </envelope>
+    
+    <layer repeat="44"><!-- no room for 45 layers -->
+      <slice material = "Steel235"   thickness = "19.0*mm" />    <!-- Absorber -->
+      <slice material = "Air"        thickness =  "2.0*mm" />
+      <slice material = "Steel235"   thickness =  "0.5*mm" />    <!-- Top plate -->
+      <slice material = "Kapton"    thickness = "0.115*mm" />    <!-- Polyimide foil -->
+      <slice material = "Copper"    thickness = "0.068*mm" />
+      <slice material = "PCB"       thickness =   "1.0*mm" />    <!-- PCB made of FR4 -->
+      <slice material = "Polystyrole" thickness = "0.1*mm" />    <!-- Reflector foil -->
+      <slice material = "Polystyrene" thickness = "3.0*mm" sensitive="yes" limits="cal_limits" />
+      <slice material = "Polystyrole" thickness = "0.1*mm" />    <!-- Reflector foil -->
+      <slice material = "Steel235"    thickness = "0.5*mm" />    <!-- Bottom plate -->
+      <slice material = "Air"       thickness = "0.617*mm" />    <!-- Clearance gap between active layer and next absorber -->	  
+    </layer>
+    
+  </detector>
+</detectors>
+
+</lccdd>

--- a/SiD/compact/SiD_o2_v04/HCalRing_o2_v04.xml
+++ b/SiD/compact/SiD_o2_v04/HCalRing_o2_v04.xml
@@ -1,0 +1,47 @@
+<lccdd>
+	
+<!--
+   Added by Aidan, originally included in the HCalEndcap XML
+   o2_v04 update by protopop@cern.ch - Oct 18, 2017
+   Question: is this still nedded?
+-->
+
+<define>
+        <constant name="HCalRing_rmin" value="HCalEndcap_rmin" />	
+	<constant name="HCalRing_rmax" value="HCalEndcap_rmax" />
+	<constant name="HCalRing_zmin" value="HCalEndcap_zmax + 2*env_safety" />
+	<constant name="HCalRing_zmax" value="HCalRing_zmin + env_safety" />
+</define>
+
+<readouts>
+    <readout name="HCalRingHits">
+      <segmentation type="CartesianGridXY" grid_size_x="HCal_cell_size" grid_size_y="HCal_cell_size" />
+      <id>${GlobalCalorimeterReadoutID}</id>
+    </readout>
+</readouts>
+
+<detectors>  
+  <detector name="HCalRingDummy" type="GenericCalEndcap_o1_v01" id="DetID_HCAL_Ring" readout="HCalRingHits" vis="HCALVis" >
+    
+    <comment>SiD HCal Ring Dummy hack to keep Pandora DDCaloHitCreator muons happy</comment>
+    
+    <type_flags type=" DetType_CALORIMETER + DetType_HADRONIC + DetType_ENDCAP + DetType_AUXILIARY"/>
+    
+    <dimensions numsides="HCalEndcap_outer_symmetry" zmin="HCalRing_zmin" zmax="HCalEndcap_zmax" rmin="HCalRing_rmin" rmax="HCalRing_rmax" nsides_inner="HCalEndcap_inner_symmetry" nsides_outer="HCalEndcap_outer_symmetry" />
+
+    <envelope vis="HCalEndcapVis">
+      <shape type="BooleanShape" operation="Subtraction" material="Air">
+	<shape type="PolyhedraRegular" numsides="HCalEndcap_outer_symmetry" rmin="HCalRing_rmin - env_safety" rmax="HCalRing_rmax + env_safety" dz="2*HCalRing_zmax + 2*env_safety" />
+	<shape type="PolyhedraRegular" numsides="HCalEndcap_outer_symmetry" rmin="0" rmax="HCalRing_rmax + 5*env_safety" dz="2*HCalRing_zmin - 2*env_safety"/>
+      </shape>
+      <rotation x="0*deg" y="0*deg" z="90*deg-180*deg/HCalEndcap_outer_symmetry"/>
+    </envelope>
+
+    <layer repeat="1">
+      <slice material="Air" thickness="0.0001*mm" vis="InvisibleNoDaughters"/>
+    </layer>
+    
+  </detector>
+</detectors>
+
+</lccdd>

--- a/SiD/compact/SiD_o2_v04/LumiCal_o2_v04.xml
+++ b/SiD/compact/SiD_o2_v04/LumiCal_o2_v04.xml
@@ -1,0 +1,41 @@
+<lccdd>
+
+<readouts>
+    <readout name="LumiCalHits">
+      <segmentation type="CartesianGridXY" grid_size_x="LumiCal_cell_size" grid_size_y="LumiCal_cell_size" />
+      <id>${GlobalForwardCaloReadoutID}</id>
+    </readout>
+</readouts>
+
+<detectors>
+ <detector id="DetID_LumiCal" name="LumiCal" reflect="true" type="DD4hep_CylindricalEndcapCalorimeter" readout="LumiCalHits" vis="LumiCalVis" calorimeterType="LUMI">
+
+  <comment>SiD Luminosity Calorimeter</comment>
+
+  <type_flags type=" DetType_CALORIMETER + DetType_ELECTROMAGNETIC + DetType_ENDCAP + DetType_FORWARD"/>
+  <dimensions inner_r = "LumiCal_rmin" outer_r = "LumiCal_rmax" inner_z = "LumiCal_zmin"/>
+  <envelope vis="LumiCalVis">
+   <shape type="BooleanShape" operation="Subtraction" material="Air">
+     <shape type="Tube" rmin="LumiCal_rmin - env_safety" rmax="LumiCal_rmax + env_safety" dz="2*(LumiCal_zmax + env_safety)"/>
+     <shape type="Tube" rmin="0" rmax="LumiCal_rmax + 2*env_safety" dz="2*(LumiCal_zmin - env_safety)"/>
+   </shape>
+  </envelope>
+
+  <layer repeat="20" >
+    <slice material = "TungstenDens24" thickness = "0.271*cm" />
+    <slice material = "Silicon" thickness = "0.032*cm" sensitive = "yes" />
+    <slice material = "Copper"  thickness = "0.005*cm" />
+    <slice material = "Kapton"  thickness = "0.030*cm" />
+    <slice material = "Air"     thickness = "0.032*cm" />
+  </layer>
+  <layer repeat="10" >
+    <slice material = "TungstenDens24" thickness = "0.543*cm" />
+    <slice material = "Silicon" thickness = "0.032*cm" sensitive = "yes" />
+    <slice material = "Copper"  thickness = "0.005*cm" />
+    <slice material = "Kapton"  thickness = "0.030*cm" />
+    <slice material = "Air"     thickness = "0.032*cm" />
+  </layer>
+ </detector>
+</detectors>
+
+</lccdd>

--- a/SiD/compact/SiD_o2_v04/MuonBarrel_o2_v04.xml
+++ b/SiD/compact/SiD_o2_v04/MuonBarrel_o2_v04.xml
@@ -1,0 +1,76 @@
+<lccdd>
+
+<!--
+   This version uses Scintillators instead of Gas RPCs
+   by protopop@cern.ch - Nov 20, 2017
+-->
+
+<readouts>
+    <readout name="MuonBarrelHits">
+      <segmentation type="CartesianGridXY" grid_size_x="MuonCal_cell_size" grid_size_y="MuonCal_cell_size" />
+      <id>${GlobalCalorimeterReadoutID}</id>
+    </readout>
+</readouts>
+
+<detectors>
+  <!-- alternate drivers: GenericCalBarrel_o1_v01, DD4hep_PolyhedraBarrelCalorimeter2, YokeBarrel_o1_v01 -->
+  <!-- Note generic version needed currently for pandora extensions, and can't handle two sensitive slices per layer  -->
+  <detector id="DetID_Muon_Barrel" name="MuonBarrel" type="SteppedMuonBarrel_o2_v02" readout="MuonBarrelHits" vis="MuonBarrelVis" calorimeterType="MUON_BARREL" gap="0.0*cm" material="Steel235">
+
+    <comment>Muon Calorimeter Barrel</comment>
+    
+    <type_flags type=" DetType_CALORIMETER + DetType_MUON + DetType_BARREL "/>
+    
+    <dimensions numsides="MuonBarrel_symmetry" rmin="MuonBarrel_rmin" rmax="MuonBarrel_rmax" z="2*MuonBarrel_half_length"/>
+    
+    <envelope vis="MuonBarrelVis">
+      <shape type="Assembly"/>
+    </envelope>
+    
+    <staves material="Iron" vis="GrayVis"/>
+    <layer repeat="11" vis="RedVis">
+      <!-- 2 x (7.383mm active stack + 7.5mm air) + 10mm air + 196mm iron -->
+      <slice material="Air"         thickness="7.5*mm" />
+      <slice material="Steel235"    thickness="0.5*mm" />    <!-- Top plate -->
+      <slice material="Kapton"      thickness="0.115*mm" />  <!-- Polyimide foil -->
+      <slice material="Copper"      thickness="0.068*mm" />
+      <slice material="PCB"         thickness="1.0*mm" />    <!-- PCB made of FR4 -->
+      <slice material="Polystyrole" thickness="0.1*mm" />    <!-- Reflector foil -->
+      <slice material="Polystyrene" thickness="3.0*mm" sensitive="yes" limits="cal_limits" />
+      <slice material="Polystyrole" thickness="0.1*mm" />    <!-- Reflector foil -->
+      <slice material="Steel235"    thickness="0.5*mm" />    <!-- Bottom plate -->
+      <slice material="Air"         thickness="10.0*mm" />   <!-- Clearance gap between active layers -->
+      <!-- repeats -->
+      <slice material="Steel235"    thickness="0.5*mm" />    <!-- Top plate -->
+      <slice material="Kapton"      thickness="0.115*mm" />  <!-- Polyimide foil -->
+      <slice material="Copper"      thickness="0.068*mm" />
+      <slice material="PCB"         thickness="1.0*mm" />    <!-- PCB made of FR4 -->
+      <slice material="Polystyrole" thickness="0.1*mm" />    <!-- Reflector foil -->
+      <slice material="Polystyrene" thickness="3.0*mm" sensitive="no" limits="cal_limits" />
+      <slice material="Polystyrole" thickness="0.1*mm" />    <!-- Reflector foil -->
+      <slice material="Steel235"    thickness="0.5*mm" />    <!-- Bottom plate -->
+      <slice material="Air"         thickness="7.5*mm" />    <!-- Clearance gap between active layer and next iron layer -->
+      <slice material="Iron"        thickness="196.0*mm" vis="RedVis" />    
+      
+      <!-- old structure: 2x15mm RPC + 10mm air + 196mm Fe --> 
+      <!-- slice material="Aluminum" thickness="0.1*cm" />
+      <slice material="Air" thickness="0.35*cm" />
+      <slice material="PyrexGlass" thickness="0.2*cm" />
+      <slice material="RPCGasDefault" thickness="0.2*cm" sensitive="yes" />
+      <slice material="PyrexGlass" thickness="0.2*cm" />
+      <slice material="Air" thickness="0.35*cm" />
+      <slice material="Aluminum" thickness="0.1*cm" />
+      <slice material="Aluminum" thickness="0.1*cm" />
+      <slice material="Air" thickness="0.35*cm" />
+      <slice material="PyrexGlass" thickness="0.2*cm" />
+      <slice material="RPCGasDefault" thickness="0.2*cm" sensitive="yes" />
+      <slice material="PyrexGlass" thickness="0.2*cm" />
+      <slice material="Air" thickness="0.35*cm" />
+      <slice material="Aluminum" thickness="0.1*cm" />
+      <slice material="Air" thickness="1.0*cm" />
+      <slice material="Iron" thickness="19.6*cm" /-->
+    </layer>
+ </detector>
+</detectors>
+
+</lccdd>

--- a/SiD/compact/SiD_o2_v04/MuonEndcap_o2_v04.xml
+++ b/SiD/compact/SiD_o2_v04/MuonEndcap_o2_v04.xml
@@ -1,0 +1,57 @@
+<lccdd>
+
+<!--
+   This version uses Scintillators instead of Gas RPCs
+   by protopop@cern.ch - Nov 20, 2017
+-->
+
+<readouts>
+    <readout name="MuonEndcapHits">
+      <segmentation type="CartesianGridXY" grid_size_x="MuonCal_cell_size" grid_size_y="MuonCal_cell_size" />
+      <id>${GlobalCalorimeterReadoutID}</id>
+    </readout>
+</readouts>
+
+<detectors>
+  <!-- alternate drivers: GenericCalEndcap_o1_v01, DD4hep_PolyhedraEndcapCalorimeter2 -->
+  <!-- Note generic version needed currently for pandora extensions, and can't handle two sensitive slices per layer  -->
+  <detector id="DetID_Muon_Endcap" name="MuonEndcap" type="SteppedMuonEndcap_o2_v02" readout="MuonEndcapHits" reflect="true" vis="MuonEndcapVis" calorimeterType="MUON_ENDCAP" gap="0.0*cm">
+    
+    <comment>Muon Calorimeter Endcaps</comment>
+    
+    <type_flags type=" DetType_CALORIMETER + DetType_MUON + DetType_ENDCAP"/>
+    
+    <dimensions numsides="MuonEndcap_outer_symmetry" nsides_inner="MuonEndcap_inner_symmetry" nsides_outer="MuonEndcap_outer_symmetry" zmin="MuonEndcap_zmin" rmin="MuonEndcap_rmin" rmax="MuonEndcap_rmax" />
+    
+    <envelope vis="MuonEndcapVis">
+      <shape type="Assembly"/>
+    </envelope>
+    
+    <layer repeat="11" vis="BlueVis">
+      <!-- 2 x (7.383mm active stack + 7.5mm air) + 10mm air + 196mm iron -->
+      <slice material="Air"         thickness="7.5*mm" />
+      <slice material="Steel235"    thickness="0.5*mm" />    <!-- Top plate -->
+      <slice material="Kapton"      thickness="0.115*mm" />  <!-- Polyimide foil -->
+      <slice material="Copper"      thickness="0.068*mm" />
+      <slice material="PCB"         thickness="1.0*mm" />    <!-- PCB made of FR4 -->
+      <slice material="Polystyrole" thickness="0.1*mm" />    <!-- Reflector foil -->
+      <slice material="Polystyrene" thickness="3.0*mm" sensitive="yes" limits="cal_limits" />
+      <slice material="Polystyrole" thickness="0.1*mm" />    <!-- Reflector foil -->
+      <slice material="Steel235"    thickness="0.5*mm" />    <!-- Bottom plate -->
+      <slice material="Air"         thickness="10.0*mm" />   <!-- Clearance gap between active layers -->
+      <!-- repeats -->
+      <slice material="Steel235"    thickness="0.5*mm" />    <!-- Top plate -->
+      <slice material="Kapton"      thickness="0.115*mm" />  <!-- Polyimide foil -->
+      <slice material="Copper"      thickness="0.068*mm" />
+      <slice material="PCB"         thickness="1.0*mm" />    <!-- PCB made of FR4 -->
+      <slice material="Polystyrole" thickness="0.1*mm" />    <!-- Reflector foil -->
+      <slice material="Polystyrene" thickness="3.0*mm" sensitive="yes" limits="cal_limits" />
+      <slice material="Polystyrole" thickness="0.1*mm" />    <!-- Reflector foil -->
+      <slice material="Steel235"    thickness="0.5*mm" />    <!-- Bottom plate -->
+      <slice material="Air"         thickness="7.5*mm" />    <!-- Clearance gap between active layer and next iron layer -->
+      <slice material="Iron"        thickness="196.0*mm" />
+    </layer>
+  </detector>
+</detectors>
+
+</lccdd>

--- a/SiD/compact/SiD_o2_v04/README.md
+++ b/SiD/compact/SiD_o2_v04/README.md
@@ -1,4 +1,8 @@
-Version 4 of the SiD option 2 model. Main changes and updates:
+Version 4 of the SiD option 2 model. Main changes and updates with respect to version 3:
 
-- fixed ECal layer 0 size and position
-- fixed beam pipe geometry (Chris Potter)
+- correct size and position of ECal layer 0 (via new driver ECalBarrel_o2_v04_geo.cpp)
+- correct beam pipe (from Chris Potter)
+- removed brass HCal model
+
+Other than that, all files are the same as in version 3, just relabelled.
+

--- a/SiD/compact/SiD_o2_v04/README.md
+++ b/SiD/compact/SiD_o2_v04/README.md
@@ -1,0 +1,4 @@
+Version 4 of the SiD option 2 model. Main changes and updates:
+
+- fixed ECal layer 0 size and position
+- fixed beam pipe geometry (Chris Potter)

--- a/SiD/compact/SiD_o2_v04/SiD_o2_v04.xml
+++ b/SiD/compact/SiD_o2_v04/SiD_o2_v04.xml
@@ -1,0 +1,259 @@
+<?xml version="1.0" encoding="utf-8"?>
+<lccdd xmlns:compact="http://www.lcsim.org/schemas/compact/1.0" 
+       xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" 
+       xs:noNamespaceSchemaLocation="http://www.lcsim.org/schemas/compact/1.0/compact.xsd">
+   <info name="SiD_o2_v04"
+        title="Silicon Detector 2022"
+        author="Norman Graf, Jeremy McCormick, Dan Protopopescu, Chris Potter"
+        url="http://confluence.slac.stanford.edu/display/ilc/sidloi"
+        status="development"
+        version="o2_v04">
+    <comment>The compact format for the Silicon Detector as of June 2022</comment>        
+  </info>
+
+  <includes>
+    <gdmlFile  ref="elements.xml"/>
+    <gdmlFile  ref="materials.xml"/>
+  </includes>
+
+  <define>
+    <constant name="world_side" value="30000*mm"/>
+    <constant name="world_x" value="world_side"/>
+    <constant name="world_y" value="world_side"/>
+    <constant name="world_z" value="world_side"/>
+
+    <constant name="env_safety" value="0.1*mm"/>
+
+    <constant name="DetID_NOTUSED"          value="0"/>
+
+    <constant name="DetID_Vertex_Barrel"    value="1"/>
+    <constant name="DetID_Vertex_Endcap"    value="2"/>
+    
+    <constant name="DetID_Tracker_Barrel"   value="3"/>
+    <constant name="DetID_Tracker_Endcap"   value="4"/>
+    <constant name="DetID_Tracker_Forward"  value="15"/>
+    
+    <constant name="DetID_ECal_Barrel"      value="5"/>
+    <constant name="DetID_ECal_Endcap"      value="29"/><!-- 6 or 29! (?) -->
+    
+    <constant name="DetID_HCAL_Barrel"      value="7"/>
+    <constant name="DetID_HCAL_Endcap"      value="8"/>
+    
+    <constant name="DetID_Muon_Barrel"      value="9"/>
+    <constant name="DetID_Muon_Endcap"      value="10"/>
+    
+    <constant name="DetID_LumiCal"          value="11"/>
+    <constant name="DetID_BeamCal"          value="12"/>
+
+    <constant name="DetID_HCAL_Ring"        value="13"/><!-- still needed? -->
+
+    <comment> suggested naming convention:
+
+      main parameters (see definitions in http://cern.ch/go/r9mZ):
+      
+      DET_rmin            : inner radius of tube like envelope  ( inscribed cylinder )
+      DET_rmax            : outer radius of tube like envelope  ( inscribed cylinder )
+      DET_half_length     : half length along z axis
+      DET_zmin            : smallest absolute value on z-axis
+      DET_zmax            : largest  absolute value on z-axis
+      DET_inner_symmetry  : number of sides on the inside  ( 0 for tube )
+      DET_outer_symmetry  : number of sides on the outside ( 0 for tube )
+      DET_symmetry        : number of sides if the same in- and outside
+      DET_inner_phi0      : optional rotation of the inner polygon ( in r-phi plane )
+      DET_outer_phi0      : optional rotation of the outer polygon ( in r-phi plane )
+      
+      additional parameters for cutting away volumes/shapes use one of the above with a number
+      appended and/or an extra specifiaction such as cone ( for a cut away cone )
+      
+      DET_rmin_1
+      DET_rmin_2
+      DET_cone_zmin
+      DET_cone_zmax
+      
+    </comment>    
+
+    <!-- These dimensions correspond to the 2016 SiD technical drawing 
+      except that a few milimeters of space were added between some 
+      adjacent subdetectors where none are shown in the 2016 drawing -->
+
+    <constant name="SiTracker_outer_radius" value="1235.0*mm"/>
+    <constant name="SiTracker_inner_radius" value="206.00*mm"/>
+    <constant name="SiTracker_zmax" value="1637.0*mm"/><!-- half-length -->
+    <constant name="SiTracker_EndcapLayers" value="4"/>
+    <constant name="SiTracker_BarrelLayers" value="SiTracker_EndcapLayers + 1"/>
+
+    <constant name="ECal_cell_size" value="3.5*mm" />
+    <constant name="ECalBarrel_half_length" value="1765.0*mm" />
+    <constant name="ECalBarrel_rmin" value="1264.0*mm" />
+    <constant name="ECalBarrel_rmax" value="1403.0*mm" />
+    <constant name="ECalBarrel_symmetry" value="12" />
+
+    <constant name="ECalEndcap_zmin" value="1657.0*mm" />
+    <constant name="ECalEndcap_zmax" value="1800.0*mm" />
+    <constant name="ECalEndcap_rmin"  value="216.0*mm" />
+    <constant name="ECalEndcap_rmax" value="1250.0*mm" />
+    <constant name="ECalEndcap_inner_symmetry" value="12" />
+    <constant name="ECalEndcap_outer_symmetry" value="12" />
+
+    <constant name="HCalBarrel_half_length" value="2950.0*mm" />
+    <constant name="HCalBarrel_rmin" value="1406.0*mm" />
+    <constant name="HCalBarrel_rmax" value="2487.0*mm" /><!-- circumscribing r=2568*mm -->
+    <constant name="HCalBarrel_symmetry" value="12" />
+
+    <constant name="HCal_cell_size" value="30.0*mm" />
+    <constant name="HCalEndcap_zmin" value="1801.0*mm" />
+    <constant name="HCalEndcap_zmax" value="3000.0*mm" />
+    <constant name="HCalEndcap_rmin" value="216.0*mm" />
+    <constant name="HCalEndcap_rmax" value="1400.0*mm" /><!-- check! -->
+    <constant name="HCalEndcap_inner_symmetry" value="12" />
+    <constant name="HCalEndcap_outer_symmetry" value="12" />
+
+    <constant name="MuonCal_cell_size" value="30.0*mm" />
+    <constant name="MuonBarrel_half_length" value="2950.0*mm" />
+    <constant name="MuonBarrel_rmin" value="3454.0*mm" />
+    <constant name="MuonBarrel_rmax" value="6054.0*mm" />
+    <constant name="MuonBarrel_symmetry" value="12" />
+    <constant name="MuonBarrel_end_angle" value="30.*deg" />
+
+    <constant name="MuonEndcap_zmin" value="3005.0*mm" />
+    <constant name="MuonEndcap_zmax" value="5600.0*mm" />
+    <constant name="MuonEndcap_rmin"  value="366.0*mm" />
+    <constant name="MuonEndcap_rmax" value="6054.0*mm" />
+    <constant name="MuonEndcap_inner_symmetry" value="12" />
+    <constant name="MuonEndcap_outer_symmetry" value="12" />    
+    <constant name="MuonEndcap_end_angle" value="30.*deg" />
+
+    <constant name="BeamCal_cell_size" value="3.5*mm"/>
+    <constant name="BeamCal_rmin" value="15.5*mm" />
+    <constant name="BeamCal_rmax" value="129.6*mm" />
+    <constant name="BeamCal_zmin" value="3039.0*mm" />
+    <constant name="BeamCal_zmax" value="3399.0*mm" />
+   
+    <constant name="LumiCal_cell_size" value="3.5*mm"/>
+    <constant name="LumiCal_rmin" value="60.0*mm"/>
+    <constant name="LumiCal_rmax" value="195.0*mm"/>
+    <constant name="LumiCal_zmin" value="1557.0*mm"/>
+    <constant name="LumiCal_zmax" value="1700.0*mm"/>
+
+    <constant name="tracking_region_radius" value="ECalBarrel_rmin - 10*env_safety"/>
+    <constant name="tracking_region_zmax" value="ECalEndcap_zmin - 10*env_safety"/>    
+    <constant name="tracker_region_rmax" value="tracking_region_radius"/>  
+    <constant name="tracker_region_zmax" value="tracking_region_zmax"/> 
+
+    <constant name="VXD_CF_sensor" value="0.026*cm"/>
+    <constant name="VXD_CF_support" value="0.05*cm"/>
+    <constant name="bp_cone_slope" value="(8.96-1.20)/(185-6.25)"/>
+
+    <constant name="Solenoid_inner_radius" value="2604*mm"/>
+    <constant name="Solenoid_half_length" value="2950*mm"/>
+    <constant name="SolenoidEndcapCryostatThickness" value="5.0*cm"/>
+    <constant name="SolenoidEndcapAirgapThickness" value="19.0*cm"/>
+    <constant name="Solenoid_Coil_half_length" value="Solenoid_half_length-SolenoidEndcapCryostatThickness-SolenoidEndcapAirgapThickness"/>
+    <constant name="Solenoid_outer_radius" value="3429*mm"/>
+
+    <constant name="GlobalTrackerReadoutID"     type="string" value="system:5,side:-2,layer:6,module:11,sensor:8"/>
+    <constant name="GlobalCalorimeterReadoutID" type="string" value="system:5,side:-2,module:8,stave:4,layer:9,submodule:4,x:32:-16,y:-16"/>
+    <constant name="GlobalForwardCaloReadoutID" type="string" value="system:8,barrel:3,layer:8,slice:8,x:32:-16,y:-16"/>
+
+  </define>
+
+  <limits>
+    <limitset name="cal_limits">
+      <limit name="step_length_max" particles="*" value="5.0" unit="mm" />
+    </limitset>
+  </limits>
+
+  <display>
+    <vis name="BeampipeVis" r="0.7734375" g="0.8671875" b="0.99609375" />
+
+    <vis name="SiVertexBarrelVis" r="0.5" g="0.7" b="0.4" />
+    <vis name="SiVertexEndcapVis" r="0.5" g="0.7" b="0.4" />
+
+    <vis name="SiTrackerForwardVis" r="0.8" g="0.1" b="0.1" />
+
+    <vis name="SiTrackerBarrelVis" r="0.8" g="1.0" b="0.1" />
+    <vis name="SiTrackerEndcapVis" r="0.0" g="0.25" b="0.53" />
+
+    <vis name="ECalBarrelVis" r="0.77" g="0.74" b="0.86" />
+    <vis name="ECalEndcapVis" r="0.77" g="0.74" b="0.86" />
+
+    <vis name="HCalBarrelVis" r="0.296875" g="0.48828125" b="0.4921875" />
+    <vis name="HCalEndcapVis" r="0.296875" g="0.48828125" b="0.4921875" />
+    
+    <vis name="SOLVis" r="0.20703125" g="0.453125" b="0.77734375" />
+    <vis name="EnvelopeVis" alpha="1.0" r="0.8"  g="0.8"  b="0.4" visible="false"/>
+
+    <vis name="MuonEndcapVis" r="0.28125" g="0.390625" b="0.625" />
+    <vis name="MuonBarrelVis" r="0.28125" g="0.390625" b="0.625" />
+    <vis name="SteppedMuonVis" r="0.28125" g="0.390625" b="0.625" />
+    
+    <vis name="LumiCalVis" r="0.5" g="0.5" b="0.5" />
+    <vis name="BeamCalVis" r="0.8" g="0.3" b="0.5" />
+
+    <!-- for testing -->
+    <vis name="RedVis"           alpha="1.0" r="1.0" g="0.0"  b="0.0"   showDaughters="false"  visible="true"/>
+    <vis name="GreenVis"         alpha="1.0" r="0.0" g="1.0"  b="0.0"   showDaughters="true"  visible="true"/>
+    <vis name="BlueVis"          alpha="1.0" r="0.0" g="0.0"  b="1.0"   showDaughters="false"  visible="true"/>
+    <vis name="CyanVis"          alpha="1.0" r="0.0" g="1.0"  b="1.0"   showDaughters="true"  visible="true"/>
+    <vis name="MagentaVis"       alpha="1.0" r="1.0" g="0.0"  b="1.0"   showDaughters="true"  visible="true"/>
+    <vis name="YellowVis"        alpha="1.0" r="1.0" g="1.0"  b="0.0"   showDaughters="true"  visible="true"/>
+    <vis name="BlackVis"         alpha="1.0" r="0.0" g="0.0"  b="0.0"   showDaughters="true"  visible="true"/>
+    <vis name="GrayVis"          alpha="1.0" r="0.5" g="0.5"  b="0.5"   showDaughters="true"  visible="true"/>
+
+  </display>
+
+  <!-- ####################### Individual sub-detectors ####################### -->
+
+  <include ref="${DD4hepINSTALL}/DDDetectors/compact/detector_types.xml"/>
+
+  <comment>Trackers</comment> 
+
+  <include ref="SiVertexBarrel_o2_v04.xml"/>
+  <include ref="SiVertexEndcap_o2_v04.xml"/>
+
+  <include ref="SiTrackers_o2_v04.xml"/>
+  <!-- the above includes now these two:
+  <include ref="SiTrackerBarrel_o2_v04.xml"/>
+  <include ref="SiTrackerEndcap_o2_v04.xml"/-->
+
+  <include ref="SiTrackerForward_o2_v04.xml"/>
+
+  <comment>Calorimeters</comment>  
+
+  <include ref="ECalBarrel_o2_v04.xml"/>
+  <include ref="ECalEndcap_o2_v04.xml"/>
+
+  <include ref="HCalBarrel_o2_v04.xml"/>
+  <include ref="HCalEndcap_o2_v04.xml"/>
+  <include ref="HCalRing_o2_v04.xml"/>
+
+  <include ref="SteppedMuon_o2_v04.xml"/>
+
+  <!-- check envelopes for these two -->
+  <include ref="LumiCal_o2_v04.xml"/>
+  <include ref="BeamCal_o2_v04.xml"/>
+
+  <include ref="Solenoid_o2_v04.xml"/>
+
+  <comment>Beam pipe</comment>
+  <include ref="BeamPipe_o2_v04.xml">
+  
+  <comment>Dead material and supports</comment>
+  <comment>Vertex Detector Supports and Readout</comment>  
+  <!--  FG: fixme: should be split up into more individual files  ... -->
+  <!-- <include ref="Support.xml"/> -->
+
+  <!-- ############ Individual plugins are now in SUBDET.xml files ############# -->
+  <plugins>
+    <plugin name="InstallSurfaceManager"/>
+  </plugins>
+
+  <!-- ############ Individual readouts are now in SUBDET.xml files ############# -->
+
+  <fields>
+    <field type="solenoid" name="GlobalSolenoid" inner_field="5.0*tesla"
+           outer_field="-0.6*tesla" zmax="2950*mm"
+           outer_radius="Solenoid_outer_radius" />
+  </fields>
+
+</lccdd>

--- a/SiD/compact/SiD_o2_v04/SiD_o2_v04.xml
+++ b/SiD/compact/SiD_o2_v04/SiD_o2_v04.xml
@@ -236,11 +236,11 @@
   <include ref="Solenoid_o2_v04.xml"/>
 
   <comment>Beam pipe</comment>
-  <include ref="BeamPipe_o2_v04.xml">
+  <include ref="BeamPipe_o2_v04.xml"/>
   
   <comment>Dead material and supports</comment>
   <comment>Vertex Detector Supports and Readout</comment>  
-  <!--  FG: fixme: should be split up into more individual files  ... -->
+  <!-- FG: fixme: should be split up into more individual files  ... -->
   <!-- <include ref="Support.xml"/> -->
 
   <!-- ############ Individual plugins are now in SUBDET.xml files ############# -->

--- a/SiD/compact/SiD_o2_v04/SiTrackerBarrel_o2_v04.xml
+++ b/SiD/compact/SiD_o2_v04/SiTrackerBarrel_o2_v04.xml
@@ -1,0 +1,271 @@
+<lccdd>
+
+<!-- 
+  This barrel implementation allows easy adjustment of the number of layers BNL,
+  between 3 and 5, with everything scaling accordingly. Default BNL=5 
+-->
+
+<define>
+
+  <constant name="SiTracker_tanTheta" value="0.949"/><!-- Theta = 43.5*deg -->
+  <constant name="SiTracker_bIntercept" value="-180*mm"/>
+
+  <constant name="SiTrackerBarrel_rc_dr" value="5.0*mm"/>
+  <constant name="SiTrackerBarrel_inner_rc" value="216.355*mm + SiTrackerBarrel_rc_dr"/><!-- rc_1 -->
+  <constant name="SiTrackerBarrel_inner_z0" value="512.128*mm"/><!-- z0_1 -->
+
+  <constant name="SiTrackerBarrel_outer_rc" value="1216.355*mm + SiTrackerBarrel_rc_dr"/><!-- rc_5 -->
+  <constant name="SiTrackerBarrel_outer_z0" value="1476.497*mm"/><!-- z0_5 -->
+
+  <constant name="SiTrackerBarrel_r_spacing" value="(SiTrackerBarrel_outer_rc - SiTrackerBarrel_inner_rc)/(SiTracker_BarrelLayers - 1)"/>
+
+  <!-- 
+    5 Layers, the innermost slightly longer, r_spacing = 250*mm, the layers in between are calculated below 
+    All measurements are from sidloi3, to enable comparison with the hardcoded model. 
+    Measurements will be updated once all arithmetics is validated. 
+  --> 
+
+  <constant name="SiTrackerBarrel_rc_2" value="SiTrackerBarrel_inner_rc + SiTrackerBarrel_r_spacing"/><!-- 466.355 + 5 -->
+  <constant name="SiTrackerBarrel_z0_2" value="(SiTrackerBarrel_rc_2 - SiTracker_bIntercept)/SiTracker_tanTheta"/><!-- 686.36 -->
+
+  <constant name="SiTrackerBarrel_rc_3" value="SiTrackerBarrel_rc_2 + SiTrackerBarrel_r_spacing"/><!-- 716.355 + 5 -->
+  <constant name="SiTrackerBarrel_z0_3" value="(SiTrackerBarrel_rc_3 - SiTracker_bIntercept)/SiTracker_tanTheta"/><!-- 949.80 -->
+
+  <constant name="SiTrackerBarrel_rc_4" value="SiTrackerBarrel_rc_3 + SiTrackerBarrel_r_spacing"/><!-- 966.355 + 5 -->
+  <constant name="SiTrackerBarrel_z0_4" value="(SiTrackerBarrel_rc_4 - SiTracker_bIntercept)/SiTracker_tanTheta"/><!-- 1213.23 -->
+
+  <constant name="SiTracker_module_z_spacing" value="42.2*mm"/><!-- SiTrackerBarrel_module_length*some_overlap_factor -->
+  <constant name="SiTrackerBarrel_inner_nz" value="1 + floor(SiTrackerBarrel_inner_z0/SiTracker_module_z_spacing)"/><!-- 13 --> 
+  <constant name="SiTrackerBarrel_nz_2" value="1 + floor(SiTrackerBarrel_z0_2/SiTracker_module_z_spacing)"/><!-- 17 -->
+  <constant name="SiTrackerBarrel_nz_3" value="1 + floor(SiTrackerBarrel_z0_3/SiTracker_module_z_spacing)"/><!-- 23 -->
+  <constant name="SiTrackerBarrel_nz_4" value="1 + floor(SiTrackerBarrel_z0_4/SiTracker_module_z_spacing)"/><!-- 29 -->
+  <constant name="SiTrackerBarrel_outer_nz" value="1 + floor(SiTrackerBarrel_outer_z0/SiTracker_module_z_spacing)"/><!-- 35 -->
+
+  <constant name="SiTracker_circular_spacing" value="12.2*mm"/><!-- SiTrackerBarrel_module_width*some_overlap_factor/2*pi -->
+  <constant name="SiTrackerBarrel_inner_nphi" value="floor(SiTrackerBarrel_inner_rc/SiTracker_circular_spacing)"/><!-- 18(20) -->
+  <constant name="SiTrackerBarrel_nphi_2" value="floor(SiTrackerBarrel_rc_2/SiTracker_circular_spacing)"/><!-- 38 -->
+  <constant name="SiTrackerBarrel_nphi_3" value="floor(SiTrackerBarrel_rc_3/SiTracker_circular_spacing)"/><!-- 59(58) -->
+  <constant name="SiTrackerBarrel_nphi_4" value="floor(SiTrackerBarrel_rc_4/SiTracker_circular_spacing)"/><!-- 79(80) -->
+  <constant name="SiTrackerBarrel_outer_nphi" value="floor(SiTrackerBarrel_outer_rc/SiTracker_circular_spacing)"/><!-- 100(102) -->
+
+  <constant name="SiTrackerBarrel_module_width" value="97.97*mm"/>
+  <constant name="SiTrackerBarrel_module_length" value="97.97*mm"/>
+
+</define>
+
+<readouts>
+    <readout name="SiTrackerBarrelHits">
+      <id>${GlobalTrackerReadoutID}</id>
+    </readout>
+</readouts>
+
+<detectors>
+ <!-- We use here NN's TrackerBarrel_o1_v03 driver -->
+ <detector id="DetID_Tracker_Barrel" name="SiTrackerBarrel" type="TrackerBarrel_o1_v03" readout="SiTrackerBarrelHits" vis="SiTrackerBarrelVis">
+
+  <envelope vis="EnvelopeVis">
+     <shape type="Assembly"/>
+  </envelope>
+
+  <comment>SiD Silicon Tracker Barrel</comment>
+
+  <type_flags type=" DetType_TRACKER + DetType_BARREL"/>
+
+  <module name="SiTrackerModule_Layer1" vis="GrayVis">
+    <module_envelope width="97.97*mm" length="97.97*mm" thickness="0.3*cm"/>
+    <module_component width="97.97*mm" length="97.97*mm" thickness="0.02*cm" material="PEEK" sensitive="false">
+      <position z="-0.14*cm" />
+    </module_component>
+    <module_component width="97.97*mm" length="97.97*mm" thickness="0.016*cm" material="CarbonFiber_50D" sensitive="false">
+      <position z="-0.122*cm" />
+    </module_component>
+    <module_component width="97.97*mm" length="97.97*mm" thickness="0.18*cm" material="Rohacell31_50D" sensitive="false">
+      <position z="-0.024*cm" />
+    </module_component>
+    <module_component width="97.97*mm" length="97.97*mm" thickness="0.0175*cm" material="Epoxy" sensitive="false">
+      <position z="0.07475*cm" />
+    </module_component>
+    <module_component width="97.97*mm" length="97.97*mm" thickness="0.016*cm" material="CarbonFiber_50D" sensitive="false">
+      <position z="0.0915*cm" />
+    </module_component>
+    <module_component width="92.031*mm" length="92.031*mm" thickness="0.03*cm" material="Silicon" sensitive="true">
+      <position z="0.1145*cm"/>
+    </module_component>
+    <module_component width="97.97*mm" length="97.97*mm" thickness="0.00048*cm" material="Silicon" sensitive="false">
+      <position z="0.12974*cm"/>
+    </module_component>
+    <module_component width="97.97*mm" length="97.97*mm" thickness="0.0038*cm" material="Kapton" sensitive="false">
+      <position z="0.1375*cm"/>
+    </module_component>
+    <module_component width="97.97*mm" length="97.97*mm" thickness="0.00038*cm" material="Copper" sensitive="false">
+      <position z="0.146*cm"/>
+    </module_component>
+  </module>
+
+  <module name="SiTrackerModule_Layer2" vis="RedVis">
+    <module_envelope width="97.97*mm" length="97.97*mm" thickness="0.3*cm"/>
+    <module_component width="97.97*mm" length="97.97*mm" thickness="0.02*cm" material="PEEK" sensitive="false">
+      <position z="-0.14*cm" />
+    </module_component>
+    <module_component width="97.97*mm" length="97.97*mm" thickness="0.016*cm" material="CarbonFiber_50D" sensitive="false">
+      <position z="-0.122*cm" />
+    </module_component>
+    <module_component width="97.97*mm" length="97.97*mm" thickness="0.18*cm" material="Rohacell31_50D" sensitive="false">
+      <position z="-0.024*cm" />
+    </module_component>
+    <module_component width="97.97*mm" length="97.97*mm" thickness="0.0175*cm" material="Epoxy" sensitive="false">
+      <position z="0.07475*cm" />
+    </module_component>
+    <module_component width="97.97*mm" length="97.97*mm" thickness="0.016*cm" material="CarbonFiber_50D" sensitive="false">
+      <position z="0.0915*cm" />
+    </module_component>
+    <module_component width="92.031*mm" length="92.031*mm" thickness="0.03*cm" material="Silicon" sensitive="true">
+      <position z="0.1145*cm"/>
+    </module_component>
+    <module_component width="97.97*mm" length="97.97*mm" thickness="0.00048*cm" material="Silicon" sensitive="false">
+      <position z="0.12974*cm"/>
+    </module_component>
+    <module_component width="97.97*mm" length="97.97*mm" thickness="0.0051*cm" material="Kapton" sensitive="false">
+      <position z="0.1375*cm"/>
+    </module_component>
+    <module_component width="97.97*mm" length="97.97*mm" thickness="0.00052*cm" material="Copper" sensitive="false">
+      <position z="0.146*cm"/>
+    </module_component>
+  </module>
+
+  <module name="SiTrackerModule_Layer3" vis="GrayVis">
+    <module_envelope width="97.97*mm" length="97.97*mm" thickness="0.3*cm"/>
+    <module_component width="97.97*mm" length="97.97*mm" thickness="0.02*cm" material="PEEK" sensitive="false">
+      <position z="-0.14*cm" />
+    </module_component>
+    <module_component width="97.97*mm" length="97.97*mm" thickness="0.016*cm" material="CarbonFiber_50D" sensitive="false">
+      <position z="-0.122*cm" />
+    </module_component>
+    <module_component width="97.97*mm" length="97.97*mm" thickness="0.18*cm" material="Rohacell31_50D" sensitive="false">
+      <position z="-0.024*cm" />
+    </module_component>
+    <module_component width="97.97*mm" length="97.97*mm" thickness="0.0175*cm" material="Epoxy" sensitive="false">
+      <position z="0.07475*cm" />
+    </module_component>
+    <module_component width="97.97*mm" length="97.97*mm" thickness="0.016*cm" material="CarbonFiber_50D" sensitive="false">
+      <position z="0.0915*cm" />
+    </module_component>
+    <module_component width="92.031*mm" length="92.031*mm" thickness="0.03*cm" material="Silicon" sensitive="true">
+      <position z="0.1145*cm"/>
+    </module_component>
+    <module_component width="97.97*mm" length="97.97*mm" thickness="0.00048*cm" material="Silicon" sensitive="false">
+      <position z="0.12974*cm"/>
+    </module_component>
+    <module_component width="97.97*mm" length="97.97*mm" thickness="0.0064*cm" material="Kapton" sensitive="false">
+      <position z="0.1375*cm"/>
+    </module_component>
+    <module_component width="97.97*mm" length="97.97*mm" thickness="0.00065*cm" material="Copper" sensitive="false">
+      <position z="0.146*cm"/>
+    </module_component>
+  </module>
+
+  <module name="SiTrackerModule_Layer4" vis="RedVis">
+    <module_envelope width="97.97*mm" length="97.97*mm" thickness="0.3*cm"/>
+    <module_component width="97.97*mm" length="97.97*mm" thickness="0.02*cm" material="PEEK" sensitive="false">
+      <position z="-0.14*cm" />
+    </module_component>
+    <module_component width="97.97*mm" length="97.97*mm" thickness="0.016*cm" material="CarbonFiber_50D" sensitive="false">
+      <position z="-0.122*cm" />
+    </module_component>
+    <module_component width="97.97*mm" length="97.97*mm" thickness="0.18*cm" material="Rohacell31_50D" sensitive="false">
+      <position z="-0.024*cm" />
+    </module_component>
+    <module_component width="97.97*mm" length="97.97*mm" thickness="0.0175*cm" material="Epoxy" sensitive="false">
+      <position z="0.07475*cm" />
+    </module_component>
+    <module_component width="97.97*mm" length="97.97*mm" thickness="0.016*cm" material="CarbonFiber_50D" sensitive="false">
+      <position z="0.0915*cm" />
+    </module_component>
+    <module_component width="92.031*mm" length="92.031*mm" thickness="0.03*cm" material="Silicon" sensitive="true">
+      <position z="0.1145*cm"/>
+    </module_component>
+    <module_component width="97.97*mm" length="97.97*mm" thickness="0.00048*cm" material="Silicon" sensitive="false">
+      <position z="0.12974*cm"/>
+    </module_component>
+    <module_component width="97.97*mm" length="97.97*mm" thickness="0.0078*cm" material="Kapton" sensitive="false">
+      <position z="0.1375*cm"/>
+    </module_component>
+    <module_component width="97.97*mm" length="97.97*mm" thickness="0.00079*cm" material="Copper" sensitive="false">
+      <position z="0.146*cm"/>
+    </module_component>
+  </module>
+
+  <module name="SiTrackerModule_Layer5" vis="GrayVis">
+    <module_envelope width="97.97*mm" length="97.97*mm" thickness="0.3*cm"/>
+    <module_component width="97.97*mm" length="97.97*mm" thickness="0.02*cm" material="PEEK" sensitive="false">
+      <position z="-0.14*cm" />
+    </module_component>
+    <module_component width="97.97*mm" length="97.97*mm" thickness="0.016*cm" material="CarbonFiber_50D" sensitive="false">
+      <position z="-0.122*cm" />
+    </module_component>
+    <module_component width="97.97*mm" length="97.97*mm" thickness="0.18*cm" material="Rohacell31_50D" sensitive="false">
+      <position z="-0.024*cm" />
+    </module_component>
+    <module_component width="97.97*mm" length="97.97*mm" thickness="0.0175*cm" material="Epoxy" sensitive="false">
+      <position z="0.07475*cm" />
+    </module_component>
+    <module_component width="97.97*mm" length="97.97*mm" thickness="0.016*cm" material="CarbonFiber_50D" sensitive="false">
+      <position z="0.0915*cm" />
+    </module_component>
+    <module_component width="92.031*mm" length="92.031*mm" thickness="0.03*cm" material="Silicon" sensitive="true">
+      <position z="0.1145*cm"/>
+    </module_component>
+    <module_component width="97.97*mm" length="97.97*mm" thickness="0.00048*cm" material="Silicon" sensitive="false">
+      <position z="0.12974*cm"/>
+    </module_component>
+    <module_component width="97.97*mm" length="97.97*mm" thickness="0.0091*cm" material="Kapton" sensitive="false">
+      <position z="0.1375*cm"/>
+    </module_component>
+    <module_component width="97.97*mm" length="97.97*mm" thickness="0.00093*cm" material="Copper" sensitive="false">
+      <position z="0.146*cm"/>
+    </module_component>
+  </module>
+
+  <layer module="SiTrackerModule_Layer1" id="1">
+    <!--barrel_envelope inner_r="215.075*mm" outer_r="245.0*mm" z_length="578 * 2*mm"/-->
+    <barrel_envelope inner_r="SiTrackerBarrel_inner_rc - 6.2*mm" outer_r="SiTrackerBarrel_inner_rc + 45.0*mm" z_length="(SiTrackerBarrel_inner_z0 + 60*mm)*2"/>
+    <rphi_layout phi_tilt="0.17506*rad" nphi="SiTrackerBarrel_inner_nphi" phi0="0.*rad" rc="SiTrackerBarrel_inner_rc" dr="0.0"/>
+    <z_layout dr="4.0*mm" z0="SiTrackerBarrel_inner_z0" nz="SiTrackerBarrel_inner_nz"/>
+  </layer>
+
+  <layer module="SiTrackerModule_Layer2" id="2">
+    <!--barrel_envelope inner_r="465.075*mm" outer_r="501.0*mm" z_length="749.8 * 2*mm"/-->
+    <barrel_envelope inner_r="SiTrackerBarrel_rc_2 - 6.2*mm" outer_r="SiTrackerBarrel_rc_2 + 45.0*mm" z_length="(SiTrackerBarrel_z0_2 + 60*mm)*2"/>
+    <rphi_layout phi_tilt="0.12217*rad" nphi="SiTrackerBarrel_nphi_2" phi0="0.087*rad" rc="SiTrackerBarrel_rc_2" dr="0.0"/>
+    <z_layout dr="4.0*mm" z0="SiTrackerBarrel_z0_2" nz="SiTrackerBarrel_nz_2"/>
+  </layer>
+
+  <layer module="SiTrackerModule_Layer3" id="3">
+    <barrel_envelope inner_r="SiTrackerBarrel_rc_3 - 6.2*mm" outer_r="SiTrackerBarrel_rc_3 + 45.0*mm" z_length="(SiTrackerBarrel_z0_3 + 60*mm)*2"/>
+    <rphi_layout phi_tilt="0.11493*rad" nphi="SiTrackerBarrel_nphi_3" phi0="0.058*rad" rc="SiTrackerBarrel_rc_3" dr="0.0"/>
+    <z_layout dr="4.0*mm" z0="SiTrackerBarrel_z0_3" nz="SiTrackerBarrel_nz_3"/>
+  </layer>
+
+  <layer module="SiTrackerModule_Layer4" id="4">
+    <barrel_envelope inner_r="SiTrackerBarrel_rc_4 - 6.2*mm" outer_r="SiTrackerBarrel_rc_4 + 45.0*mm" z_length="(SiTrackerBarrel_z0_4 + 60*mm)*2"/>
+    <rphi_layout phi_tilt="0.11502*rad" nphi="SiTrackerBarrel_nphi_4" phi0="0.0436*rad" rc="SiTrackerBarrel_rc_4" dr="0.0"/>
+    <z_layout dr="4.0*mm" z0="SiTrackerBarrel_z0_4" nz="SiTrackerBarrel_nz_4"/>
+  </layer>
+
+  <layer module="SiTrackerModule_Layer5" id="5">
+    <!--barrel_envelope inner_r="1215.075*mm" outer_r="1263.0*mm" z_length="1535.7 * 2*mm"/-->
+    <barrel_envelope inner_r="SiTrackerBarrel_outer_rc - 6.2*mm" outer_r="SiTrackerBarrel_outer_rc + 45.0*mm" z_length="(SiTrackerBarrel_outer_z0 + 60*mm)*2"/>
+    <rphi_layout phi_tilt="0.11467*rad" nphi="SiTrackerBarrel_outer_nphi" phi0="0.01745*rad" rc="SiTrackerBarrel_outer_rc" dr="0.0"/>
+    <z_layout dr="4.0*mm" z0="SiTrackerBarrel_outer_z0" nz="SiTrackerBarrel_outer_nz"/>
+  </layer>
+ </detector>
+</detectors>
+
+<plugins>
+    <plugin name="DD4hep_SiTrackerBarrelSurfacePlugin">
+      <argument value="SiTrackerBarrel"/>
+      <argument value="dimension=1"/>
+    </plugin>
+</plugins>
+
+</lccdd>

--- a/SiD/compact/SiD_o2_v04/SiTrackerEndcap_o2_v04.xml
+++ b/SiD/compact/SiD_o2_v04/SiTrackerEndcap_o2_v04.xml
@@ -1,0 +1,109 @@
+<lccdd>
+
+<readouts>
+    <readout name="SiTrackerEndcapHits">
+      <id>${GlobalTrackerReadoutID}</id>
+    </readout>
+</readouts>
+
+<detectors>
+ <!-- this works with SiTrackerEndcap_o2_v01ext only if we have one sensitive slice per module, see below --> 
+ <detector id="DetID_Tracker_Endcap" name="SiTrackerEndcap" type="SiTrackerEndcap_o2_v01ext" readout="SiTrackerEndcapHits" reflect="true" vis="SiTrackerEndcapVis">
+
+  <envelope vis="EnvelopeVis">
+    <shape type="Assembly"/>
+  </envelope>
+
+  <comment>SiD Silicon Tracker Endcaps</comment>
+
+  <type_flags type=" DetType_TRACKER + DetType_ENDCAP"/>
+
+  <module name="Module1" vis="GrayVis">
+    <trd x1="36.112*mm" x2="46.635*mm" z="100.114/2*mm" />
+    <module_component thickness="0.00052*cm"   material="Copper" />
+    <module_component thickness="0.0051*cm"   material="Kapton" />
+    <module_component thickness="0.00048*cm" material="Silicon" />
+    <module_component thickness="0.03*cm"   material="Silicon" sensitive="true" />
+    <module_component thickness="0.016*cm" material="CarbonFiber_50D" />
+    <module_component thickness="0.18*cm" material="Rohacell31_50D" />
+    <module_component thickness="0.016*cm" material="CarbonFiber_50D" />
+    <module_component thickness="0.0175*cm" material="Epoxy" />
+    <module_component thickness="0.03*cm"   material="Silicon" sensitive="false" />
+    <module_component thickness="0.00048*cm" material="Silicon" />
+    <module_component thickness="0.0051*cm"   material="Kapton" />
+    <module_component thickness="0.00052*cm"   material="Copper" />
+  </module>
+
+  <module name="Module2" vis="GreenVis">
+    <trd x1="45.245*mm" x2="54.680*mm" z="89.773/2*mm" />
+    <module_component thickness="0.00079*cm"   material="Copper" />
+    <module_component thickness="0.0078*cm"   material="Kapton" />
+    <module_component thickness="0.00048*cm" material="Silicon" />
+    <module_component thickness="0.03*cm"   material="Silicon" sensitive="true" />
+    <module_component thickness="0.016*cm" material="CarbonFiber_50D" />
+    <module_component thickness="0.18*cm" material="Rohacell31_50D" />
+    <module_component thickness="0.016*cm" material="CarbonFiber_50D" />
+    <module_component thickness="0.0175*cm" material="Epoxy" />
+    <module_component thickness="0.03*cm"   material="Silicon" sensitive="false" />
+    <module_component thickness="0.00048*cm" material="Silicon" />
+    <module_component thickness="0.0078*cm"   material="Kapton" />
+    <module_component thickness="0.00079*cm"   material="Copper" />
+  </module>
+
+  <layer id="1">
+    <ring r="256.716*mm" zstart="(787.105+1.75)*mm" nmodules="24" dz="1.75*mm" module="Module1"/>
+    <ring r="353.991*mm" zstart="(778.776+1.75)*mm" nmodules="32" dz="1.75*mm" module="Module1"/>
+    <ring r="449.180*mm" zstart="(770.544+1.75)*mm" nmodules="40" dz="1.75*mm" module="Module1"/>
+  </layer>
+
+  <layer id="2">
+    <ring r="256.716*mm" zstart="(1073.293+1.75)*mm" nmodules="24" dz="1.75*mm" module="Module1"/>
+    <ring r="353.991*mm" zstart="(1064.966+1.75)*mm" nmodules="32" dz="1.75*mm" module="Module1"/>
+    <ring r="449.180*mm" zstart="(1056.734+1.75)*mm" nmodules="40" dz="1.75*mm" module="Module1"/>
+    <ring r="538.520*mm" zstart="(1048.466+1.75)*mm" nmodules="40" dz="1.75*mm" module="Module2"/>
+    <ring r="625.654*mm" zstart="(1041.067+1.75)*mm" nmodules="48" dz="1.75*mm" module="Module2"/>
+    <ring r="703.666*mm" zstart="(1033.725+1.75)*mm" nmodules="54" dz="1.75*mm" module="Module2" phi0="pi/54"/>
+  </layer>
+
+  <layer id="3">
+    <ring r="256.716*mm" zstart="(1353.786+1.75)*mm" nmodules="24" dz="1.75*mm" module="Module1"/>
+    <ring r="353.991*mm" zstart="(1345.457+1.75)*mm" nmodules="32" dz="1.75*mm" module="Module1"/>
+    <ring r="449.180*mm" zstart="(1337.225+1.75)*mm" nmodules="40" dz="1.75*mm" module="Module1"/>
+    <ring r="538.520*mm" zstart="(1328.957+1.75)*mm" nmodules="40" dz="1.75*mm" module="Module2"/>
+    <ring r="625.654*mm" zstart="(1321.558+1.75)*mm" nmodules="48" dz="1.75*mm" module="Module2"/>
+    <ring r="703.666*mm" zstart="(1314.217+1.75)*mm" nmodules="54" dz="1.75*mm" module="Module2" phi0="pi/54"/>
+    <ring r="793.448*mm" zstart="(1306.828+1.75)*mm" nmodules="58" dz="1.75*mm" module="Module2" phi0="pi/58"/>
+    <ring r="874.239*mm" zstart="(1299.486+1.75)*mm" nmodules="64" dz="1.75*mm" module="Module2"/>
+    <ring r="958.364*mm" zstart="(1292.189+1.75)*mm" nmodules="68" dz="1.75*mm" module="Module2"/>
+  </layer>
+
+  <layer id="4">
+    <ring r="256.716*mm" zstart="(1639.164+1.75)*mm" nmodules="24" dz="1.75*mm" module="Module1"/>
+    <ring r="353.991*mm" zstart="(1630.835+1.75)*mm" nmodules="32" dz="1.75*mm" module="Module1"/>
+    <ring r="449.180*mm" zstart="(1622.603+1.75)*mm" nmodules="40" dz="1.75*mm" module="Module1"/>
+    <ring r="538.520*mm" zstart="(1614.335+1.75)*mm" nmodules="40" dz="1.75*mm" module="Module2"/>
+    <ring r="625.654*mm" zstart="(1606.936+1.75)*mm" nmodules="48" dz="1.75*mm" module="Module2"/>
+    <ring r="703.666*mm" zstart="(1599.595+1.75)*mm" nmodules="54" dz="1.75*mm" module="Module2" phi0="pi/54"/>
+    <ring r="793.448*mm" zstart="(1592.206+1.75)*mm" nmodules="58" dz="1.75*mm" module="Module2" phi0="pi/58"/>
+    <ring r="874.239*mm" zstart="(1584.864+1.75)*mm" nmodules="64" dz="1.75*mm" module="Module2"/>
+    <ring r="958.364*mm" zstart="(1577.567+1.75)*mm" nmodules="68" dz="1.75*mm" module="Module2"/>
+    <ring r="1040.970*mm" zstart="(1570.222+1.75)*mm" nmodules="72" dz="1.75*mm" module="Module2"/>
+    <ring r="1124.167*mm" zstart="(1562.916+1.75)*mm" nmodules="78" dz="1.75*mm" module="Module2" phi0="pi/78"/>
+    <ring r="1206.937*mm" zstart="(1555.647+1.75)*mm" nmodules="84" dz="1.75*mm" module="Module2"/>
+  </layer>
+
+ </detector>
+</detectors>
+
+<plugins>
+    <!-- CLIC: plugin name="DD4hep_GenericSurfaceInstallerPlugin"-->
+    <plugin name="DD4hep_SiTrackerEndcapSurfacePlugin">
+      <argument value="SiTrackerEndcap"/>
+      <argument value="dimension=2"/>
+      <!-- CLIC: <argument value="u_x=1."/>
+            <argument value="v_y=1."/>
+            <argument value="n_z=1."/>-->
+    </plugin>
+</plugins>
+
+</lccdd>

--- a/SiD/compact/SiD_o2_v04/SiTrackerForward_o2_v04.xml
+++ b/SiD/compact/SiD_o2_v04/SiTrackerForward_o2_v04.xml
@@ -1,0 +1,61 @@
+<lccdd>
+
+<readouts>
+    <readout name="SiTrackerForwardHits">
+      <id>${GlobalTrackerReadoutID}</id>
+    </readout>
+</readouts>
+
+<detectors>
+ <!-- original driver DD4hep_SiTrackerEndcap2 -->
+ <detector id="DetID_Tracker_Forward" name="SiTrackerForward" type="SiTrackerEndcap_o2_v01ext" readout="SiTrackerForwardHits" reflect="true" vis="SiTrackerForwardVis">    
+
+  <envelope vis="EnvelopeVis">
+    <shape type="Assembly"/>
+  </envelope>
+
+  <comment>SiD Forward Tracker inside Vertex Support Barrel</comment>
+
+  <type_flags type="DetType_TRACKER + DetType_ENDCAP"/>
+
+  <module name="SiTrackerForwardModule1" vis="MagentaVis">
+    <trd x1="5.620*mm" x2="32.435*mm" z="67.405*mm" />
+    <module_component thickness="0.002*cm" material="Silicon" sensitive="true" />
+    <module_component thickness="0.008*cm"   material="Silicon" />
+  </module>
+
+  <module name="SiTrackerForwardModule2" vis="MagentaVis">
+    <trd x1="15.167*mm" x2="32.435*mm" z="43.405*mm" />
+    <module_component thickness="0.002*cm" material="Silicon" sensitive="true" />
+    <module_component thickness="0.008*cm"   material="Silicon" />
+  </module>
+
+  <module name="SiTrackerForwardModule3" vis="MagentaVis">
+    <trd x1="23.522*mm" x2="32.435*mm" z="22.405*mm" />
+    <module_component thickness="0.002*cm" material="Silicon" sensitive="true" />
+    <module_component thickness="0.008*cm"   material="Silicon" />
+  </module>
+
+  <layer id="1">
+    <ring r="97.0*mm" zstart="211*mm" nmodules="16" dz="0.011*mm" module="SiTrackerForwardModule1"/>
+  </layer>
+
+  <layer id="2">
+    <ring r="121.0*mm" zstart="543*mm" nmodules="16" dz="0.011*mm" module="SiTrackerForwardModule2"/>
+  </layer>
+
+  <layer id="3">
+    <ring r="142.0*mm" zstart="834*mm" nmodules="16" dz="0.011*mm" module="SiTrackerForwardModule3"/>
+  </layer>
+
+ </detector>
+</detectors>
+
+<plugins>
+    <plugin name="DD4hep_SiTrackerEndcapSurfacePlugin">
+      <argument value="SiTrackerForward"/>
+      <argument value="dimension=2"/>
+    </plugin>
+</plugins>
+
+</lccdd>

--- a/SiD/compact/SiD_o2_v04/SiTrackers_o2_v04.xml
+++ b/SiD/compact/SiD_o2_v04/SiTrackers_o2_v04.xml
@@ -1,0 +1,30 @@
+<lccdd>
+
+<!--
+   This XML implements a common envelope for the barrel and encaps
+   by protopop@cern.ch - Dec 4, 2017
+-->
+
+<define>
+  <!-- Added some mm to the 2016 technical drawing values 
+       only in order to accomodate the common envelope -->
+  <constant name="SiTracker_rmax"  value="1260.0*mm"/>
+  <constant name="SiTracker_rmin"  value="206.00*mm"/>
+  <constant name="SiTrackers_zmax" value="1645.0*mm"/>
+</define>
+
+<comment>SiD Silicon Outer Trackers</comment>
+<detectors>
+  <detector name="SiTrackers" type="DD4hep_SubdetectorAssembly" vis="YellowVis">
+    <shape type="Tube" rmin="SiTracker_rmin - env_safety" rmax="SiTracker_rmax + env_safety" 
+	     dz="SiTrackers_zmax + env_safety" material="Air" />
+    <comment>Si Outer Trackers Assembly</comment>
+    <composite name="SiTrackerBarrel"/>
+    <composite name="SiTrackerEndcap"/>
+  </detector>
+</detectors>
+
+<include ref="SiTrackerBarrel_o2_v04.xml"/>
+<include ref="SiTrackerEndcap_o2_v04.xml"/>
+
+</lccdd>

--- a/SiD/compact/SiD_o2_v04/SiVertexBarrel_o2_v04.xml
+++ b/SiD/compact/SiD_o2_v04/SiVertexBarrel_o2_v04.xml
@@ -1,0 +1,93 @@
+<lccdd>
+
+<readouts>
+    <readout name="SiVertexBarrelHits">
+      <id>${GlobalTrackerReadoutID}</id>
+    </readout>
+</readouts>
+
+<detectors>
+ <detector id="DetID_Vertex_Barrel" name="SiVertexBarrel" type="TrackerBarrel_o1_v03" readout="SiVertexBarrelHits" insideTrackingVolume="true" vis="SiVertexBarrelVis">
+
+  <envelope vis="EnvelopeVis">
+    <shape type="Assembly"/>
+  </envelope>
+
+  <comment>SiD Vertex Detector Barrel</comment>
+  
+  <type_flags type=" DetType_TRACKER + DetType_VERTEX + DetType_BARREL"/>
+
+  <module name="VtxBarrelModuleInner">
+    <!-- another envelope? -->
+    <module_envelope width="9.8*mm" length="63.0 * 2*mm" thickness="0.6*mm"/>
+    <module_component width="7.6*mm" length="125.0*mm" thickness="VXD_CF_sensor" material="CarbonFiber_25percent" sensitive="false">
+      <position z="-0.12*mm"/>
+    </module_component>
+    <module_component width="7.6*mm" length="125.0*mm" thickness="0.05*mm" material="Epoxy" sensitive="false">
+      <position z="0.075*mm"/>
+    </module_component>
+    <module_component width="9.6*mm" length="125.0*mm" thickness="0.093*mm" material="Silicon" sensitive="false">
+      <position z="0.150*mm"/>
+    </module_component>
+    <module_component width="9.6*mm" length="125.0*mm" thickness="0.02*mm" material="Silicon" sensitive="true">
+      <position z="0.225*mm"/>
+    </module_component>
+  </module>
+
+  <module name="VtxBarrelModuleOuter">
+    <module_envelope width="14.0*mm" length="126.0*mm" thickness="0.6*mm"/>
+    <module_component width="11.6*mm" length="125.0*mm" thickness="VXD_CF_sensor" material="CarbonFiber_25percent" sensitive="false">
+      <position z="-0.12*mm"/>
+    </module_component>
+    <module_component width="11.6*mm" length="125.0*mm" thickness="0.05*mm" material="Epoxy" sensitive="false">
+      <position z="0.075*mm"/>
+    </module_component>
+    <module_component width="13.8*mm" length="125.0*mm" thickness="0.093*mm" material="Silicon" sensitive="false">
+      <position z="0.150*mm"/>
+    </module_component>
+    <module_component width="13.8*mm" length="125.0*mm" thickness="0.02*mm" material="Silicon" sensitive="true">
+      <position z="0.210*mm"/>
+    </module_component>
+  </module>
+
+  <layer module="VtxBarrelModuleInner" id="1" >
+    <barrel_envelope inner_r="13.0*mm" outer_r="17.0*mm" z_length="63 * 2*mm"/>
+    <rphi_layout phi_tilt="0.0" nphi="12" phi0="0.2618" rc="15.05*mm" dr="-1.15*mm"/>
+    <z_layout dr="0.0" z0="0.0" nz="1"/>
+  </layer>
+
+  <layer module="VtxBarrelModuleOuter" id="2" >
+    <barrel_envelope inner_r="21.0*mm" outer_r="25.0*mm" z_length="63 * 2*mm"/>
+    <rphi_layout phi_tilt="0.0" nphi="12" phi0="0.2618" rc="23.03*mm" dr="-1.13*mm"/>
+    <z_layout dr="0.0" z0="0.0" nz="1"/>
+  </layer>
+
+  <layer module="VtxBarrelModuleOuter" id="3" >
+    <barrel_envelope inner_r="34.0*mm" outer_r="38.0*mm" z_length="63 * 2*mm"/>
+    <rphi_layout phi_tilt="0.0" nphi="18" phi0="0.0" rc="35.79*mm" dr="-0.89*mm"/>
+    <z_layout dr="0.0" z0="0.0" nz="1"/>
+  </layer>
+
+  <layer module="VtxBarrelModuleOuter" id="4" >
+    <barrel_envelope inner_r="46.6*mm" outer_r="50.6*mm" z_length="63 * 2*mm"/>
+    <rphi_layout phi_tilt="0.0" nphi="24" phi0="0.1309" rc="47.5*mm" dr="0.81*mm"/>
+    <z_layout dr="0.0" z0="0.0" nz="1"/>
+  </layer>
+
+  <layer module="VtxBarrelModuleOuter" id="5" >
+    <barrel_envelope inner_r="59.0*mm" outer_r="63.0*mm" z_length="63 * 2*mm"/>
+    <rphi_layout phi_tilt="0.0" nphi="30" phi0="0.0" rc="59.9*mm" dr="0.77*mm"/>
+    <z_layout dr="0.0" z0="0.0" nz="1"/>
+  </layer>
+
+ </detector>
+</detectors>
+
+<plugins>
+    <plugin name="DD4hep_SiTrackerBarrelSurfacePlugin">
+      <argument value="SiVertexBarrel"/>
+      <argument value="dimension=2"/>
+    </plugin>
+</plugins>
+
+</lccdd>

--- a/SiD/compact/SiD_o2_v04/SiVertexEndcap_o2_v04.xml
+++ b/SiD/compact/SiD_o2_v04/SiVertexEndcap_o2_v04.xml
@@ -1,0 +1,64 @@
+<lccdd>
+
+<readouts>
+  <readout name="SiVertexEndcapHits">
+      <id>${GlobalTrackerReadoutID}</id>
+  </readout>
+</readouts>
+
+<detectors>
+ <!-- the driver used here is a modified DD4hep_SiTrackerEndcap2, where 'side' is used instead of 'barrel' -->
+ <detector id="DetID_Vertex_Endcap" name="SiVertexEndcap" type="SiTrackerEndcap_o2_v01" readout="SiVertexEndcapHits" reflect="true" vis="SiVertexEndcapVis">
+
+  <comment>SiD Vertex Detector Endcaps</comment>
+
+  <type_flags type=" DetType_TRACKER + DetType_VERTEX + DetType_ENDCAP"/>
+
+  <module name="SiVertexEndcapModule1">
+    <trd x1="3.034*mm" x2="14.682*mm" z="29.280*mm" />
+    <module_component thickness="0.002*cm" material="Silicon" sensitive="true" />
+    <module_component thickness="0.008*cm"   material="Silicon" />
+  </module>
+
+  <module name="SiVertexEndcapModule2">
+    <trd x1="3.233*mm" x2="14.682*mm" z="28.780*mm" />
+    <module_component thickness="0.002*cm" material="Silicon" sensitive="true" />
+    <module_component thickness="0.008*cm"   material="Silicon" />
+  </module>
+
+  <module name="SiVertexEndcapModule3">
+    <trd x1="3.630*mm" x2="14.682*mm" z="27.780*mm" />
+    <module_component thickness="0.002*cm" material="Silicon" sensitive="true" />
+    <module_component thickness="0.008*cm"   material="Silicon" />
+  </module>
+
+  <module name="SiVertexEndcapModule4">
+    <trd x1="4.227*mm" x2="14.682*mm" z="26.280*mm" />
+    <module_component thickness="0.002*cm" material="Silicon" sensitive="true" />
+    <module_component thickness="0.008*cm"   material="Silicon" />
+  </module>
+
+  <layer id="1">
+    <ring r="45.0*mm" zstart="76*mm" nmodules="16" dz="0.011*mm" module="SiVertexEndcapModule1"/>
+  </layer>
+  <layer id="2">
+    <ring r="45.5*mm" zstart="95*mm" nmodules="16" dz="0.011*mm" module="SiVertexEndcapModule2"/>
+  </layer>
+  <layer id="3">
+    <ring r="46.5*mm" zstart="125*mm" nmodules="16" dz="0.011*mm" module="SiVertexEndcapModule2"/>
+  </layer>
+  <layer id="4">
+    <ring r="48.0*mm" zstart="180*mm" nmodules="16" dz="0.011*mm" module="SiVertexEndcapModule2"/>
+  </layer>
+ </detector>
+</detectors>
+
+<plugins>
+    <plugin name="DD4hep_SiTrackerEndcapSurfacePlugin">
+      <argument value="SiVertexEndcap"/>
+      <argument value="dimension=2"/>
+    </plugin>
+</plugins>
+
+</lccdd>
+

--- a/SiD/compact/SiD_o2_v04/Solenoid_o2_v04.xml
+++ b/SiD/compact/SiD_o2_v04/Solenoid_o2_v04.xml
@@ -1,0 +1,49 @@
+<lccdd>
+     
+    <define>
+        <constant name="SolenoidVacuumTank_thickness" value="40*mm"/>
+        <constant name="SolenoidCoil_thickness" value="344*mm"/>        
+    </define>
+        
+    <display>
+        <vis name="SolenoidBarrelLayerVis" alpha="1" r="0"    g="0.3"  b="0.3" showDaughters="false" visible="true"/>
+        <vis name="SolenoidCoilEndsVis"    alpha="1" r="0"    g="0.9"  b="0.9" showDaughters="false" visible="true"/>
+    </display>
+    
+    <comment>SiD Solenoid</comment>
+    <detectors>
+        <detector name="Solenoid" type="DD4hep_SubdetectorAssembly" vis="RedVis">
+            <shape type="Tube" rmin="Solenoid_inner_radius - 2*env_safety" rmax="Solenoid_outer_radius + 2*env_safety" dz="Solenoid_half_length + 2*env_safety" material="Vacuum"/>
+            <composite name="SolenoidBarrel"/>
+            <composite name="SolenoidEndcaps"/> 
+        </detector>
+    </detectors>
+    
+    <detectors>        
+        <detector name="SolenoidBarrel" type="DD4hep_Solenoid_o1_v01" id="DetID_NOTUSED" insideTrackingVolume="false" reflect="true">
+	  <type_flags type=" DetType_COIL"/>
+
+            <envelope vis="SOLVis">
+                <shape type="Assembly"/>
+            </envelope>
+            
+            <layer id="1" inner_r="Solenoid_inner_radius" outer_z="Solenoid_half_length" vis="SolenoidBarrelLayerVis">
+                <slice material="Steel235" thickness="SolenoidVacuumTank_thickness"/>
+            </layer>
+            <!-- <layer id="2" inner_r="Solenoid_Coil_radius-SolenoidCoil_thickness/2.0" outer_z="Solenoid_Coil_half_length"> -->
+            <layer id="2" inner_r="Solenoid_inner_radius+SolenoidVacuumTank_thickness" outer_z="Solenoid_Coil_half_length">
+                <slice material="Aluminum" thickness="SolenoidCoil_thickness" vis="SolenoidCoilEndsVis" />            
+            </layer>
+            <layer id="3" inner_r="Solenoid_outer_radius-SolenoidVacuumTank_thickness" outer_z="Solenoid_half_length" vis="SolenoidBarrelLayerVis">
+                <slice material="Steel235" thickness="SolenoidVacuumTank_thickness"/>
+            </layer>
+        </detector>
+        
+        <detector name="SolenoidEndcaps" type="DD4hep_DiskTracker" id="DetID_NOTUSED" reflect="true" insideTrackingVolume="false" vis="SolenoidBarrelLayerVis">
+            <layer id="1" inner_r="Solenoid_inner_radius+SolenoidVacuumTank_thickness" inner_z="Solenoid_half_length-SolenoidVacuumTank_thickness" outer_r="Solenoid_outer_radius-SolenoidVacuumTank_thickness" vis="SolenoidBarrelLayerVis">
+	        <slice material="Steel235" thickness="SolenoidVacuumTank_thickness/2.0" />
+          </layer>
+        </detector>
+    </detectors>
+
+</lccdd>

--- a/SiD/compact/SiD_o2_v04/SteppedMuon_o2_v04.xml
+++ b/SiD/compact/SiD_o2_v04/SteppedMuon_o2_v04.xml
@@ -1,0 +1,38 @@
+<lccdd>
+
+<!--
+   This version uses a common envelope for the barrel and encaps
+   by protopop@cern.ch - Nov 30, 2017
+-->
+
+<define>
+  <constant name="SteppedMuon_symmetry" value="MuonBarrel_symmetry"/>
+  <constant name="SteppedMuon_rmax"     value="MuonBarrel_rmax"/>
+  <constant name="SteppedMuon_cavity_r" value="MuonBarrel_rmin"/>
+  <constant name="SteppedMuon_cavity_z" value="MuonEndcap_zmin"/>
+  <constant name="SteppedMuon_rmin"     value="MuonEndcap_rmin"/>
+  <constant name="SteppedMuon_zmax"     value="MuonEndcap_zmax"/>
+</define>
+
+<comment>SiD Stepped Muon Calorimeter</comment>
+<detectors>
+  <detector name="MuonCalorimeters" type="DD4hep_SubdetectorAssembly" vis="SteppedMuonVis">
+    <shape name="SteppedMuonEnvelope" type="BooleanShape" operation="Subtraction" material="Air">
+      <shape type="PolyhedraRegular"  numsides="SteppedMuon_symmetry" rmin="SteppedMuon_rmin - env_safety" rmax="SteppedMuon_rmax + env_safety" 
+	     dz="2*MuonEndcap_zmax + 2*env_safety" />
+      <shape type="PolyhedraRegular"  numsides="SteppedMuon_symmetry" rmin="0" rmax="SteppedMuon_cavity_r - env_safety" 
+	     dz="2*SteppedMuon_cavity_z - 2*env_safety" />
+    </shape>
+    <rotation x="0*deg" y="0*deg" z="90*deg-180*deg/SteppedMuon_symmetry"/>
+
+    <comment>Stepped Muon Assembly</comment>
+    <composite name="MuonBarrel"/>
+    <composite name="MuonEndcap"/>
+
+  </detector>
+</detectors>
+
+<include ref="MuonBarrel_o2_v04.xml"/>
+<include ref="MuonEndcap_o2_v04.xml"/>
+
+</lccdd>

--- a/SiD/compact/SiD_o2_v04/Support.xml
+++ b/SiD/compact/SiD_o2_v04/Support.xml
@@ -1,0 +1,370 @@
+<!--  FG: fixme: should be split up into more individual files  ...v-->
+<detector name="VertexBarrelSupports" type="DD4hep_MultiLayerTracker" vis="InvisibleNoDaughters">
+  <comment>Double-walled Carbon Fiber support tube</comment>
+  <layer id="6" inner_r = "16.87*cm" outer_z = "89.48*cm">
+    <slice material = "CarbonFiber" thickness ="VXD_CF_support"/>
+  </layer>
+  <layer id="7" inner_r = "18.42*cm" outer_z = "89.48*cm">
+    <slice material = "CarbonFiber" thickness ="VXD_CF_support"/>
+  </layer>
+</detector>
+<detector name="VertexEndSupports" type="DD4hep_DiskTracker" reflect="true" vis="InvisibleNoDaughters">
+  <layer id="7" inner_r = "4.80*cm" inner_z = "86.88*cm" outer_r = "16.87*cm">
+    <slice material = "CarbonFiber" thickness = "VXD_CF_support" />
+  </layer>
+  <layer id="8" inner_r = "4.91*cm" inner_z = "89.43*cm" outer_r = "16.87*cm">
+    <slice material = "CarbonFiber" thickness = "VXD_CF_support" />
+  </layer>
+</detector>
+<detector name="VertexReadout" type="DD4hep_DiskTracker" reflect="true" vis="InvisibleNoDaughters">
+  <comment>Readout and Cabling</comment>
+  <layer id="1" inner_r = "1.46*cm" outer_r = "1.66*cm"  inner_z= "6.4*cm">
+    <slice material = "G10" thickness ="0.5*cm"/>
+  </layer>
+  <layer id="2" inner_r = "2.26*cm" outer_r = "2.46*cm"  inner_z= "6.4*cm">
+    <slice material = "G10" thickness ="0.5*cm"/>
+  </layer>
+  <layer id="3" inner_r = "3.54*cm" outer_r = "3.74*cm"  inner_z= "6.4*cm">
+    <slice material = "G10" thickness ="0.5*cm"/>
+  </layer>
+  <layer id="4" inner_r = "4.80*cm" outer_r = "5.00*cm"  inner_z= "6.4*cm">
+    <slice material = "G10" thickness ="0.5*cm"/>
+  </layer>
+  <layer id="5" inner_r = "6.04*cm" outer_r = "6.24*cm"  inner_z= "6.4*cm">
+    <slice material = "G10" thickness ="0.5*cm"/>
+  </layer>
+  <layer id="6" inner_r = "1.32*cm" outer_r = "2.26*cm"  inner_z= "6.90*cm">
+    <slice material = "Copper" thickness ="0.0057*cm"/>
+  </layer>
+  <layer id="7" inner_r = "2.261*cm" outer_r = "3.54*cm"  inner_z= "6.90*cm">
+    <slice material = "Copper" thickness ="0.0031*cm"/>
+  </layer>
+  <layer id="8" inner_r = "3.541*cm" outer_r = "4.80*cm"  inner_z= "6.90*cm">
+    <slice material = "Copper" thickness ="0.0016*cm"/>
+  </layer>
+  <layer id="9" inner_r = "4.801*cm" outer_r = "6.04*cm"  inner_z= "6.90*cm">
+    <slice material = "Copper" thickness ="0.0007*cm"/>
+  </layer>
+  <layer id="10" inner_r = "1.3*cm"  outer_r = "1.399*cm" inner_z = "6.98*cm">
+    <slice material = "G10" thickness = "0.2*cm" />
+  </layer>
+  <layer id="11" inner_r = "1.5*cm"  outer_r = "1.599*cm" inner_z = "8.82*cm">
+    <slice material = "G10" thickness = "0.2*cm" />
+  </layer>
+  <layer id="12" inner_r = "1.7*cm"  outer_r = "1.799*cm" inner_z = "11.96*cm">
+    <slice material = "G10" thickness = "0.2*cm" />
+  </layer>
+  <layer id="13" inner_r = "1.9*cm"  outer_r = "1.999*cm" inner_z = "16.80*cm">
+    <slice material = "G10" thickness = "0.2*cm" />
+  </layer>
+  <layer id="14" inner_r = "7.101*cm"  outer_r = "7.6*cm" inner_z = "6.98*cm">
+    <slice material = "G10" thickness = "0.2*cm" />
+  </layer>
+  <layer id="15" inner_r = "7.101*cm"  outer_r = "7.6*cm" inner_z = "8.82*cm">
+    <slice material = "G10" thickness = "0.2*cm" />
+  </layer>
+  <layer id="16" inner_r = "7.101*cm"  outer_r = "7.6*cm" inner_z = "11.96*cm">
+    <slice material = "G10" thickness = "0.2*cm" />
+  </layer>
+  <layer id="17" inner_r = "7.101*cm"  outer_r = "7.6*cm" inner_z = "16.80*cm">
+    <slice material = "G10" thickness = "0.2*cm" />
+  </layer>
+</detector>
+<detector name="VXDcableZbackwardOuter" type="DD4hep_PolyconeSupport" insideTrackingVolume="true" vis="InvisibleNoDaughters">
+  <material name="Copper"/>
+  <zplane rmin = "((tracking_region_zmax-6.25*cm)*bp_cone_slope+1.4*cm)"
+	  rmax = "((tracking_region_zmax-6.25*cm)*bp_cone_slope+1.404*cm)"
+	  z="-tracking_region_zmax" />
+  <zplane rmin="1.542*cm"    rmax="1.552*cm"  z="-12.01*cm"/>
+</detector>
+<detector name="VXDcableZbackwardInner" type="DD4hep_PolyconeSupport" insideTrackingVolume="true" vis="InvisibleNoDaughters">
+  <material name="Copper"/>
+  <zplane rmin="1.455*cm"   rmax="1.467*cm"  z="-9.99*cm"/>
+  <zplane rmin="1.32*cm"    rmax="1.332*cm"  z="-6.91*cm"/>
+</detector>
+<detector name="VXDcableZforwardOuter" type="DD4hep_PolyconeSupport" insideTrackingVolume="true" vis="InvisibleNoDaughters">
+  <material name="Copper"/>
+  <zplane rmin = "((tracking_region_zmax-6.25*cm)*bp_cone_slope+1.4*cm)"
+	  rmax = "((tracking_region_zmax-6.25*cm)*bp_cone_slope+1.404*cm)"
+	  z="tracking_region_zmax" />
+  <zplane rmin="1.542*cm"    rmax="1.552*cm"  z="12.01*cm"/>
+</detector>
+<detector name="VXDcableZforwardInner" type="DD4hep_PolyconeSupport" insideTrackingVolume="true" vis="InvisibleNoDaughters">
+  <material name="Copper"/>
+  <zplane rmin="1.455*cm"   rmax="1.467*cm"  z="9.99*cm"/>
+  <zplane rmin="1.32*cm"    rmax="1.332*cm"  z="6.91*cm"/>
+</detector>
+<detector name="VXDserviceZbackward" type="DD4hep_PolyconeSupport" insideTrackingVolume="true" vis="InvisibleNoDaughters">
+  <material name="G10"/>
+  <zplane rmin = "1.542*cm"  rmax="1.842*cm"  z="-12.0*cm"/>
+  <zplane rmin = "1.455*cm"  rmax="1.755*cm"  z="-10.0*cm"/>
+</detector>
+<detector name="VXDserviceZforward" type="DD4hep_PolyconeSupport" insideTrackingVolume="true" vis="InvisibleNoDaughters">
+  <material name="G10"/>
+  <zplane rmin = "1.455*cm"  rmax="1.755*cm"  z="10.0*cm"/>
+  <zplane rmin = "1.542*cm"  rmax="1.842*cm"  z="12.0*cm"/>
+</detector>
+<comment>Outer Tracker Supports and Readout</comment>
+<detector name="TrackerBarrelSupports" type="DD4hep_MultiLayerTracker" vis="InvisibleNoDaughters">
+  <comment>Barrels</comment>
+  <layer id="1" inner_r="206.0*mm" outer_z="577.328*mm">
+    <slice material="CarbonFiber" thickness="0.05*cm" />
+    <slice material="Rohacell31_15percent" thickness="0.8075*cm" />
+    <slice material="CarbonFiber" thickness="0.05*cm" />
+  </layer>
+  <layer id="2" inner_r="456.0*mm" outer_z="749.781*mm">
+    <slice material="CarbonFiber" thickness="0.05*cm" />
+    <slice material="Rohacell31_15percent" thickness="0.8075*cm" />
+    <slice material="CarbonFiber" thickness="0.05*cm" />
+  </layer>
+  <layer id="3" inner_r="706.0*mm" outer_z="1013.802*mm">
+    <slice material= "CarbonFiber" thickness = "0.05*cm" />
+    <slice material= "Rohacell31_15percent" thickness="0.8075*cm" />
+    <slice material= "CarbonFiber" thickness="0.05*cm" />
+  </layer>
+  <layer id="4" inner_r="956.0*mm" outer_z="1272.251*mm">
+    <slice material="CarbonFiber" thickness="0.05*cm" />
+    <slice material="Rohacell31_15percent" thickness="0.8075*cm" />
+    <slice material="CarbonFiber" thickness="0.05*cm" />
+  </layer>
+  <layer id="5" inner_r="1206.0*mm" outer_z="1535.676*mm">
+    <slice material="CarbonFiber" thickness="0.05*cm" />
+    <slice material="Rohacell31_15percent" thickness="0.8075*cm" />
+    <slice material="CarbonFiber" thickness="0.05*cm" />
+  </layer>
+</detector>
+<comment>Dished endcap disks</comment>
+<detector name="SiTrackerEndcapSupport1" type="DD4hep_PolyconeSupport" insideTrackingVolume="true" vis="InvisibleNoDaughters">
+  <material name="CarbonFiber"/>
+  <zplane rmin="510.448*mm" rmax="510.448*mm" z="750.417*mm-0.001*mm" />
+  <zplane rmin="504.711*mm" rmax="510.448*mm" z="750.919*mm-0.001*mm" />
+  <zplane rmin="206.234*mm" rmax="211.970*mm" z="777.034*mm-0.001*mm" />
+  <zplane rmin="206.234*mm" rmax="206.234*mm" z="777.535*mm-0.001*mm" />
+</detector>
+<detector name="SiTrackerEndcapSupport2" type="DD4hep_PolyconeSupport" insideTrackingVolume="true" vis="InvisibleNoDaughters">
+  <material name="Rohacell31"/>
+  <zplane rmin="510.448*mm" rmax="510.448*mm" z="750.919*mm" />
+  <zplane rmin="438.449*mm" rmax="510.448*mm" z="757.218*mm" />
+  <zplane rmin="206.234*mm" rmax="278.187*mm" z="777.535*mm" />
+  <zplane rmin="206.234*mm" rmax="206.234*mm" z="783.834*mm" />
+</detector>
+<detector name="SiTrackerEndcapSupport3" type="DD4hep_PolyconeSupport" insideTrackingVolume="true" vis="InvisibleNoDaughters">
+  <material name="CarbonFiber"/>
+  <zplane rmin="510.448*mm" rmax="510.448*mm" z="757.218*mm+0.001*mm" />
+  <zplane rmin="504.711*mm" rmax="510.448*mm" z="757.720*mm+0.001*mm" />
+  <zplane rmin="206.234*mm" rmax="211.970*mm" z="783.834*mm+0.001*mm" />
+  <zplane rmin="206.234*mm" rmax="206.234*mm" z="784.336*mm+0.001 *mm" />
+</detector>
+<detector name="SiTrackerEndcapSupport4" type="DD4hep_PolyconeSupport" insideTrackingVolume="true" vis="InvisibleNoDaughters">
+  <material name="CarbonFiber"/>
+  <zplane rmin="763.796*mm" rmax="763.796*mm" z="1014.437*mm-0.001*mm" />
+  <zplane rmin="758.059*mm" rmax="763.796*mm" z="1014.939*mm-0.001*mm" />
+  <zplane rmin="206.234*mm" rmax="211.970*mm" z="1063.219*mm-0.001*mm" />
+  <zplane rmin="206.234*mm" rmax="206.234*mm" z="1063.721*mm-0.001*mm" />
+</detector>
+<detector name="SiTrackerEndcapSupport5" type="DD4hep_PolyconeSupport" insideTrackingVolume="true" vis="InvisibleNoDaughters">
+  <material name="Rohacell31"/>
+  <zplane rmin="763.796*mm" rmax="763.796*mm" z="1014.939*mm" />
+  <zplane rmin="691.797*mm" rmax="763.796*mm" z="1021.238*mm" />
+  <zplane rmin="206.234*mm" rmax="278.187*mm" z="1063.721*mm" />
+  <zplane rmin="206.234*mm" rmax="206.234*mm" z="1070.020*mm" />
+</detector>
+<detector name="SiTrackerEndcapSupport6" type="DD4hep_PolyconeSupport" insideTrackingVolume="true" vis="InvisibleNoDaughters">
+  <material name="CarbonFiber"/>
+  <zplane rmin="763.796*mm" rmax="763.796*mm" z="1021.238*mm+0.001*mm" />
+  <zplane rmin="758.059*mm" rmax="763.796*mm" z="1021.740*mm+0.001*mm" />
+  <zplane rmin="206.234*mm" rmax="211.970*mm" z="1070.020*mm+0.001*mm" />
+  <zplane rmin="206.234*mm" rmax="206.234*mm" z="1070.522*mm+0.001*mm" />
+</detector>
+<detector name="SiTrackerEndcapSupport7" type="DD4hep_PolyconeSupport" insideTrackingVolume="true" vis="InvisibleNoDaughters">
+  <material name="CarbonFiber"/>
+  <zplane rmin="1015.748*mm" rmax="1015.748*mm" z="1272.885*mm-0.001*mm" />
+  <zplane rmin="1010.011*mm" rmax="1015.748*mm" z="1273.387*mm-0.001*mm" />
+  <zplane rmin="206.234*mm" rmax="211.970*mm" z="1343.711*mm-0.001*mm" />
+  <zplane rmin="206.234*mm" rmax="206.234*mm" z="1344.213*mm-0.001*mm" />
+</detector>
+<detector name="SiTrackerEndcapSupport8" type="DD4hep_PolyconeSupport" insideTrackingVolume="true" vis="InvisibleNoDaughters">
+  <material name="Rohacell31"/>
+  <zplane rmin="1015.748*mm" rmax="1015.748*mm" z="1273.387*mm" />
+  <zplane rmin="943.753*mm" rmax="1015.748*mm" z="1279.686*mm" />
+  <zplane rmin="206.234*mm" rmax="278.187*mm" z="1344.213*mm" />
+  <zplane rmin="206.234*mm" rmax="206.234*mm" z="1350.512*mm" />
+</detector>
+<detector name="SiTrackerEndcapSupport9" type="DD4hep_PolyconeSupport" insideTrackingVolume="true" vis="InvisibleNoDaughters">
+  <material name="CarbonFiber"/>
+  <zplane rmin="1015.748*mm" rmax="1015.748*mm" z="1279.686*mm+0.001*mm" />
+  <zplane rmin="1010.011*mm" rmax="1015.748*mm" z="1280.188*mm+0.001*mm" />
+  <zplane rmin="206.234*mm" rmax="211.970*mm" z="1350.512*mm+0.001*mm" />
+  <zplane rmin="206.234*mm" rmax="206.234*mm" z="1351.014*mm+0.001*mm" />
+</detector>
+<detector name="SiTrackerEndcapSupport10" type="DD4hep_PolyconeSupport" insideTrackingVolume="true" vis="InvisibleNoDaughters">
+  <material name="CarbonFiber"/>
+  <zplane rmin="1263.808*mm" rmax="1263.808*mm" z="1536.560*mm-0.001*mm" />
+  <zplane rmin="1258.071*mm" rmax="1263.808*mm" z="1537.062*mm-0.001*mm" />
+  <zplane rmin="206.234*mm" rmax="211.970*mm" z="1629.089*mm-0.001*mm" />
+  <zplane rmin="206.234*mm" rmax="206.234*mm" z="1629.591*mm-0.001*mm" />
+</detector>
+<detector name="SiTrackerEndcapSupport11" type="DD4hep_PolyconeSupport" insideTrackingVolume="true" vis="InvisibleNoDaughters">
+  <material name="Rohacell31"/>
+  <zplane rmin="1263.808*mm" rmax="1263.808*mm" z="1537.062*mm" />
+  <zplane rmin="1191.810*mm" rmax="1263.808*mm" z="1543.361*mm" />
+  <zplane rmin="206.234*mm" rmax="278.187*mm" z="1629.591*mm" />
+  <zplane rmin="206.234*mm" rmax="206.234*mm" z="1635.890*mm" />
+</detector>
+<detector name="SiTrackerEndcapSupport12" type="DD4hep_PolyconeSupport" insideTrackingVolume="true" vis="InvisibleNoDaughters">
+  <material name="CarbonFiber"/>
+  <zplane rmin="1263.808*mm" rmax="1263.808*mm" z="1543.361*mm+0.001*mm" />
+  <zplane rmin="1258.071*mm" rmax="1263.808*mm" z="1543.863*mm+0.001*mm" />
+  <zplane rmin="206.234*mm" rmax="211.970*mm" z="1635.890*mm+0.001*mm" />
+  <zplane rmin="206.234*mm" rmax="206.234*mm" z="1636.392*mm+0.001*mm" />
+</detector>
+<detector name="SiTrackerEndcapSupport1Reflect" type="DD4hep_PolyconeSupport" insideTrackingVolume="true" vis="InvisibleNoDaughters">
+  <material name="CarbonFiber"/>
+  <zplane rmin="510.448*mm" rmax="510.448*mm" z="-750.417*mm+0.001*mm" />
+  <zplane rmin="504.711*mm" rmax="510.448*mm" z="-750.919*mm+0.001*mm" />
+  <zplane rmin="206.234*mm" rmax="211.970*mm" z="-777.034*mm+0.001*mm" />
+  <zplane rmin="206.234*mm" rmax="206.234*mm" z="-777.535*mm+0.001*mm" />
+</detector>
+<detector name="SiTrackerEndcapSupport2Reflect" type="DD4hep_PolyconeSupport" insideTrackingVolume="true" vis="InvisibleNoDaughters">
+  <material name="Rohacell31"/>
+  <zplane rmin="510.448*mm" rmax="510.448*mm" z="-750.919*mm" />
+  <zplane rmin="438.449*mm" rmax="510.448*mm" z="-757.218*mm" />
+  <zplane rmin="206.234*mm" rmax="278.187*mm" z="-777.535*mm" />
+  <zplane rmin="206.234*mm" rmax="206.234*mm" z="-783.834*mm" />
+</detector>
+<detector name="SiTrackerEndcapSupport3Reflect" type="DD4hep_PolyconeSupport" insideTrackingVolume="true" vis="InvisibleNoDaughters">
+  <material name="CarbonFiber"/>
+  <zplane rmin="510.448*mm" rmax="510.448*mm" z="-757.218*mm-0.001*mm" />
+  <zplane rmin="504.711*mm" rmax="510.448*mm" z="-757.720*mm-0.001*mm" />
+  <zplane rmin="206.234*mm" rmax="211.970*mm" z="-783.834*mm-0.001*mm" />
+  <zplane rmin="206.234*mm" rmax="206.234*mm" z="-784.336*mm-0.001 *mm" />
+</detector>
+<detector name="SiTrackerEndcapSupport4Reflect" type="DD4hep_PolyconeSupport" insideTrackingVolume="true" vis="InvisibleNoDaughters">
+  <material name="CarbonFiber"/>
+  <zplane rmin="763.796*mm" rmax="763.796*mm" z="-1014.437*mm+0.001*mm" />
+  <zplane rmin="758.059*mm" rmax="763.796*mm" z="-1014.939*mm+0.001*mm" />
+  <zplane rmin="206.234*mm" rmax="211.970*mm" z="-1063.219*mm+0.001*mm" />
+  <zplane rmin="206.234*mm" rmax="206.234*mm" z="-1063.721*mm+0.001*mm" />
+</detector>
+<detector name="SiTrackerEndcapSupport5Reflect" type="DD4hep_PolyconeSupport" insideTrackingVolume="true" vis="InvisibleNoDaughters">
+  <material name="Rohacell31"/>
+  <zplane rmin="763.796*mm" rmax="763.796*mm" z="-1014.939*mm" />
+  <zplane rmin="691.797*mm" rmax="763.796*mm" z="-1021.238*mm" />
+  <zplane rmin="206.234*mm" rmax="278.187*mm" z="-1063.721*mm" />
+  <zplane rmin="206.234*mm" rmax="206.234*mm" z="-1070.020*mm" />
+</detector>
+<detector name="SiTrackerEndcapSupport6Reflect" type="DD4hep_PolyconeSupport" insideTrackingVolume="true" vis="InvisibleNoDaughters">
+  <material name="CarbonFiber"/>
+  <zplane rmin="763.796*mm" rmax="763.796*mm" z="-1021.238*mm-0.001*mm" />
+  <zplane rmin="758.059*mm" rmax="763.796*mm" z="-1021.740*mm-0.001*mm" />
+  <zplane rmin="206.234*mm" rmax="211.970*mm" z="-1070.020*mm-0.001*mm" />
+  <zplane rmin="206.234*mm" rmax="206.234*mm" z="-1070.522*mm-0.001*mm" />
+</detector>
+<detector name="SiTrackerEndcapSupport7Reflect" type="DD4hep_PolyconeSupport" insideTrackingVolume="true" vis="InvisibleNoDaughters">
+  <material name="CarbonFiber"/>
+  <zplane rmin="1015.748*mm" rmax="1015.748*mm" z="-1272.885*mm+0.001*mm" />
+  <zplane rmin="1010.011*mm" rmax="1015.748*mm" z="-1273.387*mm+0.001*mm" />
+  <zplane rmin="206.234*mm" rmax="211.970*mm" z="-1343.711*mm+0.001*mm" />
+  <zplane rmin="206.234*mm" rmax="206.234*mm" z="-1344.213*mm+0.001*mm" />
+</detector>
+<detector name="SiTrackerEndcapSupport8Reflect" type="DD4hep_PolyconeSupport" insideTrackingVolume="true" vis="InvisibleNoDaughters">
+  <material name="Rohacell31"/>
+  <zplane rmin="1015.748*mm" rmax="1015.748*mm" z="-1273.387*mm" />
+  <zplane rmin="943.753*mm" rmax="1015.748*mm" z="-1279.686*mm" />
+  <zplane rmin="206.234*mm" rmax="278.187*mm" z="-1344.213*mm" />
+  <zplane rmin="206.234*mm" rmax="206.234*mm" z="-1350.512*mm" />
+</detector>
+<detector name="SiTrackerEndcapSupport9Reflect" type="DD4hep_PolyconeSupport" insideTrackingVolume="true" vis="InvisibleNoDaughters">
+  <material name="CarbonFiber"/>
+  <zplane rmin="1015.748*mm" rmax="1015.748*mm" z="-1279.686*mm-0.001*mm" />
+  <zplane rmin="1010.011*mm" rmax="1015.748*mm" z="-1280.188*mm-0.001*mm" />
+  <zplane rmin="206.234*mm" rmax="211.970*mm" z="-1350.512*mm-0.001*mm" />
+  <zplane rmin="206.234*mm" rmax="206.234*mm" z="-1351.014*mm-0.001*mm" />
+</detector>
+<detector name="SiTrackerEndcapSupport10Reflect" type="DD4hep_PolyconeSupport" insideTrackingVolume="true" vis="InvisibleNoDaughters">
+  <material name="CarbonFiber"/>
+  <zplane rmin="1263.808*mm" rmax="1263.808*mm" z="-1536.560*mm+0.001*mm" />
+  <zplane rmin="1258.071*mm" rmax="1263.808*mm" z="-1537.062*mm+0.001*mm" />
+  <zplane rmin="206.234*mm" rmax="211.970*mm" z="-1629.089*mm+0.001*mm" />
+  <zplane rmin="206.234*mm" rmax="206.234*mm" z="-1629.591*mm+0.001*mm" />
+</detector>
+<detector name="SiTrackerEndcapSupport11Reflect" type="DD4hep_PolyconeSupport" insideTrackingVolume="true" vis="InvisibleNoDaughters">
+  <material name="Rohacell31"/>
+  <zplane rmin="1263.808*mm" rmax="1263.808*mm" z="-1537.062*mm" />
+  <zplane rmin="1191.810*mm" rmax="1263.808*mm" z="-1543.361*mm" />
+  <zplane rmin="206.234*mm" rmax="278.187*mm" z="-1629.591*mm" />
+  <zplane rmin="206.234*mm" rmax="206.234*mm" z="-1635.890*mm" />
+</detector>
+<detector name="SiTrackerEndcapSupport12Reflect" type="DD4hep_PolyconeSupport" insideTrackingVolume="true" vis="InvisibleNoDaughters">
+  <material name="CarbonFiber"/>
+  <zplane rmin="1263.808*mm" rmax="1263.808*mm" z="-1543.361*mm-0.001*mm" />
+  <zplane rmin="1258.071*mm" rmax="1263.808*mm" z="-1543.863*mm-0.001*mm" />
+  <zplane rmin="206.234*mm" rmax="211.970*mm" z="-1635.890*mm-0.001*mm" />
+  <zplane rmin="206.234*mm" rmax="206.234*mm" z="-1636.392*mm-0.001*mm" />
+</detector>
+<detector name="TrackerReadout" type="DD4hep_DiskTracker" reflect="true" vis="InvisibleNoDaughters">
+  <comment>Readouts</comment>
+  <layer id="1" inner_r="25.7*cm" inner_z="590.402*mm" outer_r="45.6*cm">
+    <slice material="G10" thickness="0.057*cm" />
+    <slice material="Copper" thickness="0.0038*cm" />
+  </layer>
+  <layer id="2" inner_r="51.0*cm" inner_z="762.854*mm" outer_r="70.6*cm">
+    <slice material = "G10" thickness="0.102*cm" />
+    <slice material = "Copper" thickness="0.0068*cm" />
+  </layer>
+  <layer id="3" inner_r="76.3*cm" inner_z="1026.874*mm" outer_r="95.6*cm">
+    <slice material="G10" thickness="0.108*cm" />
+    <slice material="Copper" thickness="0.0072*cm" />
+  </layer>
+  <layer id="4" inner_r="101.3*cm" inner_z="1285.322*mm" outer_r="120.6*cm">
+    <slice material="G10" thickness="0.186*cm" />
+    <slice material="Copper" thickness="0.0124*cm" />
+  </layer>
+  <layer id="5" inner_r= "101.3*cm" inner_z="1610.0*mm" outer_r="120.6*cm">
+    <slice material="G10" thickness="0.246*cm" />
+    <slice material="Copper" thickness="0.0164*cm" />
+  </layer>
+</detector>
+
+
+<comment>Masks</comment>
+<detector name="ForwardM1" type="DD4hep_PolyconeSupport" insideTrackingVolume="false" vis="InvisibleNoDaughters">
+  <material name="TungstenDens24"/>
+  <zplane rmin = "8.0*cm" rmax="15.5*cm" z="182.0*cm" />
+  <zplane rmin="13.78*cm" rmax="15.5*cm"  z="313.5*cm"/>
+</detector>
+
+<detector name="BackwardM1" type="DD4hep_PolyconeSupport" insideTrackingVolume="false" vis="InvisibleNoDaughters">
+  <material name="TungstenDens24"/>
+  <zplane rmin="13.78*cm" rmax="15.5*cm"  z="-313.5*cm"/>
+  <zplane rmin = "8.0*cm" rmax="15.5*cm" z="-182.0*cm" />
+</detector>
+
+<detector name="ForwardLowZ" type="DD4hep_ForwardDetector" reflect="true">
+  <dimensions outer_r="12.39*cm" inner_r="0.0*cm" inner_z="282.0*cm" />
+  <beampipe crossing_angle="0.014*mrad" outgoing_r="1.2*cm" incoming_r="1.0*cm" />
+  <layer repeat="1">
+    <slice material = "BoratedPolyethylene5" thickness = "13.0*cm" sensitive = "no" />
+  </layer>
+</detector>
+
+<comment>Solenoid</comment>
+<detector name="SolenoidCoilBarrel" type="DD4hep_MultiLayerTracker" insideTrackingVolume="false" vis="SolenoidCoilVis">
+  <layer id="1" inner_r="SolenoidBarrelInnerRadius" outer_z="SolenoidBarrelOuterZ">
+    <slice material="Steel235" thickness="SolenoidBarrelInnerCryostatThickness" />
+    <slice material="Vacuum" thickness="SolenoidBarrelInnerAirgapThickness" />
+  </layer>
+  <layer id="2" inner_r="SolenoidBarrelConductorInnerRadius" outer_z="SolenoidCoilOuterZ">
+    <slice material="Aluminum" thickness="SolenoidBarrelAlConductorThickness" />
+    <slice material="Aluminum" thickness="SolenoidBarrelQuenchbackThickness" />
+  </layer>
+  <layer id="3" inner_r="SolenoidBarrelOuterCryostatInnerRadius" outer_z="SolenoidBarrelOuterZ">
+    <slice material="Vacuum" thickness="SolenoidBarrelOuterAirgapThickness" />
+    <slice material="Steel235" thickness="SolenoidBarrelOuterCryostatThickness" />
+  </layer>
+</detector>
+<!-- <detector name="SolenoidCoilEnds" type="DD4hep_DiskTracker" reflect="true" insideTrackingVolume="false" vis="SolenoidCoilVis"> -->
+<!--     <layer id="1" inner_r="SolenoidBarrelInnerRadius" inner_z="SolenoidBarrelOuterZ" outer_r="SolenoidBarrelOuterRadius"> -->
+<!--         <slice material="Steel235" thickness="SolenoidEndcapCryostatThickness" /> -->
+<!--     </layer> -->
+<!-- </detector> -->

--- a/SiD/compact/SiD_o2_v04/elements.xml
+++ b/SiD/compact/SiD_o2_v04/elements.xml
@@ -1,0 +1,884 @@
+<materials>
+ <element Z="89" formula="Ac" name="Ac" >
+  <atom type="A" unit="g/mol" value="227.028" />
+ </element>
+ <material formula="Ac" name="Actinium" state="solid" >
+  <RL type="X0" unit="cm" value="0.601558" />
+  <NIL type="lambda" unit="cm" value="21.2048" />
+  <D type="density" unit="g/cm3" value="10.07" />
+  <composite n="1" ref="Ac" />
+ </material>
+ <element Z="47" formula="Ag" name="Ag" >
+  <atom type="A" unit="g/mol" value="107.868" />
+ </element>
+ <material formula="Ag" name="Silver" state="solid" >
+  <RL type="X0" unit="cm" value="0.854292" />
+  <NIL type="lambda" unit="cm" value="15.8546" />
+  <D type="density" unit="g/cm3" value="10.5" />
+  <composite n="1" ref="Ag" />
+ </material>
+ <element Z="13" formula="Al" name="Al" >
+  <atom type="A" unit="g/mol" value="26.9815" />
+ </element>
+ <material formula="Al" name="Aluminum" state="solid" >
+  <RL type="X0" unit="cm" value="8.89632" />
+  <NIL type="lambda" unit="cm" value="38.8766" />
+  <D type="density" unit="g/cm3" value="2.699" />
+  <composite n="1" ref="Al" />
+ </material>
+ <element Z="95" formula="Am" name="Am" >
+  <atom type="A" unit="g/mol" value="243.061" />
+ </element>
+ <material formula="Am" name="Americium" state="solid" >
+  <RL type="X0" unit="cm" value="0.42431" />
+  <NIL type="lambda" unit="cm" value="15.9812" />
+  <D type="density" unit="g/cm3" value="13.67" />
+  <composite n="1" ref="Am" />
+ </material>
+ <element Z="18" formula="Ar" name="Ar" >
+  <atom type="A" unit="g/mol" value="39.9477" />
+ </element>
+ <material formula="Ar" name="Argon" state="gas" >
+  <RL type="X0" unit="cm" value="11762.1" />
+  <NIL type="lambda" unit="cm" value="71926" />
+  <D type="density" unit="g/cm3" value="0.00166201" />
+  <composite n="1" ref="Ar" />
+ </material>
+ <element Z="33" formula="As" name="As" >
+  <atom type="A" unit="g/mol" value="74.9216" />
+ </element>
+ <material formula="As" name="Arsenic" state="solid" >
+  <RL type="X0" unit="cm" value="2.0838" />
+  <NIL type="lambda" unit="cm" value="25.7324" />
+  <D type="density" unit="g/cm3" value="5.73" />
+  <composite n="1" ref="As" />
+ </material>
+ <element Z="85" formula="At" name="At" >
+  <atom type="A" unit="g/mol" value="209.987" />
+ </element>
+ <material formula="At" name="Astatine" state="solid" >
+  <RL type="X0" unit="cm" value="0.650799" />
+  <NIL type="lambda" unit="cm" value="22.3202" />
+  <D type="density" unit="g/cm3" value="9.32" />
+  <composite n="1" ref="At" />
+ </material>
+ <element Z="79" formula="Au" name="Au" >
+  <atom type="A" unit="g/mol" value="196.967" />
+ </element>
+ <material formula="Au" name="Gold" state="solid" >
+  <RL type="X0" unit="cm" value="0.334436" />
+  <NIL type="lambda" unit="cm" value="10.5393" />
+  <D type="density" unit="g/cm3" value="19.32" />
+  <composite n="1" ref="Au" />
+ </material>
+ <element Z="5" formula="B" name="B" >
+  <atom type="A" unit="g/mol" value="10.811" />
+ </element>
+ <material formula="B" name="Boron" state="solid" >
+  <RL type="X0" unit="cm" value="22.2307" />
+  <NIL type="lambda" unit="cm" value="32.2793" />
+  <D type="density" unit="g/cm3" value="2.37" />
+  <composite n="1" ref="B" />
+ </material>
+ <element Z="56" formula="Ba" name="Ba" >
+  <atom type="A" unit="g/mol" value="137.327" />
+ </element>
+ <material formula="Ba" name="Barium" state="solid" >
+  <RL type="X0" unit="cm" value="2.37332" />
+  <NIL type="lambda" unit="cm" value="51.6743" />
+  <D type="density" unit="g/cm3" value="3.5" />
+  <composite n="1" ref="Ba" />
+ </material>
+ <element Z="4" formula="Be" name="Be" >
+  <atom type="A" unit="g/mol" value="9.01218" />
+ </element>
+ <material formula="Be" name="Beryllium" state="solid" >
+  <RL type="X0" unit="cm" value="35.276" />
+  <NIL type="lambda" unit="cm" value="39.4488" />
+  <D type="density" unit="g/cm3" value="1.848" />
+  <composite n="1" ref="Be" />
+ </material>
+ <element Z="83" formula="Bi" name="Bi" >
+  <atom type="A" unit="g/mol" value="208.98" />
+ </element>
+ <material formula="Bi" name="Bismuth" state="solid" >
+  <RL type="X0" unit="cm" value="0.645388" />
+  <NIL type="lambda" unit="cm" value="21.3078" />
+  <D type="density" unit="g/cm3" value="9.747" />
+  <composite n="1" ref="Bi" />
+ </material>
+ <element Z="97" formula="Bk" name="Bk" >
+  <atom type="A" unit="g/mol" value="247.07" />
+ </element>
+ <material formula="Bk" name="Berkelium" state="solid" >
+  <RL type="X0" unit="cm" value="0.406479" />
+  <NIL type="lambda" unit="cm" value="15.6902" />
+  <D type="density" unit="g/cm3" value="14" />
+  <composite n="1" ref="Bk" />
+ </material>
+ <element Z="35" formula="Br" name="Br" >
+  <atom type="A" unit="g/mol" value="79.9035" />
+ </element>
+ <material formula="Br" name="Bromine" state="gas" >
+  <RL type="X0" unit="cm" value="1615.12" />
+  <NIL type="lambda" unit="cm" value="21299" />
+  <D type="density" unit="g/cm3" value="0.0070721" />
+  <composite n="1" ref="Br" />
+ </material>
+ <element Z="6" formula="C" name="C" >
+  <atom type="A" unit="g/mol" value="12.0107" />
+ </element>
+ <material formula="C" name="Carbon" state="solid" >
+  <RL type="X0" unit="cm" value="21.3485" />
+  <NIL type="lambda" unit="cm" value="40.1008" />
+  <D type="density" unit="g/cm3" value="2" />
+  <composite n="1" ref="C" />
+ </material>
+ <element Z="20" formula="Ca" name="Ca" >
+  <atom type="A" unit="g/mol" value="40.078" />
+ </element>
+ <material formula="Ca" name="Calcium" state="solid" >
+  <RL type="X0" unit="cm" value="10.4151" />
+  <NIL type="lambda" unit="cm" value="77.3754" />
+  <D type="density" unit="g/cm3" value="1.55" />
+  <composite n="1" ref="Ca" />
+ </material>
+ <element Z="48" formula="Cd" name="Cd" >
+  <atom type="A" unit="g/mol" value="112.411" />
+ </element>
+ <material formula="Cd" name="Cadmium" state="solid" >
+  <RL type="X0" unit="cm" value="1.03994" />
+  <NIL type="lambda" unit="cm" value="19.46" />
+  <D type="density" unit="g/cm3" value="8.65" />
+  <composite n="1" ref="Cd" />
+ </material>
+ <element Z="58" formula="Ce" name="Ce" >
+  <atom type="A" unit="g/mol" value="140.115" />
+ </element>
+ <material formula="Ce" name="Cerium" state="solid" >
+  <RL type="X0" unit="cm" value="1.19506" />
+  <NIL type="lambda" unit="cm" value="27.3227" />
+  <D type="density" unit="g/cm3" value="6.657" />
+  <composite n="1" ref="Ce" />
+ </material>
+ <element Z="98" formula="Cf" name="Cf" >
+  <atom type="A" unit="g/mol" value="251.08" />
+ </element>
+ <material formula="Cf" name="Californium" state="solid" >
+  <RL type="X0" unit="cm" value="0.568328" />
+  <NIL type="lambda" unit="cm" value="22.085" />
+  <D type="density" unit="g/cm3" value="10" />
+  <composite n="1" ref="Cf" />
+ </material>
+ <element Z="17" formula="Cl" name="Cl" >
+  <atom type="A" unit="g/mol" value="35.4526" />
+ </element>
+ <material formula="Cl" name="Chlorine" state="gas" >
+  <RL type="X0" unit="cm" value="6437.34" />
+  <NIL type="lambda" unit="cm" value="38723.9" />
+  <D type="density" unit="g/cm3" value="0.00299473" />
+  <composite n="1" ref="Cl" />
+ </material>
+ <element Z="96" formula="Cm" name="Cm" >
+  <atom type="A" unit="g/mol" value="247.07" />
+ </element>
+ <material formula="Cm" name="Curium" state="solid" >
+  <RL type="X0" unit="cm" value="0.428706" />
+  <NIL type="lambda" unit="cm" value="16.2593" />
+  <D type="density" unit="g/cm3" value="13.51" />
+  <composite n="1" ref="Cm" />
+ </material>
+ <element Z="27" formula="Co" name="Co" >
+  <atom type="A" unit="g/mol" value="58.9332" />
+ </element>
+ <material formula="Co" name="Cobalt" state="solid" >
+  <RL type="X0" unit="cm" value="1.53005" />
+  <NIL type="lambda" unit="cm" value="15.2922" />
+  <D type="density" unit="g/cm3" value="8.9" />
+  <composite n="1" ref="Co" />
+ </material>
+ <element Z="24" formula="Cr" name="Cr" >
+  <atom type="A" unit="g/mol" value="51.9961" />
+ </element>
+ <material formula="Cr" name="Chromium" state="solid" >
+  <RL type="X0" unit="cm" value="2.0814" />
+  <NIL type="lambda" unit="cm" value="18.1933" />
+  <D type="density" unit="g/cm3" value="7.18" />
+  <composite n="1" ref="Cr" />
+ </material>
+ <element Z="55" formula="Cs" name="Cs" >
+  <atom type="A" unit="g/mol" value="132.905" />
+ </element>
+ <material formula="Cs" name="Cesium" state="solid" >
+  <RL type="X0" unit="cm" value="4.4342" />
+  <NIL type="lambda" unit="cm" value="95.317" />
+  <D type="density" unit="g/cm3" value="1.873" />
+  <composite n="1" ref="Cs" />
+ </material>
+ <element Z="29" formula="Cu" name="Cu" >
+  <atom type="A" unit="g/mol" value="63.5456" />
+ </element>
+ <material formula="Cu" name="Copper" state="solid" >
+  <RL type="X0" unit="cm" value="1.43558" />
+  <NIL type="lambda" unit="cm" value="15.5141" />
+  <D type="density" unit="g/cm3" value="8.96" />
+  <composite n="1" ref="Cu" />
+ </material>
+ <element Z="66" formula="Dy" name="Dy" >
+  <atom type="A" unit="g/mol" value="162.497" />
+ </element>
+ <material formula="Dy" name="Dysprosium" state="solid" >
+  <RL type="X0" unit="cm" value="0.85614" />
+  <NIL type="lambda" unit="cm" value="22.2923" />
+  <D type="density" unit="g/cm3" value="8.55" />
+  <composite n="1" ref="Dy" />
+ </material>
+ <element Z="68" formula="Er" name="Er" >
+  <atom type="A" unit="g/mol" value="167.256" />
+ </element>
+ <material formula="Er" name="Erbium" state="solid" >
+  <RL type="X0" unit="cm" value="0.788094" />
+  <NIL type="lambda" unit="cm" value="21.2923" />
+  <D type="density" unit="g/cm3" value="9.066" />
+  <composite n="1" ref="Er" />
+ </material>
+ <element Z="63" formula="Eu" name="Eu" >
+  <atom type="A" unit="g/mol" value="151.964" />
+ </element>
+ <material formula="Eu" name="Europium" state="solid" >
+  <RL type="X0" unit="cm" value="1.41868" />
+  <NIL type="lambda" unit="cm" value="35.6178" />
+  <D type="density" unit="g/cm3" value="5.243" />
+  <composite n="1" ref="Eu" />
+ </material>
+ <element Z="9" formula="F" name="F" >
+  <atom type="A" unit="g/mol" value="18.9984" />
+ </element>
+ <material formula="F" name="Fluorine" state="gas" >
+  <RL type="X0" unit="cm" value="20838.2" />
+  <NIL type="lambda" unit="cm" value="59094.3" />
+  <D type="density" unit="g/cm3" value="0.00158029" />
+  <composite n="1" ref="F" />
+ </material>
+ <element Z="26" formula="Fe" name="Fe" >
+  <atom type="A" unit="g/mol" value="55.8451" />
+ </element>
+ <material formula="Fe" name="Iron" state="solid" >
+  <RL type="X0" unit="cm" value="1.75749" />
+  <NIL type="lambda" unit="cm" value="16.959" />
+  <D type="density" unit="g/cm3" value="7.874" />
+  <composite n="1" ref="Fe" />
+ </material>
+ <element Z="87" formula="Fr" name="Fr" >
+  <atom type="A" unit="g/mol" value="223.02" />
+ </element>
+ <material formula="Fr" name="Francium" state="solid" >
+  <RL type="X0" unit="cm" value="6.18826" />
+  <NIL type="lambda" unit="cm" value="212.263" />
+  <D type="density" unit="g/cm3" value="1" />
+  <composite n="1" ref="Fr" />
+ </material>
+ <element Z="31" formula="Ga" name="Ga" >
+  <atom type="A" unit="g/mol" value="69.7231" />
+ </element>
+ <material formula="Ga" name="Gallium" state="solid" >
+  <RL type="X0" unit="cm" value="2.1128" />
+  <NIL type="lambda" unit="cm" value="24.3351" />
+  <D type="density" unit="g/cm3" value="5.904" />
+  <composite n="1" ref="Ga" />
+ </material>
+ <element Z="64" formula="Gd" name="Gd" >
+  <atom type="A" unit="g/mol" value="157.252" />
+ </element>
+ <material formula="Gd" name="Gadolinium" state="solid" >
+  <RL type="X0" unit="cm" value="0.947208" />
+  <NIL type="lambda" unit="cm" value="23.9377" />
+  <D type="density" unit="g/cm3" value="7.9004" />
+  <composite n="1" ref="Gd" />
+ </material>
+ <element Z="32" formula="Ge" name="Ge" >
+  <atom type="A" unit="g/mol" value="72.6128" />
+ </element>
+ <material formula="Ge" name="Germanium" state="solid" >
+  <RL type="X0" unit="cm" value="2.3013" />
+  <NIL type="lambda" unit="cm" value="27.3344" />
+  <D type="density" unit="g/cm3" value="5.323" />
+  <composite n="1" ref="Ge" />
+ </material>
+ <element Z="1" formula="H" name="H" >
+  <atom type="A" unit="g/mol" value="1.00794" />
+ </element>
+ <material formula="H" name="Hydrogen" state="gas" >
+  <RL type="X0" unit="cm" value="752776" />
+  <NIL type="lambda" unit="cm" value="421239" />
+  <D type="density" unit="g/cm3" value="8.3748e-05" />
+  <composite n="1" ref="H" />
+ </material>
+ <element Z="2" formula="He" name="He" >
+  <atom type="A" unit="g/mol" value="4.00264" />
+ </element>
+ <material formula="He" name="Helium" state="gas" >
+  <RL type="X0" unit="cm" value="567113" />
+  <NIL type="lambda" unit="cm" value="334266" />
+  <D type="density" unit="g/cm3" value="0.000166322" />
+  <composite n="1" ref="He" />
+ </material>
+ <element Z="72" formula="Hf" name="Hf" >
+  <atom type="A" unit="g/mol" value="178.485" />
+ </element>
+ <material formula="Hf" name="Hafnium" state="solid" >
+  <RL type="X0" unit="cm" value="0.517717" />
+  <NIL type="lambda" unit="cm" value="14.7771" />
+  <D type="density" unit="g/cm3" value="13.31" />
+  <composite n="1" ref="Hf" />
+ </material>
+ <element Z="80" formula="Hg" name="Hg" >
+  <atom type="A" unit="g/mol" value="200.599" />
+ </element>
+ <material formula="Hg" name="Mercury" state="solid" >
+  <RL type="X0" unit="cm" value="0.475241" />
+  <NIL type="lambda" unit="cm" value="15.105" />
+  <D type="density" unit="g/cm3" value="13.546" />
+  <composite n="1" ref="Hg" />
+ </material>
+ <element Z="67" formula="Ho" name="Ho" >
+  <atom type="A" unit="g/mol" value="164.93" />
+ </element>
+ <material formula="Ho" name="Holmium" state="solid" >
+  <RL type="X0" unit="cm" value="0.822447" />
+  <NIL type="lambda" unit="cm" value="21.8177" />
+  <D type="density" unit="g/cm3" value="8.795" />
+  <composite n="1" ref="Ho" />
+ </material>
+ <element Z="53" formula="I" name="I" >
+  <atom type="A" unit="g/mol" value="126.904" />
+ </element>
+ <material formula="I" name="Iodine" state="solid" >
+  <RL type="X0" unit="cm" value="1.72016" />
+  <NIL type="lambda" unit="cm" value="35.6583" />
+  <D type="density" unit="g/cm3" value="4.93" />
+  <composite n="1" ref="I" />
+ </material>
+ <element Z="49" formula="In" name="In" >
+  <atom type="A" unit="g/mol" value="114.818" />
+ </element>
+ <material formula="In" name="Indium" state="solid" >
+  <RL type="X0" unit="cm" value="1.21055" />
+  <NIL type="lambda" unit="cm" value="23.2468" />
+  <D type="density" unit="g/cm3" value="7.31" />
+  <composite n="1" ref="In" />
+ </material>
+ <element Z="77" formula="Ir" name="Ir" >
+  <atom type="A" unit="g/mol" value="192.216" />
+ </element>
+ <material formula="Ir" name="Iridium" state="solid" >
+  <RL type="X0" unit="cm" value="0.294142" />
+  <NIL type="lambda" unit="cm" value="9.01616" />
+  <D type="density" unit="g/cm3" value="22.42" />
+  <composite n="1" ref="Ir" />
+ </material>
+ <element Z="19" formula="K" name="K" >
+  <atom type="A" unit="g/mol" value="39.0983" />
+ </element>
+ <material formula="K" name="Potassium" state="solid" >
+  <RL type="X0" unit="cm" value="20.0871" />
+  <NIL type="lambda" unit="cm" value="138.041" />
+  <D type="density" unit="g/cm3" value="0.862" />
+  <composite n="1" ref="K" />
+ </material>
+ <element Z="36" formula="Kr" name="Kr" >
+  <atom type="A" unit="g/mol" value="83.7993" />
+ </element>
+ <material formula="Kr" name="Krypton" state="gas" >
+  <RL type="X0" unit="cm" value="3269.44" />
+  <NIL type="lambda" unit="cm" value="43962.9" />
+  <D type="density" unit="g/cm3" value="0.00347832" />
+  <composite n="1" ref="Kr" />
+ </material>
+ <element Z="57" formula="La" name="La" >
+  <atom type="A" unit="g/mol" value="138.905" />
+ </element>
+ <material formula="La" name="Lanthanum" state="solid" >
+  <RL type="X0" unit="cm" value="1.32238" />
+  <NIL type="lambda" unit="cm" value="29.441" />
+  <D type="density" unit="g/cm3" value="6.154" />
+  <composite n="1" ref="La" />
+ </material>
+ <element Z="3" formula="Li" name="Li" >
+  <atom type="A" unit="g/mol" value="6.94003" />
+ </element>
+ <material formula="Li" name="Lithium" state="solid" >
+  <RL type="X0" unit="cm" value="154.997" />
+  <NIL type="lambda" unit="cm" value="124.305" />
+  <D type="density" unit="g/cm3" value="0.534" />
+  <composite n="1" ref="Li" />
+ </material>
+ <element Z="71" formula="Lu" name="Lu" >
+  <atom type="A" unit="g/mol" value="174.967" />
+ </element>
+ <material formula="Lu" name="Lutetium" state="solid" >
+  <RL type="X0" unit="cm" value="0.703651" />
+  <NIL type="lambda" unit="cm" value="19.8916" />
+  <D type="density" unit="g/cm3" value="9.84" />
+  <composite n="1" ref="Lu" />
+ </material>
+ <element Z="12" formula="Mg" name="Mg" >
+  <atom type="A" unit="g/mol" value="24.305" />
+ </element>
+ <material formula="Mg" name="Magnesium" state="solid" >
+  <RL type="X0" unit="cm" value="14.3859" />
+  <NIL type="lambda" unit="cm" value="58.7589" />
+  <D type="density" unit="g/cm3" value="1.74" />
+  <composite n="1" ref="Mg" />
+ </material>
+ <element Z="25" formula="Mn" name="Mn" >
+  <atom type="A" unit="g/mol" value="54.938" />
+ </element>
+ <material formula="Mn" name="Manganese" state="solid" >
+  <RL type="X0" unit="cm" value="1.96772" />
+  <NIL type="lambda" unit="cm" value="17.8701" />
+  <D type="density" unit="g/cm3" value="7.44" />
+  <composite n="1" ref="Mn" />
+ </material>
+ <element Z="42" formula="Mo" name="Mo" >
+  <atom type="A" unit="g/mol" value="95.9313" />
+ </element>
+ <material formula="Mo" name="Molybdenum" state="solid" >
+  <RL type="X0" unit="cm" value="0.959107" />
+  <NIL type="lambda" unit="cm" value="15.6698" />
+  <D type="density" unit="g/cm3" value="10.22" />
+  <composite n="1" ref="Mo" />
+ </material>
+ <element Z="7" formula="N" name="N" >
+  <atom type="A" unit="g/mol" value="14.0068" />
+ </element>
+ <material formula="N" name="Nitrogen" state="gas" >
+  <RL type="X0" unit="cm" value="32602.2" />
+  <NIL type="lambda" unit="cm" value="72430.3" />
+  <D type="density" unit="g/cm3" value="0.0011652" />
+  <composite n="1" ref="N" />
+ </material>
+ <element Z="11" formula="Na" name="Na" >
+  <atom type="A" unit="g/mol" value="22.9898" />
+ </element>
+ <material formula="Na" name="Sodium" state="solid" >
+  <RL type="X0" unit="cm" value="28.5646" />
+  <NIL type="lambda" unit="cm" value="102.463" />
+  <D type="density" unit="g/cm3" value="0.971" />
+  <composite n="1" ref="Na" />
+ </material>
+ <element Z="41" formula="Nb" name="Nb" >
+  <atom type="A" unit="g/mol" value="92.9064" />
+ </element>
+ <material formula="Nb" name="Niobium" state="solid" >
+  <RL type="X0" unit="cm" value="1.15783" />
+  <NIL type="lambda" unit="cm" value="18.4846" />
+  <D type="density" unit="g/cm3" value="8.57" />
+  <composite n="1" ref="Nb" />
+ </material>
+ <element Z="60" formula="Nd" name="Nd" >
+  <atom type="A" unit="g/mol" value="144.236" />
+ </element>
+ <material formula="Nd" name="Neodymium" state="solid" >
+  <RL type="X0" unit="cm" value="1.11667" />
+  <NIL type="lambda" unit="cm" value="26.6308" />
+  <D type="density" unit="g/cm3" value="6.9" />
+  <composite n="1" ref="Nd" />
+ </material>
+ <element Z="10" formula="Ne" name="Ne" >
+  <atom type="A" unit="g/mol" value="20.18" />
+ </element>
+ <material formula="Ne" name="Neon" state="gas" >
+  <RL type="X0" unit="cm" value="34504.8" />
+  <NIL type="lambda" unit="cm" value="114322" />
+  <D type="density" unit="g/cm3" value="0.000838505" />
+  <composite n="1" ref="Ne" />
+ </material>
+ <element Z="28" formula="Ni" name="Ni" >
+  <atom type="A" unit="g/mol" value="58.6933" />
+ </element>
+ <material formula="Ni" name="Nickel" state="solid" >
+  <RL type="X0" unit="cm" value="1.42422" />
+  <NIL type="lambda" unit="cm" value="15.2265" />
+  <D type="density" unit="g/cm3" value="8.902" />
+  <composite n="1" ref="Ni" />
+ </material>
+ <element Z="93" formula="Np" name="Np" >
+  <atom type="A" unit="g/mol" value="237.048" />
+ </element>
+ <material formula="Np" name="Neptunium" state="solid" >
+  <RL type="X0" unit="cm" value="0.289676" />
+  <NIL type="lambda" unit="cm" value="10.6983" />
+  <D type="density" unit="g/cm3" value="20.25" />
+  <composite n="1" ref="Np" />
+ </material>
+ <element Z="8" formula="O" name="O" >
+  <atom type="A" unit="g/mol" value="15.9994" />
+ </element>
+ <material formula="O" name="Oxygen" state="gas" >
+  <RL type="X0" unit="cm" value="25713.8" />
+  <NIL type="lambda" unit="cm" value="66233.9" />
+  <D type="density" unit="g/cm3" value="0.00133151" />
+  <composite n="1" ref="O" />
+ </material>
+ <element Z="76" formula="Os" name="Os" >
+  <atom type="A" unit="g/mol" value="190.225" />
+ </element>
+ <material formula="Os" name="Osmium" state="solid" >
+  <RL type="X0" unit="cm" value="0.295861" />
+  <NIL type="lambda" unit="cm" value="8.92553" />
+  <D type="density" unit="g/cm3" value="22.57" />
+  <composite n="1" ref="Os" />
+ </material>
+ <element Z="15" formula="P" name="P" >
+  <atom type="A" unit="g/mol" value="30.9738" />
+ </element>
+ <material formula="P" name="Phosphorus" state="solid" >
+  <RL type="X0" unit="cm" value="9.63879" />
+  <NIL type="lambda" unit="cm" value="49.9343" />
+  <D type="density" unit="g/cm3" value="2.2" />
+  <composite n="1" ref="P" />
+ </material>
+ <element Z="91" formula="Pa" name="Pa" >
+  <atom type="A" unit="g/mol" value="231.036" />
+ </element>
+ <material formula="Pa" name="Protactinium" state="solid" >
+  <RL type="X0" unit="cm" value="0.38607" />
+  <NIL type="lambda" unit="cm" value="13.9744" />
+  <D type="density" unit="g/cm3" value="15.37" />
+  <composite n="1" ref="Pa" />
+ </material>
+ <element Z="82" formula="Pb" name="Pb" >
+  <atom type="A" unit="g/mol" value="207.217" />
+ </element>
+ <material formula="Pb" name="Lead" state="solid" >
+  <RL type="X0" unit="cm" value="0.561253" />
+  <NIL type="lambda" unit="cm" value="18.2607" />
+  <D type="density" unit="g/cm3" value="11.35" />
+  <composite n="1" ref="Pb" />
+ </material>
+ <element Z="46" formula="Pd" name="Pd" >
+  <atom type="A" unit="g/mol" value="106.415" />
+ </element>
+ <material formula="Pd" name="Palladium" state="solid" >
+  <RL type="X0" unit="cm" value="0.765717" />
+  <NIL type="lambda" unit="cm" value="13.7482" />
+  <D type="density" unit="g/cm3" value="12.02" />
+  <composite n="1" ref="Pd" />
+ </material>
+ <element Z="61" formula="Pm" name="Pm" >
+  <atom type="A" unit="g/mol" value="144.913" />
+ </element>
+ <material formula="Pm" name="Promethium" state="solid" >
+  <RL type="X0" unit="cm" value="1.04085" />
+  <NIL type="lambda" unit="cm" value="25.4523" />
+  <D type="density" unit="g/cm3" value="7.22" />
+  <composite n="1" ref="Pm" />
+ </material>
+ <element Z="84" formula="Po" name="Po" >
+  <atom type="A" unit="g/mol" value="208.982" />
+ </element>
+ <material formula="Po" name="Polonium" state="solid" >
+  <RL type="X0" unit="cm" value="0.661092" />
+  <NIL type="lambda" unit="cm" value="22.2842" />
+  <D type="density" unit="g/cm3" value="9.32" />
+  <composite n="1" ref="Po" />
+ </material>
+ <element Z="59" formula="Pr" name="Pr" >
+  <atom type="A" unit="g/mol" value="140.908" />
+ </element>
+ <material formula="Pr" name="Praseodymium" state="solid" >
+  <RL type="X0" unit="cm" value="1.1562" />
+  <NIL type="lambda" unit="cm" value="27.1312" />
+  <D type="density" unit="g/cm3" value="6.71" />
+  <composite n="1" ref="Pr" />
+ </material>
+ <element Z="78" formula="Pt" name="Pt" >
+  <atom type="A" unit="g/mol" value="195.078" />
+ </element>
+ <material formula="Pt" name="Platinum" state="solid" >
+  <RL type="X0" unit="cm" value="0.305053" />
+  <NIL type="lambda" unit="cm" value="9.46584" />
+  <D type="density" unit="g/cm3" value="21.45" />
+  <composite n="1" ref="Pt" />
+ </material>
+ <element Z="94" formula="Pu" name="Pu" >
+  <atom type="A" unit="g/mol" value="244.064" />
+ </element>
+ <material formula="Pu" name="Plutonium" state="solid" >
+  <RL type="X0" unit="cm" value="0.298905" />
+  <NIL type="lambda" unit="cm" value="11.0265" />
+  <D type="density" unit="g/cm3" value="19.84" />
+  <composite n="1" ref="Pu" />
+ </material>
+ <element Z="88" formula="Ra" name="Ra" >
+  <atom type="A" unit="g/mol" value="226.025" />
+ </element>
+ <material formula="Ra" name="Radium" state="solid" >
+  <RL type="X0" unit="cm" value="1.22987" />
+  <NIL type="lambda" unit="cm" value="42.6431" />
+  <D type="density" unit="g/cm3" value="5" />
+  <composite n="1" ref="Ra" />
+ </material>
+ <element Z="37" formula="Rb" name="Rb" >
+  <atom type="A" unit="g/mol" value="85.4677" />
+ </element>
+ <material formula="Rb" name="Rubidium" state="solid" >
+  <RL type="X0" unit="cm" value="7.19774" />
+  <NIL type="lambda" unit="cm" value="100.218" />
+  <D type="density" unit="g/cm3" value="1.532" />
+  <composite n="1" ref="Rb" />
+ </material>
+ <element Z="75" formula="Re" name="Re" >
+  <atom type="A" unit="g/mol" value="186.207" />
+ </element>
+ <material formula="Re" name="Rhenium" state="solid" >
+  <RL type="X0" unit="cm" value="0.318283" />
+  <NIL type="lambda" unit="cm" value="9.5153" />
+  <D type="density" unit="g/cm3" value="21.02" />
+  <composite n="1" ref="Re" />
+ </material>
+ <element Z="45" formula="Rh" name="Rh" >
+  <atom type="A" unit="g/mol" value="102.906" />
+ </element>
+ <material formula="Rh" name="Rhodium" state="solid" >
+  <RL type="X0" unit="cm" value="0.746619" />
+  <NIL type="lambda" unit="cm" value="13.2083" />
+  <D type="density" unit="g/cm3" value="12.41" />
+  <composite n="1" ref="Rh" />
+ </material>
+ <element Z="86" formula="Rn" name="Rn" >
+  <atom type="A" unit="g/mol" value="222.018" />
+ </element>
+ <material formula="Rn" name="Radon" state="gas" >
+  <RL type="X0" unit="cm" value="697.777" />
+  <NIL type="lambda" unit="cm" value="23532" />
+  <D type="density" unit="g/cm3" value="0.00900662" />
+  <composite n="1" ref="Rn" />
+ </material>
+ <element Z="44" formula="Ru" name="Ru" >
+  <atom type="A" unit="g/mol" value="101.065" />
+ </element>
+ <material formula="Ru" name="Ruthenium" state="solid" >
+  <RL type="X0" unit="cm" value="0.764067" />
+  <NIL type="lambda" unit="cm" value="13.1426" />
+  <D type="density" unit="g/cm3" value="12.41" />
+  <composite n="1" ref="Ru" />
+ </material>
+ <element Z="16" formula="S" name="S" >
+  <atom type="A" unit="g/mol" value="32.0661" />
+ </element>
+ <material formula="S" name="Sulfur" state="solid" >
+  <RL type="X0" unit="cm" value="9.74829" />
+  <NIL type="lambda" unit="cm" value="55.6738" />
+  <D type="density" unit="g/cm3" value="2" />
+  <composite n="1" ref="S" />
+ </material>
+ <element Z="51" formula="Sb" name="Sb" >
+  <atom type="A" unit="g/mol" value="121.76" />
+ </element>
+ <material formula="Sb" name="Antimony" state="solid" >
+  <RL type="X0" unit="cm" value="1.30401" />
+  <NIL type="lambda" unit="cm" value="25.8925" />
+  <D type="density" unit="g/cm3" value="6.691" />
+  <composite n="1" ref="Sb" />
+ </material>
+ <element Z="21" formula="Sc" name="Sc" >
+  <atom type="A" unit="g/mol" value="44.9559" />
+ </element>
+ <material formula="Sc" name="Scandium" state="solid" >
+  <RL type="X0" unit="cm" value="5.53545" />
+  <NIL type="lambda" unit="cm" value="41.609" />
+  <D type="density" unit="g/cm3" value="2.989" />
+  <composite n="1" ref="Sc" />
+ </material>
+ <element Z="34" formula="Se" name="Se" >
+  <atom type="A" unit="g/mol" value="78.9594" />
+ </element>
+ <material formula="Se" name="Selenium" state="solid" >
+  <RL type="X0" unit="cm" value="2.64625" />
+  <NIL type="lambda" unit="cm" value="33.356" />
+  <D type="density" unit="g/cm3" value="4.5" />
+  <composite n="1" ref="Se" />
+ </material>
+ <element Z="14" formula="Si" name="Si" >
+  <atom type="A" unit="g/mol" value="28.0854" />
+ </element>
+ <material formula="Si" name="Silicon" state="solid" >
+  <RL type="X0" unit="cm" value="9.36607" />
+  <NIL type="lambda" unit="cm" value="45.7531" />
+  <D type="density" unit="g/cm3" value="2.33" />
+  <composite n="1" ref="Si" />
+ </material>
+ <element Z="62" formula="Sm" name="Sm" >
+  <atom type="A" unit="g/mol" value="150.366" />
+ </element>
+ <material formula="Sm" name="Samarium" state="solid" >
+  <RL type="X0" unit="cm" value="1.01524" />
+  <NIL type="lambda" unit="cm" value="24.9892" />
+  <D type="density" unit="g/cm3" value="7.46" />
+  <composite n="1" ref="Sm" />
+ </material>
+ <element Z="50" formula="Sn" name="Sn" >
+  <atom type="A" unit="g/mol" value="118.71" />
+ </element>
+ <material formula="Sn" name="Tin" state="solid" >
+  <RL type="X0" unit="cm" value="1.20637" />
+  <NIL type="lambda" unit="cm" value="23.4931" />
+  <D type="density" unit="g/cm3" value="7.31" />
+  <composite n="1" ref="Sn" />
+ </material>
+ <element Z="38" formula="Sr" name="Sr" >
+  <atom type="A" unit="g/mol" value="87.6166" />
+ </element>
+ <material formula="Sr" name="Strontium" state="solid" >
+  <RL type="X0" unit="cm" value="4.237" />
+  <NIL type="lambda" unit="cm" value="61.0238" />
+  <D type="density" unit="g/cm3" value="2.54" />
+  <composite n="1" ref="Sr" />
+ </material>
+ <element Z="73" formula="Ta" name="Ta" >
+  <atom type="A" unit="g/mol" value="180.948" />
+ </element>
+ <material formula="Ta" name="Tantalum" state="solid" >
+  <RL type="X0" unit="cm" value="0.409392" />
+  <NIL type="lambda" unit="cm" value="11.8846" />
+  <D type="density" unit="g/cm3" value="16.654" />
+  <composite n="1" ref="Ta" />
+ </material>
+ <element Z="65" formula="Tb" name="Tb" >
+  <atom type="A" unit="g/mol" value="158.925" />
+ </element>
+ <material formula="Tb" name="Terbium" state="solid" >
+  <RL type="X0" unit="cm" value="0.893977" />
+  <NIL type="lambda" unit="cm" value="23.0311" />
+  <D type="density" unit="g/cm3" value="8.229" />
+  <composite n="1" ref="Tb" />
+ </material>
+ <element Z="43" formula="Tc" name="Tc" >
+  <atom type="A" unit="g/mol" value="97.9072" />
+ </element>
+ <material formula="Tc" name="Technetium" state="solid" >
+  <RL type="X0" unit="cm" value="0.833149" />
+  <NIL type="lambda" unit="cm" value="14.0185" />
+  <D type="density" unit="g/cm3" value="11.5" />
+  <composite n="1" ref="Tc" />
+ </material>
+ <element Z="52" formula="Te" name="Te" >
+  <atom type="A" unit="g/mol" value="127.603" />
+ </element>
+ <material formula="Te" name="Tellurium" state="solid" >
+  <RL type="X0" unit="cm" value="1.41457" />
+  <NIL type="lambda" unit="cm" value="28.1797" />
+  <D type="density" unit="g/cm3" value="6.24" />
+  <composite n="1" ref="Te" />
+ </material>
+ <element Z="90" formula="Th" name="Th" >
+  <atom type="A" unit="g/mol" value="232.038" />
+ </element>
+ <material formula="Th" name="Thorium" state="solid" >
+  <RL type="X0" unit="cm" value="0.51823" />
+  <NIL type="lambda" unit="cm" value="18.353" />
+  <D type="density" unit="g/cm3" value="11.72" />
+  <composite n="1" ref="Th" />
+ </material>
+ <element Z="22" formula="Ti" name="Ti" >
+  <atom type="A" unit="g/mol" value="47.8667" />
+ </element>
+ <material formula="Ti" name="Titanium" state="solid" >
+  <RL type="X0" unit="cm" value="3.5602" />
+  <NIL type="lambda" unit="cm" value="27.9395" />
+  <D type="density" unit="g/cm3" value="4.54" />
+  <composite n="1" ref="Ti" />
+ </material>
+ <element Z="81" formula="Tl" name="Tl" >
+  <atom type="A" unit="g/mol" value="204.383" />
+ </element>
+ <material formula="Tl" name="Thallium" state="solid" >
+  <RL type="X0" unit="cm" value="0.547665" />
+  <NIL type="lambda" unit="cm" value="17.6129" />
+  <D type="density" unit="g/cm3" value="11.72" />
+  <composite n="1" ref="Tl" />
+ </material>
+ <element Z="69" formula="Tm" name="Tm" >
+  <atom type="A" unit="g/mol" value="168.934" />
+ </element>
+ <material formula="Tm" name="Thulium" state="solid" >
+  <RL type="X0" unit="cm" value="0.754428" />
+  <NIL type="lambda" unit="cm" value="20.7522" />
+  <D type="density" unit="g/cm3" value="9.321" />
+  <composite n="1" ref="Tm" />
+ </material>
+ <element Z="92" formula="U" name="U" >
+  <atom type="A" unit="g/mol" value="238.029" />
+ </element>
+ <material formula="U" name="Uranium" state="solid" >
+  <RL type="X0" unit="cm" value="0.31663" />
+  <NIL type="lambda" unit="cm" value="11.4473" />
+  <D type="density" unit="g/cm3" value="18.95" />
+  <composite n="1" ref="U" />
+ </material>
+ <element Z="23" formula="V" name="V" >
+  <atom type="A" unit="g/mol" value="50.9415" />
+ </element>
+ <material formula="V" name="Vanadium" state="solid" >
+  <RL type="X0" unit="cm" value="2.59285" />
+  <NIL type="lambda" unit="cm" value="21.2187" />
+  <D type="density" unit="g/cm3" value="6.11" />
+  <composite n="1" ref="V" />
+ </material>
+ <element Z="74" formula="W" name="W" >
+  <atom type="A" unit="g/mol" value="183.842" />
+ </element>
+ <material formula="W" name="Tungsten" state="solid" >
+  <RL type="X0" unit="cm" value="0.350418" />
+  <NIL type="lambda" unit="cm" value="10.3057" />
+  <D type="density" unit="g/cm3" value="19.3" />
+  <composite n="1" ref="W" />
+ </material>
+ <element Z="54" formula="Xe" name="Xe" >
+  <atom type="A" unit="g/mol" value="131.292" />
+ </element>
+ <material formula="Xe" name="Xenon" state="gas" >
+  <RL type="X0" unit="cm" value="1546.2" />
+  <NIL type="lambda" unit="cm" value="32477.9" />
+  <D type="density" unit="g/cm3" value="0.00548536" />
+  <composite n="1" ref="Xe" />
+ </material>
+ <element Z="39" formula="Y" name="Y" >
+  <atom type="A" unit="g/mol" value="88.9058" />
+ </element>
+ <material formula="Y" name="Yttrium" state="solid" >
+  <RL type="X0" unit="cm" value="2.32943" />
+  <NIL type="lambda" unit="cm" value="34.9297" />
+  <D type="density" unit="g/cm3" value="4.469" />
+  <composite n="1" ref="Y" />
+ </material>
+ <element Z="70" formula="Yb" name="Yb" >
+  <atom type="A" unit="g/mol" value="173.038" />
+ </element>
+ <material formula="Yb" name="Ytterbium" state="solid" >
+  <RL type="X0" unit="cm" value="1.04332" />
+  <NIL type="lambda" unit="cm" value="28.9843" />
+  <D type="density" unit="g/cm3" value="6.73" />
+  <composite n="1" ref="Yb" />
+ </material>
+ <element Z="30" formula="Zn" name="Zn" >
+  <atom type="A" unit="g/mol" value="65.3955" />
+ </element>
+ <material formula="Zn" name="Zinc" state="solid" >
+  <RL type="X0" unit="cm" value="1.74286" />
+  <NIL type="lambda" unit="cm" value="19.8488" />
+  <D type="density" unit="g/cm3" value="7.133" />
+  <composite n="1" ref="Zn" />
+ </material>
+ <element Z="40" formula="Zr" name="Zr" >
+  <atom type="A" unit="g/mol" value="91.2236" />
+ </element>
+ <material formula="Zr" name="Zirconium" state="solid" >
+  <RL type="X0" unit="cm" value="1.56707" />
+  <NIL type="lambda" unit="cm" value="24.2568" />
+  <D type="density" unit="g/cm3" value="6.506" />
+  <composite n="1" ref="Zr" />
+ </material>
+</materials>

--- a/SiD/compact/SiD_o2_v04/materials.xml
+++ b/SiD/compact/SiD_o2_v04/materials.xml
@@ -1,0 +1,262 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<materials>
+
+  <!--
+       Air by weight from
+       http://www.engineeringtoolbox.com/air-composition-24_212.html
+  -->
+  <material name="Air">
+    <D type="density" unit="g/cm3" value="0.0012"/>
+    <fraction n="0.754" ref="N"/>
+    <fraction n="0.234" ref="O"/>
+    <fraction n="0.012" ref="Ar"/>
+  </material>
+  
+  <!-- We model vacuum just as very thin air -->
+  <material name="Vacuum">  
+    <D type="density" unit="g/cm3" value="0.0000000001"/>
+    <fraction n="0.754" ref="N"/>
+    <fraction n="0.234" ref="O"/>
+    <fraction n="0.012" ref="Ar"/>
+  </material>
+
+  <material name="Epoxy">
+    <D type="density" value="1.3" unit="g/cm3"/>
+    <composite n="44" ref="H"/>
+    <composite n="15" ref="C"/>
+    <composite n="7" ref="O"/>
+  </material>
+
+  <material name="Quartz">
+    <D type="density" value="2.2" unit="g/cm3"/>
+    <composite n="1" ref="Si"/>
+    <composite n="2" ref="O"/>
+  </material>
+
+  <material name="G10">
+    <D type="density" value="1.7" unit="g/cm3"/>
+    <fraction n="0.08" ref="Cl"/>
+    <fraction n="0.773" ref="Quartz"/>
+    <fraction n="0.147" ref="Epoxy"/>
+  </material>
+
+  <material name="Polystyrene">
+    <D type="density" value="1.032" unit="g/cm3"/>
+    <composite n="19" ref="C"/>
+    <composite n="21" ref="H"/>
+  </material>
+
+  <material name="Polystyrole">
+    <D type="density" value="1.065" unit="g/cm3"/>
+    <fraction n="0.50" ref="C"/>
+    <fraction n="0.50" ref="H"/>
+  </material>
+
+  <material name="PVC">
+    <D type="density" value="1.350" unit="g/cm3"/>
+    <fraction n="0.333" ref="C"/>
+    <fraction n="0.500" ref="H"/>
+    <fraction n="0.167" ref="Cl"/>
+  </material>
+
+  <material name="Steel">
+    <D type="density" value="7.87" unit="g/cm3"/>
+    <fraction n="0.988" ref="Fe"/>
+    <fraction n="0.002" ref="C"/>
+  </material>
+
+  <!-- from https://arxiv.org/pdf/1003.2662.pdf -->
+  <material name="Steel235">
+    <D type="density" value="7.87" unit="g/cm3"/>
+    <fraction n="0.9834" ref="Fe"/>
+    <fraction n="0.0017" ref="C"/>
+    <fraction n="0.0140" ref="Mn"/>
+    <fraction n="0.00045" ref="S"/>
+    <fraction n="0.00045" ref="P"/>
+  </material>
+
+  <material name="Brass">
+    <D type="density" value="8.520" unit="g/cm3"/>
+    <fraction n="0.60" ref="Cu"/>
+    <fraction n="0.40" ref="Zn"/>
+  </material>
+
+  <!-- Cartridge Brass -->
+  <material name="C26000">
+    <D type="density" value="8.83" unit="g/cm3"/>
+    <fraction n="0.70" ref="Cu"/>
+    <fraction n="0.30" ref="Zn"/>
+  </material>
+  
+  <material name="Steel235JR">
+    <D type="density" value="7.87" unit="g/cm3"/>
+    <fraction n="0.9843" ref="Fe"/>
+    <fraction n="0.0017" ref="C"/>
+    <fraction n="0.0140" ref="Mn"/>
+  </material>
+
+  <material name="CFmix">
+    <D type="density" value="0.120" unit="g/cm3"/>
+    <fraction n="0.009" ref="Air"/>
+    <fraction n="0.872" ref="PVC"/>
+    <fraction n="0.119" ref="Polystyrole"/>
+  </material>
+
+  <material name="SiliconOxide">
+    <D type="density" value="2.65" unit="g/cm3"/>
+    <composite n="1" ref="Si"/>
+    <composite n="2" ref="O"/>
+  </material>
+
+  <material name="BoronOxide">
+    <D type="density" value="2.46" unit="g/cm3"/>
+    <composite n="2" ref="B"/>
+    <composite n="3" ref="O"/>
+  </material>
+
+  <material name="SodiumOxide">
+    <D type="density" value="2.65" unit="g/cm3"/>
+    <composite n="2" ref="Na"/>
+    <composite n="1" ref="O"/>
+  </material>
+
+  <material name="AluminumOxide">
+    <D type="density" value="3.89" unit="g/cm3"/>
+    <composite n="2" ref="Al"/>
+    <composite n="3" ref="O"/>
+  </material>
+
+  <material name="PyrexGlass">
+    <D type="density" value="2.23" unit="g/cm3"/>
+    <fraction n="0.806" ref="SiliconOxide"/>
+    <fraction n="0.130" ref="BoronOxide"/>
+    <fraction n="0.040" ref="SodiumOxide"/>
+    <fraction n="0.023" ref="AluminumOxide"/>
+  </material>
+
+  <material name="CarbonFiber">
+    <D type="density" value="1.5" unit="g/cm3"/>
+    <fraction n="0.65" ref="C"/>
+    <fraction n="0.35" ref="Epoxy"/>
+  </material>
+  
+  <material name="CarbonFiber_50D">
+    <D type="density" value="0.75" unit="g/cm3"/>
+    <fraction n="0.65" ref="C"/>
+    <fraction n="0.35" ref="Epoxy"/>
+  </material>  
+
+  <material name="Rohacell31">
+    <D type="density" value="0.032" unit="g/cm3"/>
+    <composite n="9" ref="C"/>
+    <composite n="13" ref="H"/>
+    <composite n="2" ref="O"/>
+    <composite n="1" ref="N"/>
+  </material>
+  
+  <material name="Rohacell31_50D">
+    <D type="density" value="0.016" unit="g/cm3"/>
+    <composite n="9" ref="C"/>
+    <composite n="13" ref="H"/>
+    <composite n="2" ref="O"/>
+    <composite n="1" ref="N"/>
+  </material>  
+
+  <material name="RPCGasDefault" state="gas">
+    <D type="density" value="0.0037" unit="g/cm3"/>
+    <composite n="209" ref="C"/>
+    <composite n="239" ref="H"/>
+    <composite n="381" ref="F"/>
+  </material>
+
+  <material name="PolystyreneFoam">
+    <D type="density" value="0.0056" unit="g/cm3"/>
+    <fraction n="1.0" ref="Polystyrene"/>
+  </material>
+
+  <material name="Kapton">
+    <D type="density" value="1.43" unit="g/cm3" />
+    <composite n="22" ref="C"/>
+    <composite n="10" ref="H" />
+    <composite n="2" ref="N" />
+    <composite n="5" ref="O" />
+  </material>
+
+  <material name="PEEK">
+    <D value="1.37" unit="g/cm3" />
+    <composite n="19" ref="C"/>
+    <composite n="12" ref="H" />
+    <composite n="3" ref="O" />
+  </material>
+
+  <material name="TungstenDens23">
+      <D value="17.7" unit="g/cm3"/>
+      <fraction n="0.925" ref="W"/>
+      <fraction n="0.066" ref="Ni"/>
+      <fraction n="0.009" ref="Fe"/>
+  </material>
+
+  <material name="TungstenDens24">
+      <D value="17.8" unit="g/cm3"/>
+      <fraction n="0.93" ref="W"/>
+      <fraction n="0.061" ref="Ni"/>
+      <fraction n="0.009" ref="Fe"/>
+  </material>
+
+  <material name="TungstenDens25">
+      <D value="18.2" unit="g/cm3"/>
+      <fraction n="0.950" ref="W"/>
+      <fraction n="0.044" ref="Ni"/>
+      <fraction n="0.006" ref="Fe"/>
+  </material>
+
+  <material name="CarbonFiber_25percent">
+      <D type="density" value="0.375" unit="g/cm3"/>
+      <fraction n="1.0" ref="CarbonFiber"/>
+  </material>
+  
+  <material name="CarbonFiber_15percent">
+      <D type="density" value="0.225" unit="g/cm3"/>
+      <fraction n="1.0" ref="CarbonFiber"/>
+  </material>
+
+  <material name="Rohacell31_50percent">
+      <D type="density" value="0.016" unit="g/cm3"/>
+      <fraction n="1.0" ref="Rohacell31"/>
+  </material>
+
+  <material name="Rohacell31_15percent">
+      <D type="density" value="0.0048" unit="g/cm3"/>
+      <fraction n="1.0" ref="Rohacell31"/>
+  </material>
+
+  <material name="BoratedPolyethylene5">
+      <D value="0.93" unit="g/cm3"/>
+      <fraction n="0.612" ref="C"/>
+      <fraction n="0.222" ref="O"/>
+      <fraction n="0.116" ref="H"/>
+      <fraction n="0.050" ref="B"/>
+  </material>
+
+  <material name="SiliconCarbide">
+      <D value="3.1" unit="g/cm3"/>
+      <composite n="1" ref="Si"/>
+      <composite n="1" ref="C"/>
+  </material>
+
+  <material name="SiliconCarbide_6percent">
+      <D value="0.186" unit="g/cm3"/>
+      <fraction n="1.0" ref="SiliconCarbide"/>
+  </material>
+
+  <material name="PCB" state="solid">
+    <MEE unit="eV" value="88.255598548367"/>
+    <D unit="g/cm3" value="1.7"/>
+    <fraction n="0.180774" ref="Si"/>
+    <fraction n="0.405633" ref="O"/>
+    <fraction n="0.278042" ref="C"/>
+    <fraction n="0.0684428" ref="H"/>
+    <fraction n="0.0671091" ref="Br"/>
+  </material>
+
+</materials>

--- a/detector/calorimeter/ECalBarrel_o2_v04_geo.cpp
+++ b/detector/calorimeter/ECalBarrel_o2_v04_geo.cpp
@@ -1,0 +1,393 @@
+//=========================================================================
+//  Barrel ECal driver implementation for the CLIC NDM including
+//     Layering Extensions for DDRec/Pandora
+//-------------------------------------------------------------------------
+//  Based on
+//   * S. Lu's driver for SiWEcalBarrel, ported from Mokka
+//   * M. Frank's generic driver EcalBarrel_geo.cpp
+//-------------------------------------------------------------------------
+//  D.Protopopescu: updated May 2022 to fix layer 0 size and position
+//  D.Protopopescu, Glasgow, Dec 2017  
+//  A.Steinhebel, Nov 2016
+//  M.Frank, CERN
+//  S.Lu, DESY
+//  $Id: ECalBarrel_o1_v04_geo.cpp 761 2022-04-11 14:17:14Z dan.protopopescu@glasgow.ac.uk $
+//=========================================================================
+
+#define VERBOSE_LEVEL 0
+
+#include "DD4hep/DetFactoryHelper.h"
+#include "DD4hep/Printout.h"
+#include "XML/Layering.h"
+#include "TGeoTrd2.h"
+#include "XML/Utilities.h"
+#include "DDRec/DetectorData.h"
+#include "DDSegmentation/Segmentation.h"
+
+using namespace std;
+
+using dd4hep::BUILD_ENVELOPE;
+using dd4hep::Box;
+using dd4hep::DetElement;
+using dd4hep::Detector;
+using dd4hep::Layering;
+using dd4hep::Material;
+using dd4hep::PlacedVolume;
+using dd4hep::Position;
+using dd4hep::Readout;
+using dd4hep::Ref_t;
+using dd4hep::RotationZYX;
+using dd4hep::Segmentation;
+using dd4hep::SensitiveDetector;
+using dd4hep::Transform3D;
+using dd4hep::Translation3D;
+using dd4hep::Trapezoid;
+using dd4hep::Volume;
+using dd4hep::_toString;
+
+using dd4hep::rec::LayeredCalorimeterData;
+
+static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector sens)  {
+    
+    xml_det_t     x_det     = e;
+    int           det_id    = x_det.id();
+    string        det_name  = x_det.nameStr();
+    DetElement    sdet      (det_name, det_id);
+    
+    // --- create an envelope volume and position it into the world ---------------------
+    
+    Volume envelope = dd4hep::xml::createPlacedEnvelope(theDetector, e, sdet);
+    dd4hep::xml::setDetectorTypeFlag( e, sdet ) ;
+    
+    if(theDetector.buildType() == BUILD_ENVELOPE) return sdet;
+    
+    //-----------------------------------------------------------------------------------
+
+    dd4hep::xml::Component xmlParameter = x_det.child(_Unicode(parameter));
+    const double tolerance = xmlParameter.attr<double>(_Unicode(ecal_barrel_tolerance));
+    const int n_towers = (int) xmlParameter.attr<double>(_Unicode(num_towers));
+    const int n_rails = (int) xmlParameter.attr<double>(_Unicode(num_rails));
+    const int n_stacks = (int) xmlParameter.attr<double>(_Unicode(stacks_per_tower));
+    const double towersAirGap = xmlParameter.attr<double>(_Unicode(TowersAirGap));
+    const double faceThickness = xmlParameter.attr<double>(_Unicode(TowersFaceThickness));
+    const double supportRailCS = xmlParameter.attr<double>(_Unicode(supportRailCrossSection));
+    Material Composite = theDetector.material(xmlParameter.attr<string>(_Unicode(AlveolusMaterial)));
+    Material Steel = theDetector.material(xmlParameter.attr<string>(_Unicode(supportRailMaterial)));
+
+    Readout readout = sens.readout();
+    Segmentation seg = readout.segmentation();
+    
+    std::vector<double> cellSizeVector = seg.segmentation()->cellDimensions(0); 
+    //Assume uniform cell sizes, provide dummy cellID
+    double cell_sizeX      = cellSizeVector[0];
+    double cell_sizeY      = cellSizeVector[1];
+    
+    Layering      layering (e);
+    Material      air       = theDetector.air();
+    xml_comp_t    x_staves  = x_det.staves();
+    xml_comp_t    x_dim     = x_det.dimensions();
+    int           nsides    = x_dim.numsides();
+    double        inner_r   = x_dim.rmin();                     // inscribed cylinder
+    double        dphi      = (2.*M_PI/nsides);
+    double        hphi      = dphi/2.;
+    double        mod_z     = layering.totalThickness();
+    double        r_max     = x_dim.rmax()/std::cos(hphi);      // circumscribed cylinder, see http://cern.ch/go/r9mZ
+    double        ry        = sqrt(supportRailCS)/2.;           // support rail thickness
+    double        outer_r   = (inner_r + mod_z)/std::cos(hphi); // r_outer of actual module
+    
+    // Create extension objects for reconstruction -----------------
+
+    // Create caloData object to extend driver with data required for reconstruction
+    // See http://cern.ch/go/z8tp to learn how quantities are calculated
+    LayeredCalorimeterData* caloData = new LayeredCalorimeterData;
+    caloData->layoutType = LayeredCalorimeterData::BarrelLayout;
+    caloData->inner_symmetry = nsides;
+    caloData->outer_symmetry = nsides; 
+    
+    /** NOTE: phi0=0 means lower face flat parallel to experimental floor
+     *  This is achieved by rotating the modules with respect to the envelope
+     *  which is assumed to be a Polyhedron and has its axes rotated with respect
+     *  to the world by 180/nsides. In any other case (e.g. if you want to have
+     *  a tip of the calorimeter touching the ground) this value needs to be computed
+     */
+    
+    caloData->inner_phi0 = 0.; 
+    caloData->outer_phi0 = 0.; 
+    // One should ensure that these sensitivity gaps are correctly used
+    caloData->gap0 = towersAirGap;  // the 4 gaps between the 5 towers, along z 
+    caloData->gap1 = faceThickness; // gaps between stacks in a module, along z
+    caloData->gap2 = tolerance*std::cos(hphi); // gaps where the staves overlap
+
+    // extent of the calorimeter in the r-z-plane [ rmin, rmax, zmin, zmax ] in mm.
+    caloData->extent[0] = inner_r;
+    caloData->extent[1] = outer_r; // or r_max ?
+    caloData->extent[2] = 0.;      // NN: for barrel detectors this is 0
+    caloData->extent[3] = x_dim.z()/2;
+
+    // This detector is now composed of 12 staves,
+    // each stave made of 5 towers which contain each 3 stacks of 26 sensitive layers.
+    // See schematics in http://cern.ch/go/MgF6
+
+    // Compute stave dimensions
+    double dx = mod_z*(std::tan(hphi) + 1./std::tan(dphi));       // lateral shift
+    double trd_x1 = inner_r*std::tan(hphi) + dx/2. - tolerance;   // inner, long side
+    double trd_x2 = outer_r*std::sin(hphi) - dx/2. - tolerance;   // outer, short side
+    double trd_y1s = x_dim.z()/2. - tolerance;                    // and y2 = y1
+    double trd_z  = mod_z/2.;
+    double trd_ls = trd_z/std::sin(dphi);                         // slanted side 
+
+    // Create the trapezoid for the stave. For coordinate system, see
+    // https://root.cern.ch/root/html/TGeoTrd2.html
+    // This stave is slightly bigger to contain the support rails
+    Trapezoid stv(trd_x1, // Inner side, i.e. "long" X side
+                  trd_x2 - 2*ry/std::tan(dphi), // Outer side, i.e. "short" X side
+                  trd_y1s,       // Depth at bottom face 
+                  trd_y1s,       // Depth at top face y2=y1
+                  trd_z + ry);   // Height of the stave, when rotated 
+    Volume stave_vol("stave", stv, air);
+
+#if VERBOSE_LEVEL>0
+    std::cout << "Stave height/thickness: " << 2*trd_z << std::endl;
+    std::cout << "Got r_inner = " << inner_r << std::endl;
+    std::cout << "Got r_outer = " << outer_r << " and r_max = " << r_max << std::endl;
+    std::cout << "Got mod_z = " << mod_z <<  std::endl;
+#endif
+
+    if(outer_r > r_max) { // throw exception 
+      throw std::runtime_error("ERROR: Layers don't fit within the envelope volume!");
+    }
+
+    // Create the trapezoid for the towers (5 of them per stave) 
+    double trd_y1t = (x_dim.z() - (n_towers-1)*towersAirGap)/n_towers/2 - tolerance;
+    Trapezoid twr(trd_x1,  // Inner side, i.e. the "long" X side
+                  trd_x2,  // Outer side, i.e. the "short" X side
+                  trd_y1t, // Depth at bottom face
+                  trd_y1t, // Depth at top face y2=y1
+                  trd_z);  // Height of the tower, when rotated
+    
+    // Create support rails
+    Box rail(ry, trd_y1s, ry); // y=trd_y1t for 3x5
+
+    // Create trapezoids for each of the stacks (3 of them per tower)
+    double trd_y1 = (trd_y1t - (n_stacks - 1)*faceThickness)/n_stacks; // add end faces + tolerance
+    Trapezoid stk(trd_x1, // Inner side, i.e. the "long" X side
+                  trd_x2, // Outer side, i.e. the "short" X side
+                  trd_y1, // Depth at bottom face
+                  trd_y1, // Depth at top face y2=y1
+                  trd_z); // Height of the stack, when rotated
+
+    sens.setType("calorimeter");
+
+    // Start position and angle for the module
+    double phi = M_PI/nsides;               
+    double mod_x_off = dx/2 + tolerance;                // Module X offset
+    //double mod_y_off = (inner_r + r_max*cos(hphi))/2; // Module Y offset - mid-envelope placement
+    double mod_y_off = inner_r + ry + trd_z + tolerance;// Module Y offset - inner r placement
+
+#if VERBOSE_LEVEL>0
+    std::cout << "Module y offset: " << mod_y_off << std::endl;
+#endif
+
+    DetElement stave_det("stave0", det_id);    
+    for (int t = 0; t < n_towers; t++) {
+      double t_pos_y = (t - (n_towers-1)/2)*(2*trd_y1t + towersAirGap);
+      string t_name = _toString(t+1, "module%d");
+      Volume tower_vol(t_name, twr, Composite); // solid C composite
+      DetElement tower_det(stave_det, t_name, det_id);
+
+      for (int m = 0; m < n_stacks; m++) { 
+	double m_pos_y = (m - (n_stacks-1)/2)*(2*trd_y1 + faceThickness);
+	string k_name = _toString(m+1, "submodule%d");
+	Volume stack_vol(k_name, stk, Composite); // solid C composite
+        DetElement stack_det(tower_det, k_name, det_id);
+
+        // Parameters for computing the layer dimensions:
+	double l_dim_x  = trd_x1; 
+	double l_dim_y  = trd_y1 - 2.*faceThickness;
+	double tan_beta = std::tan(dphi);
+	double l_pos_z  = -trd_z;
+	
+	// Loop over the sets of layer elements in the module
+	int l_num = 0;
+	for(xml_coll_t li(x_det,_U(layer)); li; ++li)  {
+	  
+	  xml_comp_t x_layer = li;
+	  int repeat = x_layer.repeat();
+	  
+	  // Loop over number of repeats for this layer.
+	  for (int j=0; j<repeat; j++) {
+	    
+	    string l_name = _toString(l_num, "layer%d");
+	    double l_thickness = layering.layer(l_num)->thickness(); // layer thickness          
+	    
+	    l_dim_x -= l_thickness/tan_beta;   // decreasing width 
+
+	    double l_dim_xj = l_dim_x;
+	    double x_shift = 0.;
+	    if(repeat==1){ // special case layer0 does not extend into the overlap region
+	      l_dim_xj = l_dim_x - trd_ls; 
+	      x_shift = trd_ls;
+	    }
+
+#if VERBOSE_LEVEL>1
+	    std::cout << l_name << " thickness: " << l_thickness << " l_dim_x=" << l_dim_xj << " shift=" << x_shift << std::endl;
+#endif
+	    std::cout << "Barrel ECal layer_" << l_num << "-" << repeat << "_" << j << " l_dim_x=" << l_dim_xj << " shift=" << x_shift << std::endl; 
+
+	    Position   l_pos(x_shift, 0., l_pos_z + l_thickness/2.);  // layer position 
+	    Box        l_box(l_dim_xj - tolerance, l_dim_y - tolerance, l_thickness/2.);
+	    Volume     l_vol(l_name, l_box, air);
+	    DetElement layer(stack_det, l_name, det_id);
+
+	    LayeredCalorimeterData::Layer caloLayer;
+	    double nRadiationLengths   = 0.;
+	    double nInteractionLengths = 0.;
+	    double thickness_sum       = 0.;
+	    double absorberThickness   = 0.;	    
+	    
+	    // Loop over the sublayers or slices for this layer
+	    int s_num = 1;
+	    double s_pos_z = -(l_thickness/2);
+	    for(xml_coll_t si(x_layer,_U(slice)); si; ++si)  {
+	      
+	      xml_comp_t x_slice = si;
+	      string     s_name  = _toString(s_num, "slice%d");
+	      double     s_thick = x_slice.thickness();
+#if VERBOSE_LEVEL>2
+	      std::cout << s_name << " thickness: " << s_thick << std::endl;
+#endif
+	      Box        s_box(l_dim_xj - tolerance, l_dim_y - tolerance, s_thick/2.);
+	      Material   slice_material  = theDetector.material(x_slice.materialStr());
+	      Volume     s_vol(s_name, s_box, slice_material);
+	      DetElement slice(layer, s_name, det_id);
+
+	      // For caloData (adding 1/2 here)
+              nRadiationLengths   += s_thick/2./slice_material.radLength();
+              nInteractionLengths += s_thick/2./slice_material.intLength();
+              thickness_sum       += s_thick/2.;
+	      
+	      if ( x_slice.isSensitive() ) { // only one per layer
+		s_vol.setSensitiveDetector(sens);
+		caloLayer.distance = s_pos_z + s_thick/.2 + l_pos_z + l_thickness/2. + mod_y_off - ry;
+		caloLayer.sensitive_thickness       = s_thick ;
+		caloLayer.inner_nRadiationLengths   = nRadiationLengths;
+		caloLayer.inner_nInteractionLengths = nInteractionLengths;
+		caloLayer.inner_thickness           = thickness_sum;
+
+#if VERBOSE_LEVEL>1
+		std::cout << l_name << "." << s_name << ": is sensitive" << std::endl;
+		std::cout <<" caloLayer.inner_nRadiationLengths: "<< caloLayer.inner_nRadiationLengths << std::endl;
+		std::cout <<" caloLayer.inner_nInteractionLengths: "<< caloLayer.inner_nInteractionLengths << std::endl;
+		std::cout <<" caloLayer.inner_thickness: "<< caloLayer.inner_thickness << std::endl;
+		std::cout <<" caloLayer.sensitive_thickness: "<< caloLayer.sensitive_thickness << std::endl;
+#endif
+		// Inner quantities done, reset sums
+		nRadiationLengths   = 0.;
+		nInteractionLengths = 0.;
+		thickness_sum       = 0.;
+	      }
+
+	      // For caloData (adding the other 1/2 here)
+              nRadiationLengths   += s_thick/2./slice_material.radLength();
+              nInteractionLengths += s_thick/2./slice_material.intLength();
+              thickness_sum       += s_thick/2.;
+	      
+	      if( x_slice.isRadiator() == true) {
+	      	absorberThickness += s_thick;
+	      }
+	      
+	      s_vol.setAttributes(theDetector, x_slice.regionStr(), x_slice.limitsStr(), x_slice.visStr());
+	      
+	      // Slice placement
+	      PlacedVolume slice_pv = l_vol.placeVolume(s_vol, Position(0., 0., s_pos_z + s_thick/2.));
+	      slice.setPlacement(slice_pv);	  
+	      // Increment Z position of slice
+	      s_pos_z += s_thick;
+	      
+	      // Increment slice number
+	      ++s_num;
+	    }
+	    
+	    // Set region, limitset, and visibility of layer
+	    l_vol.setAttributes(theDetector, x_layer.regionStr(), x_layer.limitsStr(), x_layer.visStr());
+	    
+	    PlacedVolume layer_pv = stack_vol.placeVolume(l_vol, l_pos);
+	    layer_pv.addPhysVolID("layer", l_num);
+	    layer.setPlacement(layer_pv);
+	    
+	    caloLayer.outer_nRadiationLengths   = nRadiationLengths;
+	    caloLayer.outer_nInteractionLengths = nInteractionLengths;
+	    caloLayer.outer_thickness           = thickness_sum;
+	    caloLayer.absorberThickness         = absorberThickness;
+	    caloLayer.cellSize0 = cell_sizeX;
+	    caloLayer.cellSize1 = cell_sizeY;
+
+#if VERBOSE_LEVEL>1
+	    std::cout <<" caloLayer.outer_nRadiationLengths: "<< caloLayer.outer_nRadiationLengths << std::endl;
+	    std::cout <<" caloLayer.outer_nInteractionLengths: "<< caloLayer.outer_nInteractionLengths << std::endl;
+	    std::cout <<" caloLayer.outer_thickness: "<< caloLayer.outer_thickness << std::endl;
+	    std::cout <<" caloLayer.absorberThickness: "<< caloLayer.absorberThickness << std::endl << std::endl;
+	    std::cout <<" caloLayer total thickness: "<< caloLayer.inner_thickness + caloLayer.outer_thickness << std::endl;
+#endif
+	    caloData->layers.push_back( caloLayer ) ;
+	    
+	    // Increment to next layer Z position
+	    l_pos_z += l_thickness;
+	    ++l_num;
+	  }
+	}
+	//stack_vol.setVisAttributes(theDetector.visAttributes("GrayVis"));
+	
+	PlacedVolume stack_pv = tower_vol.placeVolume(stack_vol, Position(0., m_pos_y, 0.));
+	//as	stack_pv.addPhysVolID("submodule", m); 
+	stack_det.setPlacement(stack_pv);
+      }
+      //tower_vol.setVisAttributes(theDetector.visAttributes("GreenVis"));
+      
+      PlacedVolume tower_pv = stave_vol.placeVolume(tower_vol, Position(0., t_pos_y, -ry));
+      //as      tower_pv.addPhysVolID("module", t);  
+      tower_det.setPlacement(tower_pv);
+    }
+      
+    if ( x_staves ) // Set the vis attributes of the stave
+      stave_det.setVisAttributes(theDetector, x_staves.visStr(), stave_vol);
+
+    // Create support rails (move in the loop for 3x5, i.e. 3 rails per tower)
+    double rail_spacing = trd_x2/2.;
+    for (int r = 0; r < n_rails; r++){
+      string r_name = _toString(r, "support_rail%d");
+      Volume rail_vol(r_name, rail, Steel);
+      DetElement rail_support(stave_det, r_name, det_id);
+      double r_pos_y = (r - (n_rails - 1)/2)*rail_spacing;
+      //PlacedVolume rail_pv = stave_vol.placeVolume(rail_vol, Position(r_pos_y, t_pos_y, trd_z));//3x5
+      PlacedVolume rail_pv = stave_vol.placeVolume(rail_vol, Position(r_pos_y, 0., trd_z));//3
+      rail_vol.setVisAttributes(theDetector.visAttributes("RedVis")); 
+      rail_support.setPlacement(rail_pv);
+    }
+        
+    // Place the staves
+    for (int i = 0; i < nsides; i++, phi -= dphi) { // i is the stave number
+      double s_pos_x = mod_x_off * std::cos(phi) - mod_y_off * std::sin(phi);
+      double s_pos_y = mod_x_off * std::sin(phi) + mod_y_off * std::cos(phi);
+      double s_pos_z = 0.;
+      Transform3D tr(RotationZYX(0., phi, M_PI/2.), Translation3D(-s_pos_x, -s_pos_y, -s_pos_z));
+      PlacedVolume pv = envelope.placeVolume(stave_vol, tr);
+      std::cout << "ECal stave/module " << i << " phi=" << phi << std::endl;
+      //as      pv.addPhysVolID("stave", i);
+      pv.addPhysVolID("module", i);
+      //as      pv.addPhysVolID("side", 0); //should set once in parent volume placement
+      //pv.addPhysVolID("system",det_id); // not needed (?)
+      DetElement sd = i==0 ? stave_det : stave_det.clone(_toString(i, "stave%d"));
+      sd.setPlacement(pv);
+      sdet.add(sd);
+    }    
+
+    // Set envelope volume attributes
+    envelope.setAttributes(theDetector,x_det.regionStr(),x_det.limitsStr(),x_det.visStr());
+    
+    sdet.addExtension< LayeredCalorimeterData >( caloData ) ;
+        
+    return sdet;
+}
+
+DECLARE_DETELEMENT(ECalBarrel_o2_v04, create_detector)

--- a/lcgeoTests/CMakeLists.txt
+++ b/lcgeoTests/CMakeLists.txt
@@ -22,14 +22,14 @@ SET_TESTS_PROPERTIES( t_${test_name} PROPERTIES FAIL_REGULAR_EXPRESSION  "Except
 
 #--------------------------------------------------
 # tests for SiD
-SET( test_name "test_SiD_o2_v02" )
-ADD_TEST( t_${test_name} "${CMAKE_INSTALL_PREFIX}/bin/run_test_${PackageName}.sh"
-  ddsim --compactFile=${CMAKE_CURRENT_SOURCE_DIR}/../SiD/compact/SiD_o2_v02/SiD_o2_v02.xml --runType=batch -G -N=1 --outputFile=testSiD_o2_v02.slcio )
-SET_TESTS_PROPERTIES( t_${test_name} PROPERTIES FAIL_REGULAR_EXPRESSION  "Exception;EXCEPTION;ERROR;Error" )
-
 SET( test_name "test_SiD_o2_v03" )
 ADD_TEST( t_${test_name} "${CMAKE_INSTALL_PREFIX}/bin/run_test_${PackageName}.sh"
   ddsim --compactFile=${CMAKE_CURRENT_SOURCE_DIR}/../SiD/compact/SiD_o2_v03/SiD_o2_v03.xml --runType=batch -G -N=1 --outputFile=testSiD_o2_v03.slcio )
+SET_TESTS_PROPERTIES( t_${test_name} PROPERTIES FAIL_REGULAR_EXPRESSION  "Exception;EXCEPTION;ERROR;Error" )
+
+SET( test_name "test_SiD_o2_v04" )
+ADD_TEST( t_${test_name} "${CMAKE_INSTALL_PREFIX}/bin/run_test_${PackageName}.sh"
+  ddsim --compactFile=${CMAKE_CURRENT_SOURCE_DIR}/../SiD/compact/SiD_o2_v04/SiD_o2_v04.xml --runType=batch -G -N=1 --outputFile=testSiD_o2_v04.slcio )
 SET_TESTS_PROPERTIES( t_${test_name} PROPERTIES FAIL_REGULAR_EXPRESSION  "Exception;EXCEPTION;ERROR;Error" )
 
 #--------------------------------------------------


### PR DESCRIPTION
BEGINRELEASENOTES
- Added SiD_o2_v04, which is an updated version of o2_v03, containing a few fixes, among which
    - correct size and position of ECal layer 0 via new driver ECalBarrel_o2_v04_geo.cpp
    - new beam pipe by Chris Potter
    - removed brass HCal option

ENDRELEASENOTES