### PR TITLE
Fix cmake development warnings.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,8 @@
 cmake_minimum_required(VERSION 3.20 FATAL_ERROR)
 
-cmake_policy(SET CMP0144 NEW)
-cmake_policy(SET CMP0167 NEW)
+if( POLICY CMP0167 )
+  cmake_policy(SET CMP0167 NEW)
+endif()
 
 #---------------------------
 set( PackageName k4geo )


### PR DESCRIPTION
With a recent cmake (tested with 3.31.6), we get warnings at the cmake step:

```
CMake Warning (dev) at /usr/share/cmake/Modules/CMakeFindDependencyMacro.cmake:76 (find_package):
  Policy CMP0144 is not set: find_package uses upper-case <PACKAGENAME>_ROOT
  variables.  Run "cmake --help-policy CMP0144" for policy details.  Use the
  cmake_policy command to set the policy and suppress this warning.

  Environment variable BOOST_ROOT is set to:

    /home/sss/atlas/extern/boost/boost_1_87_0

  For compatibility, find_package is ignoring the variable, but code in a
  .cmake module might still use it.
Call Stack (most recent call first):
  /home/sss/fcc/soft/inst/cmake/DD4hepConfig.cmake:49 (FIND_DEPENDENCY)
  CMakeLists.txt:47 (find_package)
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Warning (dev) at /usr/share/cmake/Modules/CMakeFindDependencyMacro.cmake:76 (find_package):
  Policy CMP0167 is not set: The FindBoost module is removed.  Run "cmake
  --help-policy CMP0167" for policy details.  Use the cmake_policy command to
  set the policy and suppress this warning.

Call Stack (most recent call first):
  /home/sss/fcc/soft/inst/cmake/DD4hepConfig.cmake:49 (FIND_DEPENDENCY)
  CMakeLists.txt:47 (find_package)
This warning is for project developers.  Use -Wno-dev to suppress it.
```

Fixed by requesting NEW versions of these policies.

BEGINRELEASENOTES
- Fixed cmake development warnings.
ENDRELEASENOTES

