### PR TITLE
Move stl_files folder outside

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -214,7 +214,7 @@ if(INSTALL_BEAMPIPE_STL_FILES)
         )
     # Set main FCC url
     set(FCC_URL "https://fccsw.web.cern.ch/fccsw/filesForSimDigiReco")
-    set(STL_PATH "MDI_o1_v01/stl_files/Pipe_240430")
+    set(STL_PATH "stl_files/Pipe_240430")
 
     # Set the output directory where the file will be placed
     set(OUTPUT_DIR "${PROJECT_SOURCE_DIR}/FCCee/MDI/compact/${STL_PATH}")
@@ -242,6 +242,6 @@ if(INSTALL_BEAMPIPE_STL_FILES)
     endforeach()
 
     file(MAKE_DIRECTORY share/k4geo/FCCee)
-    INSTALL(DIRECTORY ${OUTPUT_DIR} DESTINATION share/k4geo/FCCee/MDI/compact/MDI_o1_v01/stl_files )
+    INSTALL(DIRECTORY ${OUTPUT_DIR} DESTINATION share/k4geo/FCCee/MDI/compact/stl_files )
 
 endif()

--- a/FCCee/MDI/compact/MDI_o1_CADBased_v01/Beampipe_CADimport_o1_v03.xml
+++ b/FCCee/MDI/compact/MDI_o1_CADBased_v01/Beampipe_CADimport_o1_v03.xml
@@ -19,7 +19,7 @@
 
     <detector name="Beampipe_STL" type="DD4hep_TestShape_Creator">
       <check>
-        <shape type="CAD_MultiVolume" ref="${K4GEO}/FCCee/MDI/compact/MDI_o1_v01/stl_files/Pipe_240430/AlBeMet162_30042024.stl"
+        <shape type="CAD_MultiVolume" ref="${K4GEO}/FCCee/MDI/compact/stl_files/Pipe_240430/AlBeMet162_30042024.stl"
 	       unit="mm" material="AlBeMet162">
 	  <volume id="0" name="s1" vis="AlBeMet_vis" material="AlBeMet162"> 
 	    <position x="0*cm"  y="0*cm"  z="0*cm"/>
@@ -31,7 +31,7 @@
 
     <detector name="Beampipe_crotch_STL" type="DD4hep_TestShape_Creator">
       <check>
-        <shape type="CAD_MultiVolume" ref="${K4GEO}/FCCee/MDI/compact/MDI_o1_v01/stl_files/Pipe_240430/Copper_pipe_28092023.stl"
+        <shape type="CAD_MultiVolume" ref="${K4GEO}/FCCee/MDI/compact/stl_files/Pipe_240430/Copper_pipe_28092023.stl"
                unit="mm" material="Copper">
           <volume id="0" name="s1" vis="CopperCooling_vis" material="Cu">
             <position x="0*cm"  y="0*cm"  z="0*cm"/>
@@ -44,7 +44,7 @@
 
     <detector name="Gold_STL" type="DD4hep_TestShape_Creator">
       <check>
-        <shape type="CAD_MultiVolume" ref="${K4GEO}/FCCee/MDI/compact/MDI_o1_v01/stl_files/Pipe_240430/Gold_19042024.stl"
+        <shape type="CAD_MultiVolume" ref="${K4GEO}/FCCee/MDI/compact/stl_files/Pipe_240430/Gold_19042024.stl"
 	       unit="mm" material="Gold">
           <volume id="0" name="s1" vis="Gold_vis" material="Au">
             <position x="0*cm"  y="0*cm"  z="0*cm"/>
@@ -57,7 +57,7 @@
     
     <detector name="Paraffin_STL" type="DD4hep_TestShape_Creator">
       <check>
-        <shape type="CAD_MultiVolume" ref="${K4GEO}/FCCee/MDI/compact/MDI_o1_v01/stl_files/Pipe_240430/Paraffine_19042024.stl"
+        <shape type="CAD_MultiVolume" ref="${K4GEO}/FCCee/MDI/compact/stl_files/Pipe_240430/Paraffine_19042024.stl"
 	       unit="mm" material="LiquidNDecane">
           <volume id="0" name="s1" vis="Paraffin_vis" material="LiquidNDecane">
             <position x="0*cm"  y="0*cm"  z="0*cm"/>
@@ -69,7 +69,7 @@
 
     <detector name="Water_STL" type="DD4hep_TestShape_Creator">
       <check>
-        <shape type="CAD_MultiVolume" ref="${K4GEO}/FCCee/MDI/compact/MDI_o1_v01/stl_files/Pipe_240430/Water_30042024.stl"
+        <shape type="CAD_MultiVolume" ref="${K4GEO}/FCCee/MDI/compact/stl_files/Pipe_240430/Water_30042024.stl"
                unit="mm" material="Water">
           <volume id="0" name="s1" vis="Water_vis" material="Water">
             <position x="0*cm"  y="0*cm"  z="0*cm"/>
@@ -81,7 +81,7 @@
 
     <detector name="Tungsten_STL" type="DD4hep_TestShape_Creator">
       <check>
-        <shape type="CAD_MultiVolume" ref="${K4GEO}/FCCee/MDI/compact/MDI_o1_v01/stl_files/Pipe_240430/Tungsten_mask_02102023.stl"
+        <shape type="CAD_MultiVolume" ref="${K4GEO}/FCCee/MDI/compact/stl_files/Pipe_240430/Tungsten_mask_02102023.stl"
                unit="mm" material="Tungsten">
           <volume id="0" name="s1" vis="Tungsten_vis" material="W">
             <position x="0*cm"  y="0*cm"  z="0*cm"/>

--- a/FCCee/MDI/compact/MDI_o1_v01/Beampipe_CADimport_o1_v02.xml
+++ b/FCCee/MDI/compact/MDI_o1_v01/Beampipe_CADimport_o1_v02.xml
@@ -19,7 +19,7 @@
 
     <detector name="Beampipe_STL" type="DD4hep_TestShape_Creator">
       <check>
-        <shape type="CAD_MultiVolume" ref="${K4GEO}/FCCee/MDI/compact/MDI_o1_v01/stl_files/Pipe_240430/AlBeMet162_30042024.stl"
+        <shape type="CAD_MultiVolume" ref="${K4GEO}/FCCee/MDI/compact/stl_files/Pipe_240430/AlBeMet162_30042024.stl"
 	       unit="mm" material="AlBeMet162">
 	  <volume id="0" name="s1" vis="AlBeMet_vis" material="AlBeMet162"> 
 	    <position x="0*cm"  y="0*cm"  z="0*cm"/>
@@ -31,7 +31,7 @@
 
     <detector name="Beampipe_crotch_STL" type="DD4hep_TestShape_Creator">
       <check>
-        <shape type="CAD_MultiVolume" ref="${K4GEO}/FCCee/MDI/compact/MDI_o1_v01/stl_files/Pipe_240430/Copper_pipe_28092023.stl"
+        <shape type="CAD_MultiVolume" ref="${K4GEO}/FCCee/MDI/compact/stl_files/Pipe_240430/Copper_pipe_28092023.stl"
                unit="mm" material="Copper">
           <volume id="0" name="s1" vis="CopperCooling_vis" material="Cu">
             <position x="0*cm"  y="0*cm"  z="0*cm"/>
@@ -44,7 +44,7 @@
 
     <detector name="Gold_STL" type="DD4hep_TestShape_Creator">
       <check>
-        <shape type="CAD_MultiVolume" ref="${K4GEO}/FCCee/MDI/compact/MDI_o1_v01/stl_files/Pipe_240430/Gold_19042024.stl"
+        <shape type="CAD_MultiVolume" ref="${K4GEO}/FCCee/MDI/compact/stl_files/Pipe_240430/Gold_19042024.stl"
 	       unit="mm" material="Gold">
           <volume id="0" name="s1" vis="Gold_vis" material="Au">
             <position x="0*cm"  y="0*cm"  z="0*cm"/>
@@ -57,7 +57,7 @@
     
     <detector name="Paraffin_STL" type="DD4hep_TestShape_Creator">
       <check>
-        <shape type="CAD_MultiVolume" ref="${K4GEO}/FCCee/MDI/compact/MDI_o1_v01/stl_files/Pipe_240430/Paraffine_19042024.stl"
+        <shape type="CAD_MultiVolume" ref="${K4GEO}/FCCee/MDI/compact/stl_files/Pipe_240430/Paraffine_19042024.stl"
 	       unit="mm" material="LiquidNDecane">
           <volume id="0" name="s1" vis="Paraffin_vis" material="LiquidNDecane">
             <position x="0*cm"  y="0*cm"  z="0*cm"/>
@@ -69,7 +69,7 @@
 
     <detector name="Water_STL" type="DD4hep_TestShape_Creator">
       <check>
-        <shape type="CAD_MultiVolume" ref="${K4GEO}/FCCee/MDI/compact/MDI_o1_v01/stl_files/Pipe_240430/Water_30042024.stl"
+        <shape type="CAD_MultiVolume" ref="${K4GEO}/FCCee/MDI/compact/stl_files/Pipe_240430/Water_30042024.stl"
                unit="mm" material="Water">
           <volume id="0" name="s1" vis="Water_vis" material="Water">
             <position x="0*cm"  y="0*cm"  z="0*cm"/>
@@ -81,7 +81,7 @@
 
     <detector name="Tungsten_STL" type="DD4hep_TestShape_Creator">
       <check>
-        <shape type="CAD_MultiVolume" ref="${K4GEO}/FCCee/MDI/compact/MDI_o1_v01/stl_files/Pipe_240430/Tungsten_mask_02102023.stl"
+        <shape type="CAD_MultiVolume" ref="${K4GEO}/FCCee/MDI/compact/stl_files/Pipe_240430/Tungsten_mask_02102023.stl"
                unit="mm" material="Tungsten">
           <volume id="0" name="s1" vis="Tungsten_vis" material="W">
             <position x="0*cm"  y="0*cm"  z="0*cm"/>


### PR DESCRIPTION
BEGINRELEASENOTES

* FCCee/MDI: Moved the `stl_files` folder up one level:
  from `FCCee/MDI/compact/MDI_o1_v01/stl_files` to `FCCee/MDI/compact/stl_files`
  Provide a common space for CAD versions sharing the same files.

ENDRELEASENOTES

Also the folder in `/eos/project/f/fccsw-web/www/filesForSimDigiReco/` has been moved from   `MDI/MDI_o1_v01/stl_files` to `MDI/stl_files`. The old repo has been kept for now, it may be removed later.

