### PR TITLE
Remove stale CI workflow and update action versions

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -9,9 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository == 'iLCSoft/Lcgeo'
     steps:
-    - uses: actions/checkout@v2
-    - uses: cvmfs-contrib/github-action-cvmfs@v2
-    - uses: aidasoft/run-lcg-view@v3
+    - uses: actions/checkout@v3
+    - uses: cvmfs-contrib/github-action-cvmfs@v3
+    - uses: aidasoft/run-lcg-view@v4
       with:
         coverity-cmake-command: 'cmake -C $ILCSOFT/ILCSoft.cmake ..'
         coverity-project: 'iLCSoft%2FLcgeo'

--- a/.github/workflows/key4hep.yml
+++ b/.github/workflows/key4hep.yml
@@ -10,8 +10,8 @@ jobs:
       matrix:
         SETUP: ['/cvmfs/sw.hsf.org/key4hep/setup.sh', '/cvmfs/sw-nightlies.hsf.org/key4hep/setup.sh']
     steps:
-    - uses: actions/checkout@v2
-    - uses: cvmfs-contrib/github-action-cvmfs@v2
+    - uses: actions/checkout@v3
+    - uses: cvmfs-contrib/github-action-cvmfs@v3
     - name: Start container
       run: |
         docker run -it --name CI_container -v ${GITHUB_WORKSPACE}:/Package -v /cvmfs:/cvmfs:shared -d ghcr.io/aidasoft/centos7:latest /bin/bash

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -11,9 +11,9 @@ jobs:
         LCG: [100]
 
     steps:
-    - uses: actions/checkout@v2
-    - uses: cvmfs-contrib/github-action-cvmfs@v2
-    - uses: aidasoft/run-lcg-view@v3
+    - uses: actions/checkout@v3
+    - uses: cvmfs-contrib/github-action-cvmfs@v3
+    - uses: aidasoft/run-lcg-view@v4
       with:
         view-path: "/cvmfs/clicdp.cern.ch/iLCSoft/lcg/${{ matrix.LCG }}/nightly/x86_64-centos7-${{ matrix.COMPILER }}-opt"
         setup-script: "init_ilcsoft.sh"

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -9,9 +9,6 @@ jobs:
       matrix:
         COMPILER: [gcc10, clang11]
         LCG: [100]
-        include:
-          - COMPILER: gcc8
-            LCG: 99python2
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION

BEGINRELEASENOTES
- Remove gcc8 based workflow because the underlying nightly builds are no longer available
- Update github actions to latest available versions.

ENDRELEASENOTES