### PR TITLE
Move SiD_o2_v04 beampipe constants to global list.

### DIFF
--- a/.github/workflows/key4hep.yml
+++ b/.github/workflows/key4hep.yml
@@ -1,0 +1,43 @@
+name: key4hep-stack
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        SETUP: ['/cvmfs/sw.hsf.org/key4hep/setup.sh', '/cvmfs/sw-nightlies.hsf.org/key4hep/setup.sh']
+    steps:
+    - uses: actions/checkout@v2
+    - uses: cvmfs-contrib/github-action-cvmfs@v2
+    - name: Start container
+      run: |
+        docker run -it --name CI_container -v ${GITHUB_WORKSPACE}:/Package -v /cvmfs:/cvmfs:shared -d ghcr.io/aidasoft/centos7:latest /bin/bash
+    - name: CMake Configure
+      run: |
+        docker exec CI_container /bin/bash -c 'cd Package;\
+         mkdir -p build install;\
+         source ${{ matrix.SETUP }};\
+         cd build;\
+         cmake -DCMAKE_INSTALL_PREFIX=../install -DCMAKE_CXX_STANDARD=17  -DCMAKE_CXX_FLAGS=" -fdiagnostics-color=always " -G Ninja ..;'
+    - name: Compile
+      run: |
+        docker exec CI_container /bin/bash -c 'cd ./Package;\
+        source ${{ matrix.SETUP }};\
+        cd build;\
+        ninja -k0;'
+    - name: Install
+      run: |
+        docker exec CI_container /bin/bash -c 'cd ./Package;\
+          source ${{ matrix.SETUP }};\
+          cd build;\
+          ninja -k0 install;'
+    - name: Test
+      run: |
+        docker exec CI_container /bin/bash -c 'cd ./Package;\
+        source ${{ matrix.SETUP }};\
+        cd build;\
+        ninja -k0 && ctest --output-on-failure;'
+

--- a/SiD/compact/SiD_o2_v04/BeamPipe_o2_v04.xml
+++ b/SiD/compact/SiD_o2_v04/BeamPipe_o2_v04.xml
@@ -1,9 +1,6 @@
 <comment>Beampipe by Chris Potter (UOregon)</comment>
 <!-- See talk on 23-04-2022 https://agenda.linearcollider.org/event/9586/ -->
 
-<comment>Parameters from ILC TDR V4 7.4.2. (CP)</comment>
-<!-- (defined in main xml) constant name="bp_cone_slope" value="0.0570643"/ -->
-
 <detectors>
  <comment>Be Beampipe and Be Cones</comment>
  <detector name="Beampipe" type="DD4hep_PolyconeSupport" insideTrackingVolume="true" vis="BeampipeVis">

--- a/SiD/compact/SiD_o2_v04/BeamPipe_o2_v04.xml
+++ b/SiD/compact/SiD_o2_v04/BeamPipe_o2_v04.xml
@@ -1,7 +1,7 @@
-<comment>Beampipe by Chris Potter (UOregon)</comment>
-<!-- See talk on 23-04-2022 https://agenda.linearcollider.org/event/9586/ -->
 
 <detectors>
+ <comment>Beampipe by Chris Potter (UOregon)</comment>
+ <!-- See talk on 23-04-2022 https://agenda.linearcollider.org/event/9586/ -->
  <comment>Be Beampipe and Be Cones</comment>
  <detector name="Beampipe" type="DD4hep_PolyconeSupport" insideTrackingVolume="true" vis="BeampipeVis">
   <material name="Beryllium"/>

--- a/SiD/compact/SiD_o2_v04/BeamPipe_o2_v04.xml
+++ b/SiD/compact/SiD_o2_v04/BeamPipe_o2_v04.xml
@@ -3,9 +3,6 @@
 
 <comment>Parameters from ILC TDR V4 7.4.2. (CP)</comment>
 <!-- (defined in main xml) constant name="bp_cone_slope" value="0.0570643"/ -->
-<constant name="bp_cone_dr" value="(20.50-6.25)*bp_cone_slope*cm"/>
-<constant name="steel_cone_slope" value="0.0932777"/>
-<constant name="steel_cone_dr" value="(120.0-20.5)*steel_cone_slope*cm"/>
 
 <detectors>
  <comment>Be Beampipe and Be Cones</comment>

--- a/SiD/compact/SiD_o2_v04/SiD_o2_v04.xml
+++ b/SiD/compact/SiD_o2_v04/SiD_o2_v04.xml
@@ -143,6 +143,10 @@
     <constant name="VXD_CF_sensor" value="0.026*cm"/>
     <constant name="VXD_CF_support" value="0.05*cm"/>
     <constant name="bp_cone_slope" value="(8.96-1.20)/(185-6.25)"/>
+    <constant name="bp_cone_dr" value="(20.50-6.25)*bp_cone_slope*cm"/>
+    <constant name="steel_cone_slope" value="0.0932777"/>
+    <constant name="steel_cone_dr" value="(120.0-20.5)*steel_cone_slope*cm"/>
+
 
     <constant name="Solenoid_inner_radius" value="2604*mm"/>
     <constant name="Solenoid_half_length" value="2950*mm"/>

--- a/SiD/compact/SiD_o2_v04/SiD_o2_v04.xml
+++ b/SiD/compact/SiD_o2_v04/SiD_o2_v04.xml
@@ -143,6 +143,7 @@
     <constant name="VXD_CF_sensor" value="0.026*cm"/>
     <constant name="VXD_CF_support" value="0.05*cm"/>
     <constant name="bp_cone_slope" value="(8.96-1.20)/(185-6.25)"/>
+    <comment>Parameters from ILC TDR V4 7.4.2. (CP)</comment>
     <constant name="bp_cone_dr" value="(20.50-6.25)*bp_cone_slope*cm"/>
     <constant name="steel_cone_slope" value="0.0932777"/>
     <constant name="steel_cone_dr" value="(120.0-20.5)*steel_cone_slope*cm"/>


### PR DESCRIPTION
This fixes an error in the key4hep builds:

```
XercesC FATAL +++ FATAL Error at file 
"/tmp/gitlab-runner/spack-stage/spack-stage-lcgeo-commit.032c4cc7bc8ed6be1071e931dccf904fb7976b8a-2javekkqt44e34d47dhiva3wh3srpqor/spack-src/SiD/compact/SiD_o2_v04/BeamPipe_o2_v04.xml", Line 4 Column: 1 
Message:comment or processing instruction expected
```

Most likely due to a newer version of dd4hep used there not available in the lcgeo CI.

EDIT: The error is tied to Xerces-C being used by DD4hep, which is not the case for the iLCSoft nightlies. 


BEGINRELEASENOTES
- Move SiD_o2_v04 beampipe constants to global list to fix an error in key4hep builds

ENDRELEASENOTES