### PR TITLE
LinearSortingPolicy: change return value to 1 for success

### DIFF
--- a/plugins/LinearSortingPolicy.cpp
+++ b/plugins/LinearSortingPolicy.cpp
@@ -109,7 +109,7 @@ namespace {
       }// for all paths
     }
 
-    return 0;
+    return 1;
   }
 
 


### PR DESCRIPTION

BEGINRELEASENOTES
- LinearSortingPolicy: change return value to 1 for success, adapt to recent changes in DD4hep that took the actual return value from the plugin, (https://github.com/AIDASoft/DD4hep/pull/936)

ENDRELEASENOTES