### PR TITLE
Add detector type flag for IDEA o1 DRC

### DIFF
--- a/FCCee/IDEA/compact/IDEA_o1_v03/FiberDualReadoutCalo_o1_v01.xml
+++ b/FCCee/IDEA/compact/IDEA_o1_v03/FiberDualReadoutCalo_o1_v01.xml
@@ -586,6 +586,7 @@
   <!-- this is where we actually define our detector: -->
   <detectors>
     <detector id="DetID_FiberDRCalo" name="DRcalo" type="FiberDualReadoutCalo_o1_v01" readout="DRcaloSiPMreadout" region="FastSimOpFiberRegion" reflect="true" vis="DRCInvisible">
+      <type_flags type="DetType_CALORIMETER + DetType_ELECTROMAGNETIC + DetType_HADRONIC + DetType_BARREL + DetType_ENDCAP"/>
       <sensitive type="DRcaloSiPMSD"/>
       <sipmDim height="0.3*mm" material="PolyvinylChloride" vis="DRCGenericVis">
         <sipmGlass material="DR_PyrexGlass" vis="DRCGlassVis"/>

--- a/detector/calorimeter/dual-readout/src/FiberDualReadoutCalo_o1_v01.cpp
+++ b/detector/calorimeter/dual-readout/src/FiberDualReadoutCalo_o1_v01.cpp
@@ -8,6 +8,7 @@
 #include "DD4hep/OpticalSurfaces.h"
 
 #include "DDRec/DetectorData.h"
+#include "XML/Utilities.h"
 
 namespace ddDRcalo {
 static dd4hep::Ref_t create_detector(dd4hep::Detector& description, xml_h xmlElement,
@@ -89,6 +90,9 @@ static dd4hep::Ref_t create_detector(dd4hep::Detector& description, xml_h xmlEle
 
   // attach the calo data to the detector
   drDet.addExtension<dd4hep::rec::LayeredCalorimeterData>(extensionData);
+
+  // Set type flags
+  dd4hep::xml::setDetectorTypeFlag(x_det, drDet);
 
   return drDet;
 }


### PR DESCRIPTION
Added the detector type flag for IDEA o1 DRC (needed for key4hep/k4RecTracker#62).

To ease the review process, please consider the following before opening a pull request:
- [ ] the code is sufficiently well documented (e.g. inline comments)
- [ ] the relevant README(s) were updated. See e.g. https://github.com/key4hep/k4geo/blob/main/detector/calorimeter/README.md or https://github.com/key4hep/k4geo/blob/main/FCCee/IDEA/compact/README.md
- [ ] the code is covered by tests. See https://github.com/key4hep/k4geo/blob/main/test/CMakeLists.txt
- [x] the PR source branch has been rebased (`--ff-only`) to `k4geo/main`
- [x] the PR does not contain any additions or modifications that do not belong to it
- [x] The release notes below contain a succinct and comprehensive description of the changes that are sufficiently self-explanatory

If you are modifying detector dimensions or adding new xml parameters, also consider the following:
- [ ] the xml file free parameters that can not be modified without additional prescriptions are well indicated
- [x] the changes in this PR have not introduced any overlaps. You can check so with the following command: `ddsim --compactFile PATH_TO_COMPACT_FILE --runType run --ui.commandsInitialize "/geometry/test/run" > overlapDump.txt`

BEGINRELEASENOTES
- Add detector type flag for IDEA o1 DRC

ENDRELEASENOTES

