### PR TITLE
Missing #include.

### DIFF
--- a/detectorSegmentations/include/detectorSegmentations/SCEPCal_MainSegmentation_k4geo.h
+++ b/detectorSegmentations/include/detectorSegmentations/SCEPCal_MainSegmentation_k4geo.h
@@ -7,6 +7,7 @@
 #include "DD4hep/DetFactoryHelper.h"
 #include "DDSegmentation/Segmentation.h"
 #include "Math/Vector3D.h"
+#include <climits> // For CHAR_BIT
 #include <cmath>
 #include <vector>
 

--- a/detectorSegmentations/include/detectorSegmentations/SCEPCal_TimingSegmentation_k4geo.h
+++ b/detectorSegmentations/include/detectorSegmentations/SCEPCal_TimingSegmentation_k4geo.h
@@ -7,6 +7,7 @@
 #include "DD4hep/DetFactoryHelper.h"
 #include "DDSegmentation/Segmentation.h"
 #include "Math/Vector3D.h"
+#include <climits> // For CHAR_BIT
 #include <cmath>
 #include <vector>
 


### PR DESCRIPTION
Need to include <climits> for CHAR_BIT.
Fixes compilation failure seen with gcc16.

BEGINRELEASENOTES
- Fix some compilation failures seen with gcc16. Need to include <climits> for CHAR_BIT.

ENDRELEASENOTES

