### PR TITLE
Enable compiling with C++26.

### DIFF
--- a/cmake/Key4hepConfig.cmake
+++ b/cmake/Key4hepConfig.cmake
@@ -43,7 +43,7 @@ endmacro()
 macro(key4hep_set_cxx_standard_and_extensions)
   set(CMAKE_CXX_STANDARD 20 CACHE STRING "")
 
-  if(NOT CMAKE_CXX_STANDARD MATCHES "20|23")
+  if(NOT CMAKE_CXX_STANDARD MATCHES "20|23|26")
     message(FATAL_ERROR "Unsupported C++ standard: ${CMAKE_CXX_STANDARD}, supported values are 20 and 23")
   endif()
 


### PR DESCRIPTION

BEGINRELEASENOTES
- Enable compiling with C++26.
ENDRELEASENOTES

