### PR TITLE
Allow negative time optical photons (from BIB overlay) in the DRCaloSDAction

### DIFF
--- a/plugins/FiberDRCaloSDAction.cpp
+++ b/plugins/FiberDRCaloSDAction.cpp
@@ -1,5 +1,4 @@
 // DD4hep Framework include files
-#include "DD4hep/Printout.h"
 #include "DD4hep/Segmentations.h"
 #include "DDG4/Geant4Mapping.h"
 #include "DDG4/Geant4Random.h"


### PR DESCRIPTION
To ease the review process, please consider the following before opening a pull request:
- [x] the code is sufficiently well documented (e.g. inline comments)
- [ ] the relevant README(s) were updated. See e.g. https://github.com/key4hep/k4geo/blob/main/detector/calorimeter/README.md or https://github.com/key4hep/k4geo/blob/main/FCCee/IDEA/compact/README.md
- [x] the code is covered by tests. See https://github.com/key4hep/k4geo/blob/main/test/CMakeLists.txt
- [x] the PR source branch has been rebased (`--ff-only`) to `k4geo/main`
- [x] the PR does not contain any additions or modifications that do not belong to it
- [x] The release notes below contain a succinct and comprehensive description of the changes that are sufficiently self-explanatory

BEGINRELEASENOTES
- Allow negative time optical photons (from BIB overlay) in the DRCaloSDAction

ENDRELEASENOTES

`DRCaloSDAction` has a 'timing window' to record incoming optical photons from Cherenkov fibers. This is currently set to 5-70 ns, which has no issue with the signal photons. However, we need to allow possible contributions in the negative time (from the previous bunch crossing, etc) for background overlays and BIB studies. This PR allows this and makes the time window configurable.