### PR TITLE
[IDEA] Add calo hit contributions in IDEA_o2 hadronic calorimeter

### DIFF
--- a/plugins/DRTubesSDAction.cpp
+++ b/plugins/DRTubesSDAction.cpp
@@ -261,6 +261,11 @@ namespace sim {
     } // end of Volume ID and hit collection creation for barrel
 
     // We now calculate the hit signal
+    // If m_PhotonsTimeBinWidth <= 0 we set it to 0.1 ns
+    double thisPhotonsTimeBinWidth = m_userData.m_PhotonsTimeBinWidth;
+    if (thisPhotonsTimeBinWidth <= 0) {
+      thisPhotonsTimeBinWidth = 0.1 * CLHEP::ns;
+    }
     G4double steplength = aStep->GetStepLength();
     G4int signalhit = 0;
     G4double hitTimeOfArrival = 0.;    // time of arrival of hit photons at SiPM
@@ -275,10 +280,9 @@ namespace sim {
       signalhit = DRTubesSglHpr::AttenuateSSignal(signalhit, distance_to_sipm);
       hitTimeOfArrival =
           (distance_to_sipm * m_userData.PMMARefractiveIndex) / CLHEP::c_light; // time of arrival at SiPM (ns)
-      hitBinTimeOfArrival =
-          static_cast<double>(std::floor((aStep->GetPostStepPoint()->GetGlobalTime() + hitTimeOfArrival) /
-                                         m_userData.m_PhotonsTimeBinWidth) *
-                              m_userData.m_PhotonsTimeBinWidth);
+      hitBinTimeOfArrival = static_cast<double>(
+          std::floor((aStep->GetPostStepPoint()->GetGlobalTime() + hitTimeOfArrival) / thisPhotonsTimeBinWidth) *
+          thisPhotonsTimeBinWidth);
       if (signalhit == 0)
         return true;
     } // end of scintillating fibre sigal calculation
@@ -313,10 +317,9 @@ namespace sim {
           signalhit = DRTubesSglHpr::AttenuateCSignal(c_signal, distance_to_sipm);
           hitTimeOfArrival = (distance_to_sipm * m_userData.FluorinatedPolymerRefractiveIndex) /
                              CLHEP::c_light; // time of arrival at SiPM (ns)
-          hitBinTimeOfArrival =
-              static_cast<double>(std::floor((aStep->GetPostStepPoint()->GetGlobalTime() + hitTimeOfArrival) /
-                                             m_userData.m_PhotonsTimeBinWidth) *
-                                  m_userData.m_PhotonsTimeBinWidth);
+          hitBinTimeOfArrival = static_cast<double>(
+              std::floor((aStep->GetPostStepPoint()->GetGlobalTime() + hitTimeOfArrival) / thisPhotonsTimeBinWidth) *
+              thisPhotonsTimeBinWidth);
           if (signalhit == 0)
             return true;
           aStep->GetTrack()->SetTrackStatus(fStopAndKill);


### PR DESCRIPTION
- [x] the code is sufficiently well documented (e.g. inline comments)
- [x] the relevant README(s) were updated. See e.g. https://github.com/key4hep/k4geo/blob/main/detector/calorimeter/README.md or https://github.com/key4hep/k4geo/blob/main/FCCee/IDEA/compact/README.md
- [ ] the code is covered by tests. See https://github.com/key4hep/k4geo/blob/main/test/CMakeLists.txt
- [x] the PR source branch has been rebased (`--ff-only`) to `k4geo/main`
- [x] the PR does not contain any additions or modifications that do not belong to it
- [x] The release notes below contain a succinct and comprehensive description of the changes that are sufficiently self-explanatory

BEGINRELEASENOTES
- Added calo hit contributions in the hadronic calorimeter of IDEA_o2 to store the time of arrival of photons (photo-electrons) at SiPMs. Divided the time of arrivals into temporal bins.

ENDRELEASENOTES

To save the time of arrivals of photons (photoelectrons) at the SiPMs I included calo hit contributions in the sensitive detector action. To choose/minimize the output file size, photons are grouped into time bins. If more than one photon falls within the same time bin, they are counted in that bin.

These changes are needed for the last digitization step, which is the SiPM emulation in GAUDI.

Actual output file size for IDEA_o2 with 40 GeV pion showers is ~0.14 Mb/event.
