### PR TITLE
update readout used by FCChh ECAL

### DIFF
--- a/FCChh/compact/FCChhBaseline/CalDiscs/Endcaps_coneCryo.xml
+++ b/FCChh/compact/FCChhBaseline/CalDiscs/Endcaps_coneCryo.xml
@@ -63,22 +63,18 @@
       <segmentation type="FCCSWGridPhiEta_k4geo" phi_bins="704" offset_phi="-pi+(pi/704.)" grid_size_eta="0.01" offset_eta="-2.51024"/>
       <id>system:4,subsystem:1,type:3,subtype:3,layer:8,sublayer:8,eta:10,phi:10</id>
     </readout>
-    <!--
     <readout name="EMECPhiEtaReco">
       <segmentation type="FCCSWGridPhiEta_k4geo" phi_bins="704" offset_phi="-pi+(pi/704.)" grid_size_eta="0.01" offset_eta="-2.51024"/>
       <id>system:4,subsystem:1,type:3,subtype:3,layer:8,eta:10,phi:10</id>
     </readout>
-    -->
     <readout name="HECPhiEta">
       <segmentation type="FCCSWGridPhiEta_k4geo" phi_bins="256" offset_phi="-pi+(pi/256.)" grid_size_eta="0.025" offset_eta="-2.51024"/>
       <id>system:4,subsystem:1,type:3,subtype:3,layer:8,sublayer:8,eta:10,phi:10</id>
     </readout>
-    <!--
     <readout name="HECPhiEtaReco">
       <segmentation type="FCCSWGridPhiEta_k4geo" phi_bins="256" offset_phi="-pi+(pi/256.)" grid_size_eta="0.025" offset_eta="-2.51024"/>
       <id>system:4,subsystem:1,type:3,subtype:3,layer:8,eta:10,phi:10</id>
     </readout>
-    -->
   </readouts>
 
   <detectors>

--- a/FCChh/compact/FCChhBaseline/CalDiscs/Forward_coneCryo.xml
+++ b/FCChh/compact/FCChhBaseline/CalDiscs/Forward_coneCryo.xml
@@ -60,22 +60,18 @@
       <segmentation type="FCCSWGridPhiEta_k4geo" phi_bins="256" offset_phi="-pi+(pi/256.)" grid_size_eta="0.025" offset_eta="-6.00024"/>
       <id>system:4,subsystem:1,type:3,subtype:3,layer:8,sublayer:8,eta:11,phi:10</id>
     </readout>
-    <!--
     <readout name="EMFwdPhiEtaReco">
       <segmentation type="FCCSWGridPhiEta_k4geo" phi_bins="256" offset_phi="-pi+(pi/256.)" grid_size_eta="0.025" offset_eta="-6.00024"/>
       <id>system:4,subsystem:1,type:3,subtype:3,layer:8,eta:11,phi:10</id>
     </readout>
-    -->
     <readout name="HFwdPhiEta">
       <segmentation type="FCCSWGridPhiEta_k4geo" phi_bins="128" offset_phi="-pi+(pi/128.)" grid_size_eta="0.05" offset_eta="-6.00024"/>
       <id>system:4,subsystem:1,type:3,subtype:3,layer:8,sublayer:8,eta:11,phi:10</id>
     </readout>
-    <!--
     <readout name="HFwdPhiEtaReco">
       <segmentation type="FCCSWGridPhiEta_k4geo" phi_bins="128" offset_phi="-pi+(pi/128.)" grid_size_eta="0.05" offset_eta="-6.00024"/>
       <id>system:4,subsystem:1,type:3,subtype:3,layer:8,eta:11,phi:10</id>
     </readout>
-    -->
   </readouts>
   <detectors>
     <!-- positive side: cryostat -->

--- a/FCChh/compact/FCChhBaseline/ECalInclined/FCChh_ECalBarrel_Common.xml
+++ b/FCChh/compact/FCChhBaseline/ECalInclined/FCChh_ECalBarrel_Common.xml
@@ -61,7 +61,7 @@
     <!-- phi position is calculated based on the centre of volume (hence it cannot be done in the simulation from energy deposits position) -->
     <readout name="ECalBarrelPhiEta">
       <segmentation type="FCCSWGridPhiEta_k4geo" grid_size_eta="0.01" phi_bins="704" offset_eta="-1.68024" offset_phi="-pi+(pi/704.)"/>
-      <id>system:4,cryo:1,type:3,subtype:3,layer:8,module:11,eta:9,phi:10</id>
+      <id>system:4,cryo:1,type:3,subtype:3,layer:8,eta:9,phi:10</id>
     </readout>
   </readouts>
 

--- a/FCChh/compact/FCChhBaseline/ECalInclined/FCChh_ECalBarrel_Common.xml
+++ b/FCChh/compact/FCChhBaseline/ECalInclined/FCChh_ECalBarrel_Common.xml
@@ -66,7 +66,7 @@
   </readouts>
 
   <detectors>
-    <detector id="BarECal_id" name="ECalBarrel" type="ECalBarrel_NobleLiquid_InclinedTrapezoids_o1_v01" readout="ECalBarrelPhiEta">
+    <detector id="BarECal_id" name="ECalBarrel" type="ECalBarrel_NobleLiquid_InclinedTrapezoids_o1_v01" readout="ECalBarrelEta">
       <type_flags type=" DetType_CALORIMETER + DetType_ELECTROMAGNETIC + DetType_BARREL"/>
       <sensitive type="calorimeter"/>
       <dimensions rmin="BarCryoECal_rmin" rmax="BarCryoECal_rmax" dz="BarCryoECal_dz" vis="ecal_envelope"/>

--- a/FCChh/compact/README.md
+++ b/FCChh/compact/README.md
@@ -7,5 +7,6 @@ Further notes:
     for the latter.  It appears that in previous configurations, the first
     one was what was used.  These variables have been adjusted to make them
     unique.
-  - The simulation and reconstruction segmentations have been made consistent,
-    adding additional CellID fields where needed.
+  - Multiple segmentations are defined, as in the original FCChh workflow
+    (where they were used for either simulation and reconstruction)
+    By default, the detector uses the readout of the simulation


### PR DESCRIPTION
BEGINRELEASENOTES
- Restore readout used for simulation of FCC-hh ECAL
ENDRELEASENOTES

Needed to make FCC-hh digitisation scripts work - and more in line with legacy FCC-hh code in https://github.com/HEP-FCC/FCCDetectors/tree/main/Detector