### PR TITLE
Set the helicity once it becomes possible

### DIFF
--- a/plugins/Geant4Output2EDM4hep_DRC.cpp
+++ b/plugins/Geant4Output2EDM4hep_DRC.cpp
@@ -409,10 +409,10 @@ void Geant4Output2EDM4hep_DRC::saveParticles(Geant4ParticleMap* particles) {
       if (mcp.isCreatedInSimulation())
         mcp.setGeneratorStatus(0);
 
-#if EDM4HEP_BUILD_VERSION <= EDM4HEP_VERSION(0, 99, 2)
-      mcp.setSpin(p->spin);
-#else
+#ifdef EDM4HEP_MCPARTICLE_HAS_HELICITY
       mcp.setHelicity(p->spin[2]);
+#else
+      mcp.setSpin(p->spin);
 #endif
 
       p_ids[id] = cnt++;


### PR DESCRIPTION


BEGINRELEASENOTES
- Set the helicity for the MCParticle once it becomes available. See [EDM4hep#404](https://github.com/key4hep/EDM4hep/pull/404) and [DD4hep#1488](https://github.com/AIDASoft/DD4hep/pull/1488) for more details.

ENDRELEASENOTES

