### PR TITLE
[IDEA] Equal fiber radius in IDEA_o2 endcap and barrel

### DIFF
--- a/FCCee/IDEA/compact/IDEA_o2_v01/DectDimensions_IDEA_o2_v01.xml
+++ b/FCCee/IDEA/compact/IDEA_o2_v01/DectDimensions_IDEA_o2_v01.xml
@@ -251,7 +251,7 @@
     <constant name="DRETNbOfZRot"    value="72"/>
     <constant name="DRETTubeRadius"  value="1.0*mm"/>
     <constant name="DRETCladRadius"  value="0.5*mm"/>
-    <constant name="DRETCoreRadius"  value="0.45*mm"/>
+    <constant name="DRETCoreRadius"  value="0.485*mm"/>
     <!-- end of Dual-Readout Endcap Tubes (DRET) calorimeter dimensions-->
 
     <!-- Dual-Readout Barrel Tubes (DRBT) calorimeter dimensions-->
@@ -267,8 +267,8 @@
     <constant name="DRBTInnerCaloHalfLength" value="2.805*m"  />
     <constant name="DRBTTowerThetaCoverage"  value="1.0*deg"/>      
     <constant name="DRBTTowerPhiCoverage"    value="5.0*deg"  />
-    <constant name="DRBTSupportSideThickness" value="1.0*mm" />
-    <constant name="DRBTSupportFrontThickness" value="1.0*mm" />
+    <constant name="DRBTSupportSideThickness" value="0.0*mm" />
+    <constant name="DRBTSupportFrontThickness" value="0.0*mm" />
     <constant name="DRBTSupportBackThickness" value="0.0*cm" />
     <!--Variables to construct only part of the calorimeter-->
     <!-- Base values are: Start = '0*deg', End = '360*deg' -->


### PR DESCRIPTION
- [X] the code is sufficiently well documented (e.g. inline comments)
- [X] the relevant README(s) were updated. See e.g. https://github.com/key4hep/k4geo/blob/main/detector/calorimeter/README.md or https://github.com/key4hep/k4geo/blob/main/FCCee/IDEA/compact/README.md
- [X] the code is covered by tests. See https://github.com/key4hep/k4geo/blob/main/test/CMakeLists.txt
- [X] the PR source branch has been rebased (`--ff-only`) to `k4geo/main`
- [X] the PR does not contain any additions or modifications that do not belong to it
- [X] The release notes below contain a succinct and comprehensive description of the changes that are sufficiently self-explanatory
- [X] the changes in this PR have not introduced any overlaps. You can check so with the following command: `ddsim --compactFile PATH_TO_COMPACT_FILE --runType run --ui.commandsInitialize "/geometry/test/run" > overlapDump.txt`

BEGINRELEASENOTES
- Set optical fiber radius identical for IDEA_o2 endcap and barrel hadronic calorimeters
- Do not include IDEA_o2 hadronic barrel calorimeter casing by default

ENDRELEASENOTES

Very short PR. By mistake the fiber radius for the IDEA_o2 barrel and endcap hadronic calorimeters was set different, but we do not foresee any difference in the fibers used. Also, the design of the barrel calorimeter casing is still ongoing and we should not include it by default in the simulation untill we have an approved version.