### PR TITLE
add some useful debug printout to the ECal barrel with inclined absorbers

### DIFF
--- a/detector/calorimeter/ECalBarrel_NobleLiquid_InclinedTrapezoids_o1_v03_geo.cpp
+++ b/detector/calorimeter/ECalBarrel_NobleLiquid_InclinedTrapezoids_o1_v03_geo.cpp
@@ -868,23 +868,25 @@ static dd4hep::detail::Ref_t createECalBarrelInclined(dd4hep::Detector& aLcdd, d
     dd4hep::rec::Vector3D ivr2 =
         dd4hep::rec::Vector3D(0., rad_last, 0); // defining end vector points of the given layer
     // for debug: calculate and print theta ID of cells at lateral edge, in addition to radial information
-    dd4hep::DDSegmentation::Vector3D edge1(0., rad_first, caloDim.dz());
-    dd4hep::DDSegmentation::Vector3D edge2(0., rad_last - 1e-5, caloDim.dz());
-    dd4hep::DDSegmentation::Vector3D edge3(0., rad_first, -caloDim.dz());
-    dd4hep::DDSegmentation::Vector3D edge4(0., rad_last - 1e-5, -caloDim.dz());
-    dd4hep::CellID vID(0);
-    encoder.set(vID, layerFieldName, iLay);
-    dd4hep::CellID cID1 = seg->cellID(edge1, edge1, vID);
-    dd4hep::CellID cID2 = seg->cellID(edge2, edge2, vID);
-    dd4hep::CellID cID3 = seg->cellID(edge3, edge3, vID);
-    dd4hep::CellID cID4 = seg->cellID(edge4, edge4, vID);
-    int theta_min = encoder.get(cID1, "theta");
-    int theta_max = encoder.get(cID2, "theta");
-    int theta_min2 = encoder.get(cID4, "theta");
-    int theta_max2 = encoder.get(cID3, "theta");
-    dd4hep::printout(dd4hep::DEBUG, "ECalBarrel_NobleLiquid_InclinedTrapezoids_o1_v03",
-                     "    radius first = %f, radius last = %f, radius middle = %f, thetaID = %d-%d | %d-%d", rad_first,
-                     rad_last, rad_mid, theta_min, theta_max, theta_min2, theta_max2);
+    if (dd4hep::printLevel() <= dd4hep::DEBUG) {
+      dd4hep::DDSegmentation::Vector3D edge1(0., rad_first, caloDim.dz());
+      dd4hep::DDSegmentation::Vector3D edge2(0., rad_last - 1e-5, caloDim.dz());
+      dd4hep::DDSegmentation::Vector3D edge3(0., rad_first, -caloDim.dz());
+      dd4hep::DDSegmentation::Vector3D edge4(0., rad_last - 1e-5, -caloDim.dz());
+      dd4hep::CellID vID(0);
+      encoder.set(vID, layerFieldName, iLay);
+      dd4hep::CellID cID1 = seg->cellID(edge1, edge1, vID);
+      dd4hep::CellID cID2 = seg->cellID(edge2, edge2, vID);
+      dd4hep::CellID cID3 = seg->cellID(edge3, edge3, vID);
+      dd4hep::CellID cID4 = seg->cellID(edge4, edge4, vID);
+      int theta_min = encoder.get(cID1, "theta");
+      int theta_max = encoder.get(cID2, "theta");
+      int theta_min2 = encoder.get(cID4, "theta");
+      int theta_max2 = encoder.get(cID3, "theta");
+      dd4hep::printout(dd4hep::DEBUG, "ECalBarrel_NobleLiquid_InclinedTrapezoids_o1_v03",
+                       "    radius first = %f, radius last = %f, radius middle = %f, thetaID = %d-%d | %d-%d",
+                       rad_first, rad_last, rad_mid, theta_min, theta_max, theta_min2, theta_max2);
+    }
 
     const dd4hep::rec::MaterialVec& materials =
         matMgr.materialsBetween(ivr1, ivr2); // calling material manager to get material info between two points


### PR DESCRIPTION
To ease the review process, please consider the following before opening a pull request:
- [x] the code is sufficiently well documented (e.g. inline comments)
- [x] the code is covered by tests. See https://github.com/key4hep/k4geo/blob/main/test/CMakeLists.txt
- [x] the PR source branch has been rebased (`--ff-only`) to `k4geo/main`
- [x] the PR does not contain any additions or modifications that do not belong to it
- [x] The release notes below contain a succinct and comprehensive description of the changes that are sufficiently self-explanatory


BEGINRELEASENOTES
- Add to debug printout of ECal barrel with inclined absorbers the information about cellIDs span by cells at lateral surface of calorimeter 
ENDRELEASENOTES
This MR add to the debug printout of ECal barrel with inclined absorbers the information about cellIDs span by cells at lateral surface of calorimeter  - used to debug the ecal barrel<->endcap neighbour links for topoclustering
