### PR TITLE
Fix comment describing return value 

### DIFF
--- a/detectorSegmentations/src/FCCSWEndcapTurbine_k4geo.cpp
+++ b/detectorSegmentations/src/FCCSWEndcapTurbine_k4geo.cpp
@@ -248,7 +248,7 @@ namespace DDSegmentation {
     return TMath::ATan2(xprime, yprime);
   }
 
-  /// determine absolute x position based on the cell ID
+  /// determine absolute z position based on the cell ID
   double FCCSWEndcapTurbine_k4geo::z(const CellID cID) const {
     CellID zValue = decoder()->get(cID, m_zIndex);
     CellID sideValue = decoder()->get(cID, m_sideIndex);


### PR DESCRIPTION
To ease the review process, please consider the following before opening a pull request:
- [ ] the code is sufficiently well documented (e.g. inline comments)
- [ ] the relevant README(s) were updated. See e.g. https://github.com/key4hep/k4geo/blob/main/detector/calorimeter/README.md or https://github.com/key4hep/k4geo/blob/main/FCCee/IDEA/compact/README.md
- [ ] the code is covered by tests. See https://github.com/key4hep/k4geo/blob/main/test/CMakeLists.txt
- [ ] the PR source branch has been rebased (`--ff-only`) to `k4geo/main`
- [ ] the PR does not contain any additions or modifications that do not belong to it
- [ ] The release notes below contain a succinct and comprehensive description of the changes that are sufficiently self-explanatory

If you are modifying detector dimensions or adding new xml parameters, also consider the following:
- [ ] the xml file free parameters that can not be modified without additional prescriptions are well indicated
- [ ] the changes in this PR have not introduced any overlaps. You can check so with the following command: `ddsim --compactFile PATH_TO_COMPACT_FILE --runType run --ui.commandsInitialize "/geometry/test/run" > overlapDump.txt`

BEGINRELEASENOTES

Fixed comment above the z() function in detectorSegmentations/src/FCCSWEndcapTurbine_k4geo.cpp to accurately describe the return value

ENDRELEASENOTES

