### PR TITLE
SCEPCal partial construction

### DIFF
--- a/FCCee/IDEA/compact/IDEA_o2_v01/DectDimensions_IDEA_o2_v01.xml
+++ b/FCCee/IDEA/compact/IDEA_o2_v01/DectDimensions_IDEA_o2_v01.xml
@@ -233,9 +233,9 @@
     <constant name="scepcal_timing_xtal_length" value="10*cm"/>
 
     <!-- SCEPCal variables for partial construction -->
-    <!-- Barrel phi segment loading, no. segments defined above, base start="0", main layer only -->
-    <constant name="scepcal_barrel_phi_load_start" value="0"/>
-    <constant name="scepcal_barrel_phi_load_end" value="127"/>
+    <!-- Barrel and endcap phi segment loading, no. segments defined above, base start="0", main layer only -->
+    <constant name="scepcal_phi_load_start" value="0"/>
+    <constant name="scepcal_phi_load_end" value="127"/>
     <!-- Barrel Theta loading, no. segments depends on barrel size, outputted upon constructing, base start = "0" -->
     <constant name="scepcal_barrel_theta_load_start" value="0"/>
     <constant name="scepcal_barrel_theta_load_end" value="489"/>

--- a/FCCee/IDEA/compact/IDEA_o2_v01/DectDimensions_IDEA_o2_v01.xml
+++ b/FCCee/IDEA/compact/IDEA_o2_v01/DectDimensions_IDEA_o2_v01.xml
@@ -233,13 +233,13 @@
     <constant name="scepcal_timing_xtal_length" value="10*cm"/>
 
     <!-- SCEPCal variables for partial construction -->
-    <!-- Barrel and endcap phi segment loading, base start = "0", end = "127", main layer only" -->
+    <!-- Barrel phi segment loading, no. segments defined above, base start="0", main layer only -->
     <constant name="scepcal_barrel_phi_load_start" value="0"/>
     <constant name="scepcal_barrel_phi_load_end" value="127"/>
-    <!-- Barrel Theta loading, start = "0", end = "489" -->
+    <!-- Barrel Theta loading, no. segments depends on barrel size, outputted upon constructing, base start = "0" -->
     <constant name="scepcal_barrel_theta_load_start" value="0"/>
     <constant name="scepcal_barrel_theta_load_end" value="489"/>
-    <!-- Barrel Gamma loading, start = "0", end = "10" -->
+    <!-- Barrel Gamma loading, 11 segments, base start = "0" -->
     <constant name="scepcal_barrel_gamma_load_start" value="0"/>
     <constant name="scepcal_barrel_gamma_load_end" value="10"/>
     <!-- End of SCEPCal Dimensions -->

--- a/FCCee/IDEA/compact/IDEA_o2_v01/DectDimensions_IDEA_o2_v01.xml
+++ b/FCCee/IDEA/compact/IDEA_o2_v01/DectDimensions_IDEA_o2_v01.xml
@@ -232,6 +232,19 @@
     <constant name="scepcal_timing_xtal_depth" value="5*mm"/>
     <constant name="scepcal_timing_xtal_length" value="10*cm"/>
 
+    <!-- SCEPCal variables for partial construction -->
+    <!-- Barrel and endcap phi segment loading, base start = "0", end = "127", main layer only" -->
+    <constant name="scepcal_barrel_phi_load_start" value="0"/>
+    <constant name="scepcal_barrel_phi_load_end" value="127"/>
+    <!-- Barrel Theta loading, start = "0", end = "489" -->
+    <constant name="scepcal_barrel_theta_load_start" value="0"/>
+    <constant name="scepcal_barrel_theta_load_end" value="489"/>
+    <!-- Barrel Gamma loading, start = "0", end = "10" -->
+    <constant name="scepcal_barrel_gamma_load_start" value="0"/>
+    <constant name="scepcal_barrel_gamma_load_end" value="10"/>
+    <!-- End of SCEPCal Dimensions -->
+
+
     <!-- Dual-Readout Endcap Tubes (DRET) calorimeter dimensions-->
     <constant name="DRETinnerRadius" value="2.8*m"/>
     <constant name="DRETtowerHeight" value="1.8*m"/>

--- a/FCCee/IDEA/compact/IDEA_o2_v01/SCEPCal_o1_v01.xml
+++ b/FCCee/IDEA/compact/IDEA_o2_v01/SCEPCal_o1_v01.xml
@@ -1067,16 +1067,16 @@
   </readouts>
 
   <display>
-    <vis name="crystalFVis"  alpha="1"   r="0.0"  g="0.0"  b="1.0"  showDaughters="true"  visible="false"/>
-    <vis name="crystalRVis"  alpha="1"   r="0.0"  g="0.5"  b="1.0"  showDaughters="true"  visible="false"/>
-    <vis name="crystalTVis"  alpha="1"   r="0.0"  g="1.0"  b="0.1"  showDaughters="true"  visible="false"/>
+    <vis name="crystalFVis"  alpha="1"   r="0.0"  g="0.0"  b="1.0"  showDaughters="true"  visible="true"/>
+    <vis name="crystalRVis"  alpha="1"   r="0.0"  g="0.5"  b="1.0"  showDaughters="true"  visible="true"/>
+    <vis name="crystalTVis"  alpha="1"   r="0.0"  g="1.0"  b="0.1"  showDaughters="true"  visible="true"/>
 
-    <vis name="barrelAssemblyGlobalVis"  alpha="0.1" r="1."  g="0."  b="0."  showDaughters="true"  visible="false"/>
+    <vis name="barrelAssemblyGlobalVis"  alpha="0.1" r="1."  g="0."  b="0."  showDaughters="true"  visible="true"/>
     <vis name="barrelAssemblyPhiVis"     alpha="0.1" r="0."  g="1."  b="0."  showDaughters="true"  visible="true"/>
-    <vis name="barrelAssemblyThetaVis"   alpha="0.1" r="0."  g="0."  b="1."  showDaughters="true"  visible="false"/>
+    <vis name="barrelAssemblyThetaVis"   alpha="0.1" r="0."  g="0."  b="1."  showDaughters="true"  visible="true"/>
     
     <vis name="endcapAssemblyGlobalVis"  alpha="0.1" r="1."  g="0."  b="0."  showDaughters="true"  visible="false"/>
-    <vis name="endcapAssemblyPhiVis"     alpha="0.1" r="0."  g="1."  b="0."  showDaughters="true"  visible="true"/>
+    <vis name="endcapAssemblyPhiVis"     alpha="0.1" r="0."  g="1."  b="0."  showDaughters="true"  visible="false"/>
     <vis name="endcapAssemblyThetaVis"   alpha="0.1" r="0."  g="0."  b="1."  showDaughters="true"  visible="false"/>
 
     <vis name="tlbarrelAssemblyGlobalVis"  alpha="0.1" r="1."  g="0."  b="0."  showDaughters="true"  visible="false"/>
@@ -1098,7 +1098,9 @@
               readout="SCEPCal_Main"
               vis="scepcalAssemblyGlobalVis"
               sensitive="true">
-      <sensitive type="calorimeter"/>
+    <sensitive type="calorimeter"/>
+
+    <!-- SCEPCal main layer dimensions, last block is for partial visualisation -->
 
       <dim    barrelHalfZ="scepcal_barrel_half_z"
               barrelInnerR="scepcal_barrel_inner_r" 
@@ -1119,11 +1121,18 @@
               projectiveOffsetR="scepcal_projective_offset_r"
               projectiveOffsetX="scepcal_projective_offset_x"
               
-              useOpticalSurfaces="false"
-      />
+	      useOpticalSurfaces="false"
+
+	      phi_load_start="scepcal_barrel_phi_load_start"
+	      phi_load_end="scepcal_barrel_phi_load_end"
+	      theta_load_start="scepcal_barrel_theta_load_start"
+	      theta_load_end="scepcal_barrel_theta_load_end"
+	      gamma_load_start="scepcal_barrel_gamma_load_start"
+	      gamma_load_end="scepcal_barrel_gamma_load_end"
+              />
 
       <barrel    system="DetID_ECAL_Barrel" construct="true"/>
-      <endcap    system="DetID_ECAL_Endcap" construct="true"/>
+      <endcap    system="DetID_ECAL_Endcap" construct="false"/>
 
       <crystalF  material="PbWO"          vis="crystalFVis"/>
       <crystalR  material="PbWO"          vis="crystalRVis"/>
@@ -1162,10 +1171,10 @@
               projectiveOffsetR="scepcal_projective_offset_r"
               
               useOpticalSurfaces="false"
-      />
+	      />
 
-      <tlbarrel  system="DetID_Timing_Barrel" construct="true"/>
-      <tlendcap  system="DetID_Timing_Endcap" construct="true"/>
+      <tlbarrel  system="DetID_Timing_Barrel" construct="false"/>
+      <tlendcap  system="DetID_Timing_Endcap" construct="false"/>
 
       <crystalT  material="LYSO"          vis="crystalTVis"/>
 

--- a/FCCee/IDEA/compact/IDEA_o2_v01/SCEPCal_o1_v01.xml
+++ b/FCCee/IDEA/compact/IDEA_o2_v01/SCEPCal_o1_v01.xml
@@ -1123,8 +1123,8 @@
               
 	      useOpticalSurfaces="false"
 
-	      phi_load_start="scepcal_barrel_phi_load_start"
-	      phi_load_end="scepcal_barrel_phi_load_end"
+	      phi_load_start="scepcal_phi_load_start"
+	      phi_load_end="scepcal_phi_load_end"
 	      theta_load_start="scepcal_barrel_theta_load_start"
 	      theta_load_end="scepcal_barrel_theta_load_end"
 	      gamma_load_start="scepcal_barrel_gamma_load_start"

--- a/FCCee/IDEA/compact/IDEA_o2_v01/SCEPCal_o1_v01.xml
+++ b/FCCee/IDEA/compact/IDEA_o2_v01/SCEPCal_o1_v01.xml
@@ -1067,16 +1067,16 @@
   </readouts>
 
   <display>
-    <vis name="crystalFVis"  alpha="1"   r="0.0"  g="0.0"  b="1.0"  showDaughters="true"  visible="true"/>
-    <vis name="crystalRVis"  alpha="1"   r="0.0"  g="0.5"  b="1.0"  showDaughters="true"  visible="true"/>
-    <vis name="crystalTVis"  alpha="1"   r="0.0"  g="1.0"  b="0.1"  showDaughters="true"  visible="true"/>
+    <vis name="crystalFVis"  alpha="1"   r="0.0"  g="0.0"  b="1.0"  showDaughters="true"  visible="false"/>
+    <vis name="crystalRVis"  alpha="1"   r="0.0"  g="0.5"  b="1.0"  showDaughters="true"  visible="false"/>
+    <vis name="crystalTVis"  alpha="1"   r="0.0"  g="1.0"  b="0.1"  showDaughters="true"  visible="false"/>
 
-    <vis name="barrelAssemblyGlobalVis"  alpha="0.1" r="1."  g="0."  b="0."  showDaughters="true"  visible="true"/>
+    <vis name="barrelAssemblyGlobalVis"  alpha="0.1" r="1."  g="0."  b="0."  showDaughters="true"  visible="false"/>
     <vis name="barrelAssemblyPhiVis"     alpha="0.1" r="0."  g="1."  b="0."  showDaughters="true"  visible="true"/>
-    <vis name="barrelAssemblyThetaVis"   alpha="0.1" r="0."  g="0."  b="1."  showDaughters="true"  visible="true"/>
+    <vis name="barrelAssemblyThetaVis"   alpha="0.1" r="0."  g="0."  b="1."  showDaughters="true"  visible="false"/>
     
     <vis name="endcapAssemblyGlobalVis"  alpha="0.1" r="1."  g="0."  b="0."  showDaughters="true"  visible="false"/>
-    <vis name="endcapAssemblyPhiVis"     alpha="0.1" r="0."  g="1."  b="0."  showDaughters="true"  visible="false"/>
+    <vis name="endcapAssemblyPhiVis"     alpha="0.1" r="0."  g="1."  b="0."  showDaughters="true"  visible="true"/>
     <vis name="endcapAssemblyThetaVis"   alpha="0.1" r="0."  g="0."  b="1."  showDaughters="true"  visible="false"/>
 
     <vis name="tlbarrelAssemblyGlobalVis"  alpha="0.1" r="1."  g="0."  b="0."  showDaughters="true"  visible="false"/>
@@ -1120,19 +1120,19 @@
               
               projectiveOffsetR="scepcal_projective_offset_r"
               projectiveOffsetX="scepcal_projective_offset_x"
-              
-	      useOpticalSurfaces="false"
 
-	      phi_load_start="scepcal_phi_load_start"
-	      phi_load_end="scepcal_phi_load_end"
-	      theta_load_start="scepcal_barrel_theta_load_start"
-	      theta_load_end="scepcal_barrel_theta_load_end"
-	      gamma_load_start="scepcal_barrel_gamma_load_start"
-	      gamma_load_end="scepcal_barrel_gamma_load_end"
+              useOpticalSurfaces="false"
+
+              phi_load_start="scepcal_phi_load_start"
+              phi_load_end="scepcal_phi_load_end"
+              theta_load_start="scepcal_barrel_theta_load_start"
+              theta_load_end="scepcal_barrel_theta_load_end"
+              gamma_load_start="scepcal_barrel_gamma_load_start"
+              gamma_load_end="scepcal_barrel_gamma_load_end"
               />
 
       <barrel    system="DetID_ECAL_Barrel" construct="true"/>
-      <endcap    system="DetID_ECAL_Endcap" construct="false"/>
+      <endcap    system="DetID_ECAL_Endcap" construct="true"/>
 
       <crystalF  material="PbWO"          vis="crystalFVis"/>
       <crystalR  material="PbWO"          vis="crystalRVis"/>
@@ -1171,10 +1171,10 @@
               projectiveOffsetR="scepcal_projective_offset_r"
               
               useOpticalSurfaces="false"
-	      />
+              />
 
-      <tlbarrel  system="DetID_Timing_Barrel" construct="false"/>
-      <tlendcap  system="DetID_Timing_Endcap" construct="false"/>
+      <tlbarrel  system="DetID_Timing_Barrel" construct="true"/>
+      <tlendcap  system="DetID_Timing_Endcap" construct="true"/>
 
       <crystalT  material="LYSO"          vis="crystalTVis"/>
 

--- a/detector/calorimeter/SCEPCal_MainLayer.cpp
+++ b/detector/calorimeter/SCEPCal_MainLayer.cpp
@@ -474,11 +474,11 @@ static dd4hep::Ref_t create_detector_SCEPCal_MainLayer(dd4hep::Detector& theDete
             XYZVector dispGlobal(-center[1], center[0], rGlobal);
             XYZVector posGlobal = (rotZphiGlobal * (rotYthGlobal * dispGlobal + DISP_PROJ_R));
 
-	    if ((nGamma >= GAMMA_LOAD_START) && (nGamma <= GAMMA_LOAD_END)) {
+            if ((nGamma >= GAMMA_LOAD_START) && (nGamma <= GAMMA_LOAD_END)) {
 
               CreateEightPointShapeVolume_SetVolAttributes_Place_SetCellId(
-                  "BarrelCrystalF", XTAL_LEN_F / 2, vFsub, crystalFXML, Transform3D(dispFsub), 
-                  barrelThetaAssemblyVolume, BARREL_SYSTEM_NO, iPhi, N_THETA_ENDCAP + iTheta, nGamma, nEpsilon, 0, 
+                  "BarrelCrystalF", XTAL_LEN_F / 2, vFsub, crystalFXML, Transform3D(dispFsub),
+                  barrelThetaAssemblyVolume, BARREL_SYSTEM_NO, iPhi, N_THETA_ENDCAP + iTheta, nGamma, nEpsilon, 0,
                   posGlobal);
               numCrystalsBarrel += 1;
             }
@@ -498,10 +498,10 @@ static dd4hep::Ref_t create_detector_SCEPCal_MainLayer(dd4hep::Detector& theDete
             XYZVector dispGlobal(-center[1], center[0], rGlobal);
             XYZVector posGlobal = (rotZphiGlobal * (rotYthGlobal * dispGlobal + DISP_PROJ_R));
 
-	    if ((nGamma >= GAMMA_LOAD_START) && (nGamma <= GAMMA_LOAD_END)) {
+            if ((nGamma >= GAMMA_LOAD_START) && (nGamma <= GAMMA_LOAD_END)) {
               CreateEightPointShapeVolume_SetVolAttributes_Place_SetCellId(
                   "BarrelCrystalR", XTAL_LEN_R / 2, vRsub, crystalRXML, Transform3D(dispRsub),
-                  barrelThetaAssemblyVolume, BARREL_SYSTEM_NO, iPhi, N_THETA_ENDCAP + iTheta, nGamma, nEpsilon, 1, 
+                  barrelThetaAssemblyVolume, BARREL_SYSTEM_NO, iPhi, N_THETA_ENDCAP + iTheta, nGamma, nEpsilon, 1,
                   posGlobal);
               numCrystalsBarrel += 1;
             }

--- a/detector/calorimeter/SCEPCal_MainLayer.cpp
+++ b/detector/calorimeter/SCEPCal_MainLayer.cpp
@@ -326,7 +326,7 @@ static dd4hep::Ref_t create_detector_SCEPCal_MainLayer(dd4hep::Detector& theDete
   // Gamma - divide a theta slab into square NxN crystal towers in phi
   // Epsilon - index of single crystal in a NxN tower
   // Projective offsets - tilt the rear face of the trapezoids to point at specified offset away from IP
-  //////////////////////////////
+  /////////////////////////////
 
   for (int iPhi = CONSTRUCT_BARREL ? BARREL_PHI_START : BARREL_PHI_END; iPhi < BARREL_PHI_END; iPhi++) {
     double phiGlobal = iPhi * D_PHI_GLOBAL;
@@ -388,8 +388,9 @@ static dd4hep::Ref_t create_detector_SCEPCal_MainLayer(dd4hep::Detector& theDete
                                                theDetector.material("Vacuum"));
       barrelThetaAssemblyVolume.setVisAttributes(theDetector, barrelAssemblyThetaVisXML.visStr());
 
-      if ((iTheta >= THETA_LOAD_START) && (iTheta <= THETA_LOAD_END)){
-      barrelPhiAssemblyVolume.placeVolume(barrelThetaAssemblyVolume, Transform3D(rotE, dispE));}
+      if ((iTheta >= THETA_LOAD_START) && (iTheta <= THETA_LOAD_END)) {
+        barrelPhiAssemblyVolume.placeVolume(barrelThetaAssemblyVolume, Transform3D(rotE, dispE));
+      }
 
       for (int nGamma = 0; nGamma < N_GAMMA_BARREL; nGamma++) {
         double gamma = -D_PHI_GLOBAL / 2 + D_GAMMA_BARREL / 2 + D_GAMMA_BARREL * nGamma;
@@ -475,13 +476,14 @@ static dd4hep::Ref_t create_detector_SCEPCal_MainLayer(dd4hep::Detector& theDete
             double rGlobal = r0e + XTAL_LEN_F / 2;
             XYZVector dispGlobal(-center[1], center[0], rGlobal);
             XYZVector posGlobal = (rotZphiGlobal * (rotYthGlobal * dispGlobal + DISP_PROJ_R));
+	    
+	    if ((nGamma >= GAMMA_LOAD_START) && (nGamma <= GAMMA_LOAD_END)) {
 
-	    if ((nGamma >= GAMMA_LOAD_START) && (nGamma <= GAMMA_LOAD_END)){
-
-            CreateEightPointShapeVolume_SetVolAttributes_Place_SetCellId(
-                "BarrelCrystalF", XTAL_LEN_F / 2, vFsub, crystalFXML, Transform3D(dispFsub), barrelThetaAssemblyVolume,
-                BARREL_SYSTEM_NO, iPhi, N_THETA_ENDCAP + iTheta, nGamma, nEpsilon, 0, posGlobal);
-            numCrystalsBarrel += 1;
+              CreateEightPointShapeVolume_SetVolAttributes_Place_SetCellId(
+                  "BarrelCrystalF", XTAL_LEN_F / 2, vFsub, crystalFXML, Transform3D(dispFsub), barrelThetaAssemblyVolume,
+                  BARREL_SYSTEM_NO, iPhi, N_THETA_ENDCAP + iTheta, nGamma, nEpsilon, 0, 
+		  posGlobal);
+              numCrystalsBarrel += 1;
             }
           }
 	}
@@ -499,12 +501,12 @@ static dd4hep::Ref_t create_detector_SCEPCal_MainLayer(dd4hep::Detector& theDete
             XYZVector dispGlobal(-center[1], center[0], rGlobal);
             XYZVector posGlobal = (rotZphiGlobal * (rotYthGlobal * dispGlobal + DISP_PROJ_R));
 
-	    if ((nGamma >= GAMMA_LOAD_START) && (nGamma <= GAMMA_LOAD_END)){
+	    if ((nGamma >= GAMMA_LOAD_START) && (nGamma <= GAMMA_LOAD_END)) {
 
-            CreateEightPointShapeVolume_SetVolAttributes_Place_SetCellId(
-                "BarrelCrystalR", XTAL_LEN_R / 2, vRsub, crystalRXML, Transform3D(dispRsub), barrelThetaAssemblyVolume,
-                BARREL_SYSTEM_NO, iPhi, N_THETA_ENDCAP + iTheta, nGamma, nEpsilon, 1, posGlobal);
-            numCrystalsBarrel += 1;
+              CreateEightPointShapeVolume_SetVolAttributes_Place_SetCellId(
+                  "BarrelCrystalR", XTAL_LEN_R / 2, vRsub, crystalRXML, Transform3D(dispRsub), barrelThetaAssemblyVolume,
+                  BARREL_SYSTEM_NO, iPhi, N_THETA_ENDCAP + iTheta, nGamma, nEpsilon, 1, posGlobal);
+              numCrystalsBarrel += 1;
             }
           }
 	}
@@ -541,8 +543,7 @@ static dd4hep::Ref_t create_detector_SCEPCal_MainLayer(dd4hep::Detector& theDete
         endcapGlobalAssemblyVol.placeVolume(endcapPhiAssemblyVolume, Transform3D(rotZphiGlobal));
         endcapGlobalAssemblyVol_1.placeVolume(endcapPhiAssemblyVolume_1, Transform3D(rotZphiGlobal));
       }
-    }
-    else if (PHI_LOAD_START > PHI_LOAD_END) {
+    } else if (PHI_LOAD_START > PHI_LOAD_END) {
       if ((iPhi >= PHI_LOAD_START) || (iPhi <= PHI_LOAD_END)) {
         endcapGlobalAssemblyVol.placeVolume(endcapPhiAssemblyVolume, Transform3D(rotZphiGlobal));
         endcapGlobalAssemblyVol_1.placeVolume(endcapPhiAssemblyVolume_1, Transform3D(rotZphiGlobal));
@@ -605,15 +606,11 @@ static dd4hep::Ref_t create_detector_SCEPCal_MainLayer(dd4hep::Detector& theDete
       dd4hep::Volume endcapThetaAssemblyVolume("endcapThetaAssembly", endcapThetaAssemblyShape,
                                                theDetector.material("Vacuum"));
       endcapThetaAssemblyVolume.setVisAttributes(theDetector, endcapAssemblyThetaVisXML.visStr());
-      //if ((iTheta >= THETA_LOAD_START) && (iTheta <= THETA_LOAD_END)) {
       endcapPhiAssemblyVolume.placeVolume(endcapThetaAssemblyVolume, Transform3D(rotE, dispE));
-      //}
       dd4hep::Volume endcapThetaAssemblyVolume_1("endcapThetaAssembly_1", endcapThetaAssemblyShape_1,
                                                  theDetector.material("Vacuum"));
       endcapThetaAssemblyVolume_1.setVisAttributes(theDetector, endcapAssemblyThetaVisXML.visStr());
-      //if ((iTheta >= THETA_LOAD_START) && (iTheta <= THETA_LOAD_END)) {
       endcapPhiAssemblyVolume_1.placeVolume(endcapThetaAssemblyVolume_1, Transform3D(rotE_1, dispE_1));
-      //}
 
       for (int nGamma = 0; nGamma < nGammaEndcap; nGamma++) {
         double gamma = -D_PHI_GLOBAL / 2 + dGammaEndcap / 2 + dGammaEndcap * nGamma;
@@ -705,7 +702,6 @@ static dd4hep::Ref_t create_detector_SCEPCal_MainLayer(dd4hep::Detector& theDete
             XYZVector dispGlobal_1(-center_1[1], center_1[0], -rGlobal);
             XYZVector posGlobal_1 = (rotZphiGlobal * (rotYthGlobal_1 * dispGlobal_1 + DISP_PROJ_R));
 
-	    //if ((nGamma >= GAMMA_LOAD_START) && (nGamma <= GAMMA_LOAD_END)){
 
             CreateEightPointShapeVolume_SetVolAttributes_Place_SetCellId(
                 "EndcapCrystalF", XTAL_LEN_F / 2, vFsub, crystalFXML, Transform3D(dispFsub), endcapThetaAssemblyVolume,
@@ -717,7 +713,6 @@ static dd4hep::Ref_t create_detector_SCEPCal_MainLayer(dd4hep::Detector& theDete
                 endcapThetaAssemblyVolume_1, ENDCAP_SYSTEM_NO, iPhi, 2 * N_THETA_ENDCAP + N_THETA_BARREL - iTheta,
                 nGamma, nEpsilon, 0, posGlobal_1);
             numCrystalsEndcap += 1;
-	    //}
           }
         }
 
@@ -740,7 +735,6 @@ static dd4hep::Ref_t create_detector_SCEPCal_MainLayer(dd4hep::Detector& theDete
             XYZVector dispGlobal_1(-center_1[1], center_1[0], -rGlobal);
             XYZVector posGlobal_1 = (rotZphiGlobal * (rotYthGlobal_1 * dispGlobal_1 + DISP_PROJ_R));
 
-	    if ((nGamma >= GAMMA_LOAD_START) && (nGamma <= GAMMA_LOAD_END)){
             CreateEightPointShapeVolume_SetVolAttributes_Place_SetCellId(
                 "EndcapCrystalR", XTAL_LEN_R / 2, vRsub, crystalRXML, Transform3D(dispRsub), endcapThetaAssemblyVolume,
                 ENDCAP_SYSTEM_NO, iPhi, iTheta, nGamma, nEpsilon, 1, posGlobal);
@@ -751,7 +745,6 @@ static dd4hep::Ref_t create_detector_SCEPCal_MainLayer(dd4hep::Detector& theDete
                 endcapThetaAssemblyVolume_1, ENDCAP_SYSTEM_NO, iPhi, 2 * N_THETA_ENDCAP + N_THETA_BARREL - iTheta,
                 nGamma, nEpsilon, 1, posGlobal_1);
             numCrystalsEndcap += 1;
-            }
           }
         }
       }

--- a/detector/calorimeter/SCEPCal_MainLayer.cpp
+++ b/detector/calorimeter/SCEPCal_MainLayer.cpp
@@ -58,6 +58,15 @@ static dd4hep::Ref_t create_detector_SCEPCal_MainLayer(dd4hep::Detector& theDete
 
   const bool USE_OPTICAL_SURFACES = dimXML.attr<bool>(_Unicode(useOpticalSurfaces));
 
+  // Start of partial visualisation parameters
+  const int PHI_LOAD_START = dimXML.attr<int>(_Unicode(phi_load_start));
+  const int PHI_LOAD_END = dimXML.attr<int>(_Unicode(phi_load_end));
+  const int THETA_LOAD_START = dimXML.attr<int>(_Unicode(theta_load_start));
+  const int THETA_LOAD_END = dimXML.attr<int>(_Unicode(theta_load_end));
+  const int GAMMA_LOAD_START = dimXML.attr<int>(_Unicode(gamma_load_start));
+  const int GAMMA_LOAD_END = dimXML.attr<int>(_Unicode(gamma_load_end));
+  // End of partial visualisation parameters
+
   const int BARREL_SYSTEM_NO = barrelXML.attr<int>(_Unicode(system));
   const bool CONSTRUCT_BARREL = barrelXML.attr<bool>(_Unicode(construct));
   const int BARREL_PHI_START = 0;
@@ -71,6 +80,7 @@ static dd4hep::Ref_t create_detector_SCEPCal_MainLayer(dd4hep::Detector& theDete
   const double D_PHI_GLOBAL = 2 * M_PI / PHI_SEGMENTS;
 
   double THETA_SIZE_BARREL = atan(BARREL_HALF_Z / (BARREL_INNER_R + PROJ_OFFSET_R));
+
   double THETA_SIZE_ENDCAP = atan((BARREL_INNER_R + PROJ_OFFSET_R) / BARREL_HALF_Z);
 
   int N_THETA_BARREL = 2 * floor(BARREL_HALF_Z / XTAL_TH_WIDTH);
@@ -81,6 +91,7 @@ static dd4hep::Ref_t create_detector_SCEPCal_MainLayer(dd4hep::Detector& theDete
 
   int N_GAMMA_BARREL = std::max(int(2 * M_PI * BARREL_INNER_R / (PHI_SEGMENTS * XTAL_TH_WIDTH)), 1);
   double D_GAMMA_BARREL = D_PHI_GLOBAL / N_GAMMA_BARREL;
+
 
   XYZVector DISP_PROJ_R(-PROJ_OFFSET_R, 0, 0);
   int ENDCAP_THETA_START = 0;
@@ -149,6 +160,14 @@ static dd4hep::Ref_t create_detector_SCEPCal_MainLayer(dd4hep::Detector& theDete
   std::cout << "PROJECTIVE_OFFSET_X:  " << PROJ_OFFSET_X << std::endl;
   std::cout << "BEAMPIPE_OPENING:     " << BEAMPIPE_OPENING << std::endl;
   std::cout << "REAR_GAP:             " << REAR_GAP << std::endl;
+  std::cout << std::endl;
+  std::cout << "=PARTIAL VISUALISATION PARAMETERS================" << std::endl;
+  std::cout << "PHI_LOAD_START:       " << PHI_LOAD_START << std::endl;
+  std::cout << "PHI_LOAD_END:         " << PHI_LOAD_END << std::endl;
+  std::cout << "THETA_LOAD_START:     " << THETA_LOAD_START << std::endl;
+  std::cout << "THETA_LOAD_END:       " << THETA_LOAD_END << std::endl;
+  std::cout << "GAMMA_LOAD_START:     " << GAMMA_LOAD_START << std::endl;
+  std::cout << "GAMMA_LOAD_END:       " << GAMMA_LOAD_END << std::endl;
   std::cout << std::endl;
   std::cout << std::endl;
   std::cout << "=CONTROL=========================================" << std::endl;
@@ -312,15 +331,22 @@ static dd4hep::Ref_t create_detector_SCEPCal_MainLayer(dd4hep::Detector& theDete
   for (int iPhi = CONSTRUCT_BARREL ? BARREL_PHI_START : BARREL_PHI_END; iPhi < BARREL_PHI_END; iPhi++) {
     double phiGlobal = iPhi * D_PHI_GLOBAL;
     RotationZ rotZphiGlobal(phiGlobal);
-
     dd4hep::Polyhedra barrelPhiAssemblyShape(1, -D_PHI_GLOBAL / 2, D_PHI_GLOBAL, zBarrelPolyhedra, rminBarrelPolyhedra,
                                              rmaxBarrelPolyhedra);
     dd4hep::Volume barrelPhiAssemblyVolume("barrelPhiAssembly", barrelPhiAssemblyShape, theDetector.material("Vacuum"));
     barrelPhiAssemblyVolume.setVisAttributes(theDetector, barrelAssemblyPhiVisXML.visStr());
-    barrelGlobalAssemblyVol.placeVolume(barrelPhiAssemblyVolume, Transform3D(rotZphiGlobal));
-
+    if (PHI_LOAD_START <= PHI_LOAD_END) {
+      if ((iPhi >= PHI_LOAD_START) && (iPhi <= PHI_LOAD_END)) {
+        barrelGlobalAssemblyVol.placeVolume(barrelPhiAssemblyVolume, Transform3D(rotZphiGlobal));
+      }
+    }
+    else if (PHI_LOAD_START > PHI_LOAD_END) {
+      if ((iPhi >= PHI_LOAD_START) || (iPhi <= PHI_LOAD_END)) {
+        barrelGlobalAssemblyVol.placeVolume(barrelPhiAssemblyVolume, Transform3D(rotZphiGlobal));
+      }
+    }
+   
     for (int iTheta = 0; iTheta < N_THETA_BARREL; iTheta++) {
-
       double thC = THETA_SIZE_ENDCAP + D_THETA_BARREL / 2 + (iTheta * D_THETA_BARREL);
       RotationY rotYthGlobal(thC);
 
@@ -336,7 +362,7 @@ static dd4hep::Ref_t create_detector_SCEPCal_MainLayer(dd4hep::Detector& theDete
 
       double x0y1 = r1e * sin(thC) - y1e * cos(thC) - PROJ_OFFSET_R;
       double x1y1 = r1e * sin(thC) + y1e * cos(thC) - PROJ_OFFSET_R;
-
+      
       double x0y2 = r2e * sin(thC) - y2e * cos(thC) - PROJ_OFFSET_R;
       double x1y2 = r2e * sin(thC) + y2e * cos(thC) - PROJ_OFFSET_R;
 
@@ -361,7 +387,9 @@ static dd4hep::Ref_t create_detector_SCEPCal_MainLayer(dd4hep::Detector& theDete
       dd4hep::Volume barrelThetaAssemblyVolume("barrelThetaAssembly", barrelThetaAssemblyShape,
                                                theDetector.material("Vacuum"));
       barrelThetaAssemblyVolume.setVisAttributes(theDetector, barrelAssemblyThetaVisXML.visStr());
-      barrelPhiAssemblyVolume.placeVolume(barrelThetaAssemblyVolume, Transform3D(rotE, dispE));
+
+      if ((iTheta >= THETA_LOAD_START) && (iTheta <= THETA_LOAD_END)){
+      barrelPhiAssemblyVolume.placeVolume(barrelThetaAssemblyVolume, Transform3D(rotE, dispE));}
 
       for (int nGamma = 0; nGamma < N_GAMMA_BARREL; nGamma++) {
         double gamma = -D_PHI_GLOBAL / 2 + D_GAMMA_BARREL / 2 + D_GAMMA_BARREL * nGamma;
@@ -434,6 +462,7 @@ static dd4hep::Ref_t create_detector_SCEPCal_MainLayer(dd4hep::Detector& theDete
         double verticesR[] = {x0y1r, y1e, x1y1r, -y1e, x1y1l, -y1e, x0y1l, y1e,
                               x0y2r, y2e, x1y2r, -y2e, x1y2l, -y2e, x0y2l, y2e};
 
+	
         for (int i = 0; i < XTAL_DIV_F; i++) {
           for (int j = 0; j < XTAL_DIV_F; j++) {
             int nEpsilon = i * XTAL_DIV_F + j;
@@ -447,12 +476,15 @@ static dd4hep::Ref_t create_detector_SCEPCal_MainLayer(dd4hep::Detector& theDete
             XYZVector dispGlobal(-center[1], center[0], rGlobal);
             XYZVector posGlobal = (rotZphiGlobal * (rotYthGlobal * dispGlobal + DISP_PROJ_R));
 
+	    if ((nGamma >= GAMMA_LOAD_START) && (nGamma <= GAMMA_LOAD_END)){
+
             CreateEightPointShapeVolume_SetVolAttributes_Place_SetCellId(
                 "BarrelCrystalF", XTAL_LEN_F / 2, vFsub, crystalFXML, Transform3D(dispFsub), barrelThetaAssemblyVolume,
                 BARREL_SYSTEM_NO, iPhi, N_THETA_ENDCAP + iTheta, nGamma, nEpsilon, 0, posGlobal);
             numCrystalsBarrel += 1;
+            }
           }
-        }
+	}
 
         for (int i = 0; i < XTAL_DIV_R; i++) {
           for (int j = 0; j < XTAL_DIV_R; j++) {
@@ -467,12 +499,15 @@ static dd4hep::Ref_t create_detector_SCEPCal_MainLayer(dd4hep::Detector& theDete
             XYZVector dispGlobal(-center[1], center[0], rGlobal);
             XYZVector posGlobal = (rotZphiGlobal * (rotYthGlobal * dispGlobal + DISP_PROJ_R));
 
+	    if ((nGamma >= GAMMA_LOAD_START) && (nGamma <= GAMMA_LOAD_END)){
+
             CreateEightPointShapeVolume_SetVolAttributes_Place_SetCellId(
                 "BarrelCrystalR", XTAL_LEN_R / 2, vRsub, crystalRXML, Transform3D(dispRsub), barrelThetaAssemblyVolume,
                 BARREL_SYSTEM_NO, iPhi, N_THETA_ENDCAP + iTheta, nGamma, nEpsilon, 1, posGlobal);
             numCrystalsBarrel += 1;
+            }
           }
-        }
+	}
       }
     }
   }
@@ -497,12 +532,22 @@ static dd4hep::Ref_t create_detector_SCEPCal_MainLayer(dd4hep::Detector& theDete
 
     dd4hep::Volume endcapPhiAssemblyVolume("endcapPhiVol", endcapPhiAssemblyShape, theDetector.material("Vacuum"));
     endcapPhiAssemblyVolume.setVisAttributes(theDetector, endcapAssemblyPhiVisXML.visStr());
-    endcapGlobalAssemblyVol.placeVolume(endcapPhiAssemblyVolume, Transform3D(rotZphiGlobal));
-
     dd4hep::Volume endcapPhiAssemblyVolume_1("endcapPhiVol_1", endcapPhiAssemblyShape_1,
                                              theDetector.material("Vacuum"));
     endcapPhiAssemblyVolume_1.setVisAttributes(theDetector, endcapAssemblyPhiVisXML.visStr());
-    endcapGlobalAssemblyVol_1.placeVolume(endcapPhiAssemblyVolume_1, Transform3D(rotZphiGlobal));
+
+    if (PHI_LOAD_START <= PHI_LOAD_END) {
+      if ((iPhi >= PHI_LOAD_START) && (iPhi <= PHI_LOAD_END)) {
+        endcapGlobalAssemblyVol.placeVolume(endcapPhiAssemblyVolume, Transform3D(rotZphiGlobal));
+        endcapGlobalAssemblyVol_1.placeVolume(endcapPhiAssemblyVolume_1, Transform3D(rotZphiGlobal));
+      }
+    }
+    else if (PHI_LOAD_START > PHI_LOAD_END) {
+      if ((iPhi >= PHI_LOAD_START) || (iPhi <= PHI_LOAD_END)) {
+        endcapGlobalAssemblyVol.placeVolume(endcapPhiAssemblyVolume, Transform3D(rotZphiGlobal));
+        endcapGlobalAssemblyVol_1.placeVolume(endcapPhiAssemblyVolume_1, Transform3D(rotZphiGlobal));
+      }
+    }
 
     for (int iTheta = ENDCAP_THETA_START; iTheta < N_THETA_ENDCAP; iTheta++) {
 
@@ -560,12 +605,15 @@ static dd4hep::Ref_t create_detector_SCEPCal_MainLayer(dd4hep::Detector& theDete
       dd4hep::Volume endcapThetaAssemblyVolume("endcapThetaAssembly", endcapThetaAssemblyShape,
                                                theDetector.material("Vacuum"));
       endcapThetaAssemblyVolume.setVisAttributes(theDetector, endcapAssemblyThetaVisXML.visStr());
+      //if ((iTheta >= THETA_LOAD_START) && (iTheta <= THETA_LOAD_END)) {
       endcapPhiAssemblyVolume.placeVolume(endcapThetaAssemblyVolume, Transform3D(rotE, dispE));
-
+      //}
       dd4hep::Volume endcapThetaAssemblyVolume_1("endcapThetaAssembly_1", endcapThetaAssemblyShape_1,
                                                  theDetector.material("Vacuum"));
       endcapThetaAssemblyVolume_1.setVisAttributes(theDetector, endcapAssemblyThetaVisXML.visStr());
+      //if ((iTheta >= THETA_LOAD_START) && (iTheta <= THETA_LOAD_END)) {
       endcapPhiAssemblyVolume_1.placeVolume(endcapThetaAssemblyVolume_1, Transform3D(rotE_1, dispE_1));
+      //}
 
       for (int nGamma = 0; nGamma < nGammaEndcap; nGamma++) {
         double gamma = -D_PHI_GLOBAL / 2 + dGammaEndcap / 2 + dGammaEndcap * nGamma;
@@ -657,6 +705,8 @@ static dd4hep::Ref_t create_detector_SCEPCal_MainLayer(dd4hep::Detector& theDete
             XYZVector dispGlobal_1(-center_1[1], center_1[0], -rGlobal);
             XYZVector posGlobal_1 = (rotZphiGlobal * (rotYthGlobal_1 * dispGlobal_1 + DISP_PROJ_R));
 
+	    //if ((nGamma >= GAMMA_LOAD_START) && (nGamma <= GAMMA_LOAD_END)){
+
             CreateEightPointShapeVolume_SetVolAttributes_Place_SetCellId(
                 "EndcapCrystalF", XTAL_LEN_F / 2, vFsub, crystalFXML, Transform3D(dispFsub), endcapThetaAssemblyVolume,
                 ENDCAP_SYSTEM_NO, iPhi, iTheta, nGamma, nEpsilon, 0, posGlobal);
@@ -667,6 +717,7 @@ static dd4hep::Ref_t create_detector_SCEPCal_MainLayer(dd4hep::Detector& theDete
                 endcapThetaAssemblyVolume_1, ENDCAP_SYSTEM_NO, iPhi, 2 * N_THETA_ENDCAP + N_THETA_BARREL - iTheta,
                 nGamma, nEpsilon, 0, posGlobal_1);
             numCrystalsEndcap += 1;
+	    //}
           }
         }
 
@@ -689,6 +740,7 @@ static dd4hep::Ref_t create_detector_SCEPCal_MainLayer(dd4hep::Detector& theDete
             XYZVector dispGlobal_1(-center_1[1], center_1[0], -rGlobal);
             XYZVector posGlobal_1 = (rotZphiGlobal * (rotYthGlobal_1 * dispGlobal_1 + DISP_PROJ_R));
 
+	    if ((nGamma >= GAMMA_LOAD_START) && (nGamma <= GAMMA_LOAD_END)){
             CreateEightPointShapeVolume_SetVolAttributes_Place_SetCellId(
                 "EndcapCrystalR", XTAL_LEN_R / 2, vRsub, crystalRXML, Transform3D(dispRsub), endcapThetaAssemblyVolume,
                 ENDCAP_SYSTEM_NO, iPhi, iTheta, nGamma, nEpsilon, 1, posGlobal);
@@ -699,6 +751,7 @@ static dd4hep::Ref_t create_detector_SCEPCal_MainLayer(dd4hep::Detector& theDete
                 endcapThetaAssemblyVolume_1, ENDCAP_SYSTEM_NO, iPhi, 2 * N_THETA_ENDCAP + N_THETA_BARREL - iTheta,
                 nGamma, nEpsilon, 1, posGlobal_1);
             numCrystalsEndcap += 1;
+            }
           }
         }
       }

--- a/detector/calorimeter/SCEPCal_MainLayer.cpp
+++ b/detector/calorimeter/SCEPCal_MainLayer.cpp
@@ -339,13 +339,12 @@ static dd4hep::Ref_t create_detector_SCEPCal_MainLayer(dd4hep::Detector& theDete
       if ((iPhi >= PHI_LOAD_START) && (iPhi <= PHI_LOAD_END)) {
         barrelGlobalAssemblyVol.placeVolume(barrelPhiAssemblyVolume, Transform3D(rotZphiGlobal));
       }
-    }
-    else if (PHI_LOAD_START > PHI_LOAD_END) {
+    } else if (PHI_LOAD_START > PHI_LOAD_END) {
       if ((iPhi >= PHI_LOAD_START) || (iPhi <= PHI_LOAD_END)) {
         barrelGlobalAssemblyVol.placeVolume(barrelPhiAssemblyVolume, Transform3D(rotZphiGlobal));
       }
     }
-   
+
     for (int iTheta = 0; iTheta < N_THETA_BARREL; iTheta++) {
       double thC = THETA_SIZE_ENDCAP + D_THETA_BARREL / 2 + (iTheta * D_THETA_BARREL);
       RotationY rotYthGlobal(thC);
@@ -362,7 +361,7 @@ static dd4hep::Ref_t create_detector_SCEPCal_MainLayer(dd4hep::Detector& theDete
 
       double x0y1 = r1e * sin(thC) - y1e * cos(thC) - PROJ_OFFSET_R;
       double x1y1 = r1e * sin(thC) + y1e * cos(thC) - PROJ_OFFSET_R;
-      
+
       double x0y2 = r2e * sin(thC) - y2e * cos(thC) - PROJ_OFFSET_R;
       double x1y2 = r2e * sin(thC) + y2e * cos(thC) - PROJ_OFFSET_R;
 
@@ -462,7 +461,6 @@ static dd4hep::Ref_t create_detector_SCEPCal_MainLayer(dd4hep::Detector& theDete
                               x0y1r, y1e, x1y1r, -y1e, x1y1l, -y1e, x0y1l, y1e};
         double verticesR[] = {x0y1r, y1e, x1y1r, -y1e, x1y1l, -y1e, x0y1l, y1e,
                               x0y2r, y2e, x1y2r, -y2e, x1y2l, -y2e, x0y2l, y2e};
-
 	
         for (int i = 0; i < XTAL_DIV_F; i++) {
           for (int j = 0; j < XTAL_DIV_F; j++) {
@@ -476,12 +474,12 @@ static dd4hep::Ref_t create_detector_SCEPCal_MainLayer(dd4hep::Detector& theDete
             double rGlobal = r0e + XTAL_LEN_F / 2;
             XYZVector dispGlobal(-center[1], center[0], rGlobal);
             XYZVector posGlobal = (rotZphiGlobal * (rotYthGlobal * dispGlobal + DISP_PROJ_R));
-	    
+
 	    if ((nGamma >= GAMMA_LOAD_START) && (nGamma <= GAMMA_LOAD_END)) {
 
               CreateEightPointShapeVolume_SetVolAttributes_Place_SetCellId(
-                  "BarrelCrystalF", XTAL_LEN_F / 2, vFsub, crystalFXML, Transform3D(dispFsub), barrelThetaAssemblyVolume,
-                  BARREL_SYSTEM_NO, iPhi, N_THETA_ENDCAP + iTheta, nGamma, nEpsilon, 0, 
+                  "BarrelCrystalF", XTAL_LEN_F / 2, vFsub, crystalFXML, Transform3D(dispFsub), 
+		  barrelThetaAssemblyVolume, BARREL_SYSTEM_NO, iPhi, N_THETA_ENDCAP + iTheta, nGamma, nEpsilon, 0, 
 		  posGlobal);
               numCrystalsBarrel += 1;
             }
@@ -504,8 +502,9 @@ static dd4hep::Ref_t create_detector_SCEPCal_MainLayer(dd4hep::Detector& theDete
 	    if ((nGamma >= GAMMA_LOAD_START) && (nGamma <= GAMMA_LOAD_END)) {
 
               CreateEightPointShapeVolume_SetVolAttributes_Place_SetCellId(
-                  "BarrelCrystalR", XTAL_LEN_R / 2, vRsub, crystalRXML, Transform3D(dispRsub), barrelThetaAssemblyVolume,
-                  BARREL_SYSTEM_NO, iPhi, N_THETA_ENDCAP + iTheta, nGamma, nEpsilon, 1, posGlobal);
+                  "BarrelCrystalR", XTAL_LEN_R / 2, vRsub, crystalRXML, Transform3D(dispRsub),
+		  barrelThetaAssemblyVolume, BARREL_SYSTEM_NO, iPhi, N_THETA_ENDCAP + iTheta, nGamma, nEpsilon, 1, 
+		  posGlobal);
               numCrystalsBarrel += 1;
             }
           }
@@ -701,7 +700,6 @@ static dd4hep::Ref_t create_detector_SCEPCal_MainLayer(dd4hep::Detector& theDete
 
             XYZVector dispGlobal_1(-center_1[1], center_1[0], -rGlobal);
             XYZVector posGlobal_1 = (rotZphiGlobal * (rotYthGlobal_1 * dispGlobal_1 + DISP_PROJ_R));
-
 
             CreateEightPointShapeVolume_SetVolAttributes_Place_SetCellId(
                 "EndcapCrystalF", XTAL_LEN_F / 2, vFsub, crystalFXML, Transform3D(dispFsub), endcapThetaAssemblyVolume,

--- a/detector/calorimeter/SCEPCal_MainLayer.cpp
+++ b/detector/calorimeter/SCEPCal_MainLayer.cpp
@@ -92,7 +92,6 @@ static dd4hep::Ref_t create_detector_SCEPCal_MainLayer(dd4hep::Detector& theDete
   int N_GAMMA_BARREL = std::max(int(2 * M_PI * BARREL_INNER_R / (PHI_SEGMENTS * XTAL_TH_WIDTH)), 1);
   double D_GAMMA_BARREL = D_PHI_GLOBAL / N_GAMMA_BARREL;
 
-
   XYZVector DISP_PROJ_R(-PROJ_OFFSET_R, 0, 0);
   int ENDCAP_THETA_START = 0;
 
@@ -326,7 +325,7 @@ static dd4hep::Ref_t create_detector_SCEPCal_MainLayer(dd4hep::Detector& theDete
   // Gamma - divide a theta slab into square NxN crystal towers in phi
   // Epsilon - index of single crystal in a NxN tower
   // Projective offsets - tilt the rear face of the trapezoids to point at specified offset away from IP
-  /////////////////////////////
+  //////////////////////////////
 
   for (int iPhi = CONSTRUCT_BARREL ? BARREL_PHI_START : BARREL_PHI_END; iPhi < BARREL_PHI_END; iPhi++) {
     double phiGlobal = iPhi * D_PHI_GLOBAL;
@@ -461,7 +460,7 @@ static dd4hep::Ref_t create_detector_SCEPCal_MainLayer(dd4hep::Detector& theDete
                               x0y1r, y1e, x1y1r, -y1e, x1y1l, -y1e, x0y1l, y1e};
         double verticesR[] = {x0y1r, y1e, x1y1r, -y1e, x1y1l, -y1e, x0y1l, y1e,
                               x0y2r, y2e, x1y2r, -y2e, x1y2l, -y2e, x0y2l, y2e};
-	
+
         for (int i = 0; i < XTAL_DIV_F; i++) {
           for (int j = 0; j < XTAL_DIV_F; j++) {
             int nEpsilon = i * XTAL_DIV_F + j;
@@ -479,12 +478,12 @@ static dd4hep::Ref_t create_detector_SCEPCal_MainLayer(dd4hep::Detector& theDete
 
               CreateEightPointShapeVolume_SetVolAttributes_Place_SetCellId(
                   "BarrelCrystalF", XTAL_LEN_F / 2, vFsub, crystalFXML, Transform3D(dispFsub), 
-		  barrelThetaAssemblyVolume, BARREL_SYSTEM_NO, iPhi, N_THETA_ENDCAP + iTheta, nGamma, nEpsilon, 0, 
-		  posGlobal);
+                  barrelThetaAssemblyVolume, BARREL_SYSTEM_NO, iPhi, N_THETA_ENDCAP + iTheta, nGamma, nEpsilon, 0, 
+                  posGlobal);
               numCrystalsBarrel += 1;
             }
           }
-	}
+        }
 
         for (int i = 0; i < XTAL_DIV_R; i++) {
           for (int j = 0; j < XTAL_DIV_R; j++) {
@@ -500,15 +499,14 @@ static dd4hep::Ref_t create_detector_SCEPCal_MainLayer(dd4hep::Detector& theDete
             XYZVector posGlobal = (rotZphiGlobal * (rotYthGlobal * dispGlobal + DISP_PROJ_R));
 
 	    if ((nGamma >= GAMMA_LOAD_START) && (nGamma <= GAMMA_LOAD_END)) {
-
               CreateEightPointShapeVolume_SetVolAttributes_Place_SetCellId(
                   "BarrelCrystalR", XTAL_LEN_R / 2, vRsub, crystalRXML, Transform3D(dispRsub),
-		  barrelThetaAssemblyVolume, BARREL_SYSTEM_NO, iPhi, N_THETA_ENDCAP + iTheta, nGamma, nEpsilon, 1, 
-		  posGlobal);
+                  barrelThetaAssemblyVolume, BARREL_SYSTEM_NO, iPhi, N_THETA_ENDCAP + iTheta, nGamma, nEpsilon, 1, 
+                  posGlobal);
               numCrystalsBarrel += 1;
             }
           }
-	}
+        }
       }
     }
   }


### PR DESCRIPTION
BEGINRELEASENOTES
- New variables added for partial construction of SCEPCal 


ENDRELEASENOTES

- 3 Files changed 
- Able to control phi, theta and gamma 
- Phi can loop around same as for H-cal, recommend only changing gamma if you are loading only 1 phi slice. 
