### PR TITLE
Extend magnetic field to full tracker volume

### DIFF
--- a/FCCee/IDEA/compact/IDEA_o1_v03/IDEA_o1_v03.xml
+++ b/FCCee/IDEA/compact/IDEA_o1_v03/IDEA_o1_v03.xml
@@ -92,7 +92,7 @@
     <field name="GlobalSolenoid" type="solenoid"
            inner_field="SolenoidField"
            outer_field="-1.7*tesla"
-           zmax="Solenoid_Coil_half_length"
+           zmax="FiberDRCalo_endcap_z_start * 1.1"
            outer_radius="Solenoid_Coil_radius">
     </field>
 

--- a/FCCee/IDEA/compact/IDEA_o1_v03/IDEA_o1_v03.xml
+++ b/FCCee/IDEA/compact/IDEA_o1_v03/IDEA_o1_v03.xml
@@ -92,7 +92,7 @@
     <field name="GlobalSolenoid" type="solenoid"
            inner_field="SolenoidField"
            outer_field="-1.7*tesla"
-           zmax="FiberDRCalo_endcap_z_start * 1.1"
+           zmax="Solenoid_Coil_half_length"
            outer_radius="Solenoid_Coil_radius">
     </field>
 

--- a/FCCee/IDEA/compact/IDEA_o1_v03/IDEA_o1_v03.xml
+++ b/FCCee/IDEA/compact/IDEA_o1_v03/IDEA_o1_v03.xml
@@ -92,7 +92,7 @@
     <field name="GlobalSolenoid" type="solenoid"
            inner_field="SolenoidField"
            outer_field="-1.7*tesla"
-           zmax="Solenoid_Coil_half_length"
+           zmax="1.2 * Solenoid_Coil_half_length"
            outer_radius="Solenoid_Coil_radius">
     </field>
 

--- a/FCCee/IDEA/compact/IDEA_o1_v04/IDEA_o1_v04.xml
+++ b/FCCee/IDEA/compact/IDEA_o1_v04/IDEA_o1_v04.xml
@@ -92,7 +92,7 @@
     <field name="GlobalSolenoid" type="solenoid"
            inner_field="SolenoidField"
            outer_field="-1.7*tesla"
-           zmax="Solenoid_Coil_half_length"
+           zmax="1.2 * Solenoid_Coil_half_length"
            outer_radius="Solenoid_Coil_radius">
     </field>
 

--- a/FCCee/IDEA/compact/IDEA_o2_v01/IDEA_o2_v01.xml
+++ b/FCCee/IDEA/compact/IDEA_o2_v01/IDEA_o2_v01.xml
@@ -82,7 +82,7 @@
     <field name="GlobalSolenoid" type="solenoid"
            inner_field="SolenoidField"
            outer_field="-1.7*tesla"
-           zmax="Solenoid_Coil_half_length"
+           zmax="1.2 * Solenoid_Coil_half_length"
            outer_radius="Solenoid_Coil_radius">
     </field>
 


### PR DESCRIPTION
BEGINRELEASENOTES
- Update the z boundary of the magnetic field definition from `Solenoid_Coil_half_length` to `1.2 * Solenoid_Coil_half_length`

ENDRELEASENOTES

Hello all!
This pull request extends the magnetic field map currently used in IDEA v3 o1 to cover the full tracker volume. In the current implementation, the magnetic field returns zero in the endcap region of the silicon wrapper.
This modification is necessary to ensure consistent track propagation from the last hit in the tracker to the calorimeter surface. This step is performed by the track fitter, which checks the magnetic field value at the last hit before propagating the track. If the field value is zero or invalid, the propagation is skipped, because it should occur only for tracks outside the tracker, that do not require propagation to the inner calorimeter surface.
Furthermore, the magnetic field value directly affects the estimation of track parameters at the last track state. Ensuring a consistent field in the endcap region therefore improves the reliability of the reconstructed track parameters.

Thank you!
Andrea