### PR TITLE
Use . instead of -> for objects that are not pointers

### DIFF
--- a/plugins/Geant4Output2EDM4hep_DRC.cpp
+++ b/plugins/Geant4Output2EDM4hep_DRC.cpp
@@ -535,7 +535,7 @@ void Geant4Output2EDM4hep_DRC::saveCollection(OutputContext<G4Event>& /*ctxt*/, 
     // Create the hit container even if there are no entries!
     auto& hits = m_trackerHits[colName];
     for (unsigned i = 0; i < nhits; ++i) {
-      auto sth = hits->create();
+      auto sth = hits.create();
       const Geant4Tracker::Hit* hit = coll->hit(i);
       const Geant4Tracker::Hit::Contribution& t = hit->truth;
       int trackID = pm->particleID(t.trackID);
@@ -569,7 +569,7 @@ void Geant4Output2EDM4hep_DRC::saveCollection(OutputContext<G4Event>& /*ctxt*/, 
     // Create the hit container even if there are no entries!
     auto& hits = m_calorimeterHits[colName];
     for (unsigned i = 0; i < nhits; ++i) {
-      auto sch = hits.first->create();
+      auto sch = hits.first.create();
       const Geant4Calorimeter::Hit* hit = coll->hit(i);
       const auto& pos = hit->position;
       sch.setCellID(hit->cellID);
@@ -579,7 +579,7 @@ void Geant4Output2EDM4hep_DRC::saveCollection(OutputContext<G4Event>& /*ctxt*/, 
       // now add the individual step contributions
       for (auto ci = hit->truth.begin(); ci != hit->truth.end(); ++ci) {
 
-        auto sCaloHitCont = hits.second->create();
+        auto sCaloHitCont = hits.second.create();
         sch.addToContributions(sCaloHitCont);
 
         const Geant4HitData::Contribution& c = *ci;
@@ -606,9 +606,9 @@ void Geant4Output2EDM4hep_DRC::saveCollection(OutputContext<G4Event>& /*ctxt*/, 
       const Geant4DRCalorimeter::Hit* hit = coll->hit(i);
 
       // For DRC calo hit & time series
-      auto simCaloHits = DRhits.first->create();
-      auto rawTimeStruct = DRhits.second->create();
-      auto rawWaveStruct = DRwaves->create();
+      auto simCaloHits = DRhits.first.create();
+      auto rawTimeStruct = DRhits.second.create();
+      auto rawWaveStruct = DRwaves.create();
 
       float samplingT = hit->GetSamplingTime();
       float timeStart = hit->GetTimeStart();


### PR DESCRIPTION
BEGINRELEASENOTES
- Use . instead of -> for objects that are not pointers

ENDRELEASENOTES

It's allowed in podio but I think it's an antipattern, I may propose for it to be removed.
Tagging @swkim95 