### PR TITLE
Use subdetector-specific VolumeManager in FCCSWGridModuleThetaMerged_k4geo

### DIFF
--- a/detectorSegmentations/src/FCCSWGridModuleThetaMerged_k4geo.cpp
+++ b/detectorSegmentations/src/FCCSWGridModuleThetaMerged_k4geo.cpp
@@ -76,7 +76,9 @@ namespace DDSegmentation {
 
     dd4hep::printout(dd4hep::INFO, "FCCSWGridModuleThetaMerged_k4geo", "Precalculating position info of radial layers");
     dd4hep::Detector* dd4hepgeo = &(dd4hep::Detector::getInstance());
-    VolumeManager vman = VolumeManager::getVolumeManager(*dd4hepgeo);
+    const DetElementObject& de = *dd4hepgeo->readout(this->name()).segmentation().detector();
+    VolumeManager vman_glob = VolumeManager::getVolumeManager(*dd4hepgeo);
+    VolumeManager vman = vman_glob.subdetector(de.id);
 
     std::vector<LayerInfo> out;
     out.reserve(m_nLayers);


### PR DESCRIPTION
Different subsystems use different bit-widths for the system field of identifiers.  This implies that volume IDs are not necessarily globally unique.  For example, volume IDs for the ALLEGRO HCAL barrel (detid=8, system bit width=4) have been observed to collide with those from the silicon wrapper (detid=24 [SiWr_disks], system bit width=5). This can be avoided by doing the lookup in the system-specific VolumeManager, rather than from the global instance.

Although i have not observed an issue with the ALLEGRO ECal, implement this change to avoid potential issues in the future.

Comments in VolumeManager imply that allowing different bit widths for the system field is intentional.  But it would probably be better to adopt a uniform width to avoid ambiguities.  However, this changes all cellids and invalidates existing data files.

BEGINRELEASENOTES
- detectorSegmentations/src/FCCSWGridModuleThetaMerged_k4geo.cpp: Avoid possible issue due to volume IDs not being globally unique.  
ENDRELEASENOTES

