### PR TITLE
Remove unused variable in LumiCal_o1_v02_geo.cpp

### DIFF
--- a/detector/fcal/LumiCal_o1_v02_geo.cpp
+++ b/detector/fcal/LumiCal_o1_v02_geo.cpp
@@ -3,34 +3,25 @@
 
 #include <string>
 
-using dd4hep::_toString;
 using dd4hep::Assembly;
 using dd4hep::Box;
-using dd4hep::BUILD_ENVELOPE;
-using dd4hep::Cone;
 using dd4hep::Detector;
 using dd4hep::DetElement;
-using dd4hep::IntersectionSolid;
-using dd4hep::Layer;
 using dd4hep::Layering;
 using dd4hep::Material;
 using dd4hep::PlacedVolume;
-using dd4hep::PolyhedraRegular;
 using dd4hep::Position;
-using dd4hep::Readout;
 using dd4hep::Ref_t;
 using dd4hep::Rotation3D;
 using dd4hep::RotationY;
 using dd4hep::RotationZ;
 using dd4hep::RotationZYX;
-using dd4hep::Segmentation;
 using dd4hep::SensitiveDetector;
 using dd4hep::SubtractionSolid;
 using dd4hep::Transform3D;
 using dd4hep::Translation3D;
 using dd4hep::Trapezoid;
 using dd4hep::Tube;
-using dd4hep::UnionSolid;
 using dd4hep::Volume;
 
 static Ref_t create_detector(Detector& theDetector, xml_h element, SensitiveDetector sens) {
@@ -269,7 +260,6 @@ static Ref_t create_detector(Detector& theDetector, xml_h element, SensitiveDete
   */
 
   const Position bcForwardPos(0, 0, 0);
-  const Position bcBackwardPos(0, 0, 0);
   const Rotation3D bcForwardRot(RotationY(0));
   const Rotation3D bcBackwardRot(RotationY(0));
 


### PR DESCRIPTION
BEGINRELEASENOTES
- Remove unused variable in LumiCal_o1_v02_geo.cpp to fix a compiler warning and some namespaces that are not being used

ENDRELEASENOTES