### PR TITLE
Use the hierarchical drivers in MuSIC_v2 tracker as well

### DIFF
--- a/MuColl/MuSIC/compact/MuSIC_v2/InnerTracker_o2_v07_01.xml
+++ b/MuColl/MuSIC/compact/MuSIC_v2/InnerTracker_o2_v07_01.xml
@@ -125,7 +125,7 @@
         </detector>
 
 
-        <detector id="DetID_IT_Endcap" name="InnerTrackerEndcap" type="TrackerEndcap_o2_v06" readout="InnerTrackerEndcapCollection" reflect="true" region="InnerTrackerEndcapRegion">
+        <detector id="DetID_IT_Endcap" name="InnerTrackerEndcap" type="TrackerEndcap_o2_v07" readout="InnerTrackerEndcapCollection" reflect="true" region="InnerTrackerEndcapRegion">
             <envelope vis="ITVis">
                 <shape type="Assembly"/>
             </envelope>

--- a/MuColl/MuSIC/compact/MuSIC_v2/MuSIC_v2.xml
+++ b/MuColl/MuSIC/compact/MuSIC_v2/MuSIC_v2.xml
@@ -191,8 +191,8 @@
 
     <include ref="Vertex_o2_v06_01.xml"/>
 
-    <include ref="InnerTracker_o2_v06_01.xml"/>
-    <include ref="OuterTracker_o2_v06_01.xml"/>
+    <include ref="InnerTracker_o2_v07_01.xml"/>
+    <include ref="OuterTracker_o2_v07_01.xml"/>
 
     <include ref="ECalBarrel_crilin.xml"/>
     <include ref="ECalEndcap_crilin.xml"/>

--- a/MuColl/MuSIC/compact/MuSIC_v2/OuterTracker_o2_v07_01.xml
+++ b/MuColl/MuSIC/compact/MuSIC_v2/OuterTracker_o2_v07_01.xml
@@ -91,7 +91,7 @@
         </detector>
 
 
-        <detector id="DetID_OT_Endcap" name="OuterTrackerEndcap" type="TrackerEndcap_o2_v06" readout="OuterTrackerEndcapCollection" reflect="true" region="OuterTrackerEndcapRegion">
+        <detector id="DetID_OT_Endcap" name="OuterTrackerEndcap" type="TrackerEndcap_o2_v07" readout="OuterTrackerEndcapCollection" reflect="true" region="OuterTrackerEndcapRegion">
             <envelope vis="OTVis">
                 <shape type="Assembly"/>
             </envelope>

--- a/MuColl/MuSIC/compact/MuSIC_v2/Vertex_o2_v06_01.xml
+++ b/MuColl/MuSIC/compact/MuSIC_v2/Vertex_o2_v06_01.xml
@@ -139,7 +139,7 @@
     </detectors>
 
     <detectors>
-        <detector id="DetID_VXD_Endcap" name="VertexEndcap" type="VertexEndcap_o1_v06" readout="VertexEndcapCollection" reflect="true" region="VertexEndcapRegion">
+        <detector id="DetID_VXD_Endcap" name="VertexEndcap" type="VertexEndcap_o1_v07" readout="VertexEndcapCollection" reflect="true" region="VertexEndcapRegion">
             <envelope vis="VXDVis">
                 <shape type="Assembly"/>
             </envelope>


### PR DESCRIPTION
To ease the review process, please consider the following before opening a pull request:
- [ ] the code is sufficiently well documented (e.g. inline comments)
- [ ] the relevant README(s) were updated. See e.g. https://github.com/key4hep/k4geo/blob/main/detector/calorimeter/README.md or https://github.com/key4hep/k4geo/blob/main/FCCee/IDEA/compact/README.md
- [ ] the code is covered by tests. See https://github.com/key4hep/k4geo/blob/main/test/CMakeLists.txt
- [ ] the PR source branch has been rebased (`--ff-only`) to `k4geo/main`
- [ ] the PR does not contain any additions or modifications that do not belong to it
- [ ] The release notes below contain a succinct and comprehensive description of the changes that are sufficiently self-explanatory

If you are modifying detector dimensions or adding new xml parameters, also consider the following:
- [ ] the xml file free parameters that can not be modified without additional prescriptions are well indicated
- [ ] the changes in this PR have not introduced any overlaps. You can check so with the following command: `ddsim --compactFile PATH_TO_COMPACT_FILE --runType run --ui.commandsInitialize "/geometry/test/run" > overlapDump.txt`

BEGINRELEASENOTES
- Use the more hierarchical detector drivers for MuSIC_v2 introduced in #549 in more detector concepts to facilitate conversion to  ACTS

ENDRELEASENOTES

Technically the updated ACTS geometry conversion API could also deal with ungrouped / less hierarchical drivers but the conversion code on our side would be easier to maintain if we do not have to deal with this, resp. if we treat all of these the same.