### PR TITLE
FCC-ee ALLEGRO detector concept: include plugins attaching additional info to the geometry, needed to generate `edm4hep::TrackerHitPlane`

### DIFF
--- a/FCCee/ALLEGRO/compact/ALLEGRO_o1_v03/ALLEGRO_o1_v03.xml
+++ b/FCCee/ALLEGRO/compact/ALLEGRO_o1_v03/ALLEGRO_o1_v03.xml
@@ -122,7 +122,6 @@
     <!-- Include plugins attaching additional info to the geometry and needed to generate edm4hep::TrackerHitPlane, see e.g. CLD detector-concept case https://github.com/key4hep/k4geo/blob/main/FCCee/CLD/compact/CLD_o2_v08/CLD_o2_v08.xml#L333-L390 -->
   <plugins>
 
-    <plugin name="DD4hepVolumeManager"/>
     <plugin name="InstallSurfaceManager"/>
 
   </plugins>


### PR DESCRIPTION
Timing tests running `ddsim --enableGun --gun.distribution uniform --gun.energy "10*GeV" --gun.particle e- --numberOfEvents 100 --outputFile ALLEGRO_sim.root --random.enableEventSeed --random.seed 42 --compactFile $K4GEO/FCCee/ALLEGRO/compact/ALLEGRO_o1_v03/ALLEGRO_o1_v03.xml`:
- `ddsim` before change: 
```
DDSim            INFO Total Time:   170.24 s (User), 5.11 s (System)
DDSim            INFO StartUp Time: 7.28 s, Processing and Init: 162.96 s (~1.63 s/Event) 
```
- `ddsim` after change: 
```
DDSim            INFO Total Time:   172.26 s (User), 5.16 s (System)
DDSim            INFO StartUp Time: 11.45 s, Processing and Init: 160.81 s (~1.61 s/Event) 
```
It seems like fluctuations may be larger than any computational change introduced by this small change.

BEGINRELEASENOTES
- FCC-ee ALLEGRO detector concept: include plugins attaching additional info to the geometry, needed to generate `edm4hep::TrackerHitPlane`.
ENDRELEASENOTES
