### PR TITLE
Lumical_o1_v01: change det type flags for purely passive use of this detector

### DIFF
--- a/detector/fcal/LumiCal_o1_v01_geo.cpp
+++ b/detector/fcal/LumiCal_o1_v01_geo.cpp
@@ -1,39 +1,27 @@
-#include "DD4hep/DetType.h"
-#include "DDRec/DetectorData.h"
-#include "XML/Utilities.h"
 #include <DD4hep/DetFactoryHelper.h>
+#include <DD4hep/DetType.h>
+#include <DDRec/DetectorData.h>
 #include <XML/Layering.h>
+#include <XML/Utilities.h>
 
 #include <string>
 
 using dd4hep::_toString;
-using dd4hep::Assembly;
-using dd4hep::Box;
 using dd4hep::BUILD_ENVELOPE;
-using dd4hep::Cone;
 using dd4hep::Detector;
 using dd4hep::DetElement;
 using dd4hep::DetType;
-using dd4hep::IntersectionSolid;
-using dd4hep::Layer;
 using dd4hep::Layering;
 using dd4hep::Material;
 using dd4hep::PlacedVolume;
-using dd4hep::PolyhedraRegular;
 using dd4hep::Position;
-using dd4hep::Readout;
 using dd4hep::Ref_t;
 using dd4hep::Rotation3D;
 using dd4hep::RotationY;
 using dd4hep::RotationZYX;
-using dd4hep::Segmentation;
 using dd4hep::SensitiveDetector;
-using dd4hep::SubtractionSolid;
 using dd4hep::Transform3D;
-using dd4hep::Translation3D;
-using dd4hep::Trapezoid;
 using dd4hep::Tube;
-using dd4hep::UnionSolid;
 using dd4hep::Volume;
 
 using dd4hep::rec::LayeredCalorimeterData;


### PR DESCRIPTION
To ease the review process, please consider the following before opening a pull request:
- [x] the code is sufficiently well documented (e.g. inline comments)
- [x] the relevant README(s) were updated. See e.g. https://github.com/key4hep/k4geo/blob/main/detector/calorimeter/README.md or https://github.com/key4hep/k4geo/blob/main/FCCee/IDEA/compact/README.md
- [x] the code is covered by tests. See https://github.com/key4hep/k4geo/blob/main/test/CMakeLists.txt
- [x] the PR source branch has been rebased (`--ff-only`) to `k4geo/main`
- [x] the PR does not contain any additions or modifications that do not belong to it
- [x] The release notes below contain a succinct and comprehensive description of the changes that are sufficiently self-explanatory


BEGINRELEASENOTES
- Lumical_o1_v01: only set calorimeter type flags for detectors with sensitive elements, otherwise use SUPPORT and AUXILIARY. Fixes #495 

ENDRELEASENOTES

