### PR TITLE
Set the env variable K4GEO in thisk4geo.sh

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -158,7 +158,7 @@ endif()
 dd4hep_instantiate_package(${PackageName})
 if(EXISTS "${PROJECT_BINARY_DIR}/this${PackageName}.sh")
   message(STATUS "this${PackageName}.sh created successfully.")
-  # Replace the K4GEO environment variable with the actual installation path
+  # Replace the K4GEO environment variable with the path to the source
   file(APPEND "${PROJECT_BINARY_DIR}/this${PackageName}.sh" "\nexport K4GEO=\"${CMAKE_CURRENT_SOURCE_DIR}\"")
 else()
   message(WARNING "this${PackageName}.sh was not created.")


### PR DESCRIPTION
BEGINRELEASENOTES
- Set the env variable K4GEO in thisk4geo.sh to the current source directory, since in the installation there may be or not a folder with the compact files (depending on the cmake option `INSTALL_COMPACT_FILES`)

ENDRELEASENOTES

This will make paths like `$K4GEO/FCCee/CLD` keep working but using the local version (from the source directory) after sourcing `thisk4geo.sh`

Fix https://github.com/key4hep/k4geo/issues/313