### PR TITLE
Bring back majority of ILD_FCCee_v01

### DIFF
--- a/FCCee/ILD_FCCee/compact/ILD_FCCee_v01/ILD_FCCee_v01.xml
+++ b/FCCee/ILD_FCCee/compact/ILD_FCCee_v01/ILD_FCCee_v01.xml
@@ -76,18 +76,18 @@
   <include ref="InnerTrackerILD_o1_v02_00.xml"/>
 
   <!-- these are from the "main" ILD versions -->
-  <!-- <include ref="../ILD_common_v02/tpc10_01.xml"/> -->
-  <!-- <include ref="../ILD_common_v02/set_simple_planar_sensors_01.xml"/> -->
-  <!-- <include ref="../ILD_common_v02/SEcal06_hybrid_Barrel.xml"/> -->
-  <!-- <include ref="../ILD_common_v02/SEcal06_hybrid_Endcaps.xml"/> -->
-  <!-- <include ref="../ILD_common_FCCee/SEcal06_siw_ECRing.xml"/> -->
-  <!-- <include ref="../ILD_common_v02/SHcalSc04_Barrel_v04.xml"/> -->
-  <!-- <include ref="../ILD_common_v02/SHcalSc04_Endcaps_v01_LARGE.xml"/> -->
-  <!-- <include ref="../ILD_common_v02/SHcalSc04_EndcapRing_v01.xml"/> -->
-  <!-- <include ref="../ILD_common_v02/Yoke05_Barrel.xml"/> -->
-  <!-- <include ref="../ILD_common_v02/Yoke06_Endcaps.xml"/> -->
-  <!-- <include ref="../ILD_common_v02/coil03.xml"/> -->
-  <!-- <include ref="../ILD_common_v02/SServices01.xml"/> -->
+  <include ref="../ILD_common_v02/tpc10_01.xml"/>
+  <include ref="../ILD_common_v02/set_simple_planar_sensors_01.xml"/>
+  <include ref="../ILD_common_v02/SEcal06_hybrid_Barrel.xml"/>
+  <include ref="../ILD_common_v02/SEcal06_hybrid_Endcaps.xml"/>
+  <include ref="../ILD_common_FCCee/SEcal06_siw_ECRing.xml"/>
+  <include ref="../ILD_common_v02/SHcalSc04_Barrel_v04.xml"/>
+  <include ref="../ILD_common_v02/SHcalSc04_Endcaps_v01_LARGE.xml"/>
+  <include ref="../ILD_common_v02/SHcalSc04_EndcapRing_v01.xml"/>
+  <include ref="../ILD_common_v02/Yoke05_Barrel.xml"/>
+  <include ref="../ILD_common_v02/Yoke06_Endcaps.xml"/>
+  <include ref="../ILD_common_v02/coil03.xml"/>
+  <include ref="../ILD_common_v02/SServices01.xml"/>
 
   <plugins>
     <plugin name="DD4hepVolumeManager"/>


### PR DESCRIPTION
Accidentally commented and merged in an previous change

To ease the review process, please consider the following before opening a pull request:
- [ ] the code is sufficiently well documented (e.g. inline comments)
- [ ] the relevant README(s) were updated. See e.g. https://github.com/key4hep/k4geo/blob/main/detector/calorimeter/README.md or https://github.com/key4hep/k4geo/blob/main/FCCee/IDEA/compact/README.md
- [ ] the code is covered by tests. See https://github.com/key4hep/k4geo/blob/main/test/CMakeLists.txt
- [ ] the PR source branch has been rebased (`--ff-only`) to `k4geo/main`
- [ ] the PR does not contain any additions or modifications that do not belong to it
- [ ] The release notes below contain a succinct and comprehensive description of the changes that are sufficiently self-explanatory

If you are modifying detector dimensions or adding new xml parameters, also consider the following:
- [ ] the xml file free parameters that can not be modified without additional prescriptions are well indicated
- [ ] the changes in this PR have not introduced any overlaps. You can check so with the following command: `ddsim --compactFile PATH_TO_COMPACT_FILE --runType run --ui.commandsInitialize "/geometry/test/run" > overlapDump.txt`

BEGINRELEASENOTES
- Revert changes introduced in [#570](https://github.com/key4hep/k4geo/pull/570) that removed the majority of the components from `ILD_FCCee_v01`

ENDRELEASENOTES

