### PR TITLE
Fix position calculation for FCCSWHCalPhi[Theta,Row]_k4geo.

### DIFF
--- a/FCCee/ALLEGRO/compact/ALLEGRO_o1_v03/HCalBarrel_TileCal_v03.xml
+++ b/FCCee/ALLEGRO/compact/ALLEGRO_o1_v03/HCalBarrel_TileCal_v03.xml
@@ -92,6 +92,9 @@
            dz_row - size of the row consisting of 2 * Master plate + 1 * Spacer plate + 1 * Scintillator + Air.
            phi_bins - number of bins in phi
            offset_phi - center of the first phi bin.
+           [even,odd]_vol_offset - offset in z of the center of the sensitive
+             volume within a row, for even (sequence_a) and odd (sequence_b)
+             layers
       -->
       <segmentation type="FCCSWHCalPhiRow_k4geo" 
          detLayout="0"
@@ -104,7 +107,10 @@
          grouped_rows=""
          dz_row="2*BarHCal_master_plate_thickness + BarHCal_spacer_plate_thickness + BarHCal_scintillator_thickness + 2*BarHCal_air_space_thickness"
          phi_bins="BarHCal_n_phi_modules"
-         offset_phi="-pi+(pi/BarHCal_n_phi_modules)"/>
+         offset_phi="-pi+(pi/BarHCal_n_phi_modules)"
+         even_vol_offset="2*BarHCal_master_plate_thickness + BarHCal_spacer_plate_thickness + BarHCal_air_space_thickness + BarHCal_scintillator_thickness/2"
+         odd_vol_offset="BarHCal_master_plate_thickness + BarHCal_air_space_thickness + BarHCal_scintillator_thickness/2"
+         />
       <id>system:4,layer:5,row:9,phi:10</id>
     </readout>
   </readouts>

--- a/FCCee/ALLEGRO/compact/ALLEGRO_o1_v03/HCalEndcaps_ThreeParts_TileCal_v03.xml
+++ b/FCCee/ALLEGRO/compact/ALLEGRO_o1_v03/HCalEndcaps_ThreeParts_TileCal_v03.xml
@@ -100,6 +100,9 @@
            dz_row - size of the row consisting of 2 * Master plate + 1 * Spacer plate + 1 * Scintillator + Air.
            phi_bins - number of bins in phi
            offset_phi - center of the first phi bin.
+           [even,odd]_vol_offset - offset in z of the center of the sensitive
+             volume within a row, for even (sequence_b) and odd (sequence_a)
+             layers
       -->
       <segmentation type="FCCSWHCalPhiRow_k4geo" 
          detLayout="1"
@@ -112,7 +115,10 @@
          grouped_rows=""
          dz_row="2*EndcapHCal_master_plate_thickness + EndcapHCal_spacer_plate_thickness + EndcapHCal_scintillator_thickness + 2*EndcapHCal_air_space_thickness" 
          phi_bins="EndcapHCal_n_phi_modules" 
-         offset_phi="-pi+(pi/EndcapHCal_n_phi_modules)"/>
+         offset_phi="-pi+(pi/EndcapHCal_n_phi_modules)"
+         even_vol_offset="EndcapHCal_master_plate_thickness + EndcapHCal_air_space_thickness + EndcapHCal_scintillator_thickness/2"
+         odd_vol_offset="2*EndcapHCal_master_plate_thickness + EndcapHCal_spacer_plate_thickness + EndcapHCal_air_space_thickness + EndcapHCal_scintillator_thickness/2"
+         />
       <id>system:4,type:3,layer:6,pseudoLayer:8,row:-8,phi:10</id>
     </readout>
   </readouts>

--- a/detector/calorimeter/HCalTileBarrel_o1_v02_geo.cpp
+++ b/detector/calorimeter/HCalTileBarrel_o1_v02_geo.cpp
@@ -163,7 +163,7 @@ static dd4hep::Ref_t createHCal(dd4hep::Detector& lcdd, xml_det_t xmlDet, dd4hep
     dd4hep::printout(dd4hep::INFO, "HCalTileBarrel_o1_v02", "layer %d (cm): %.2f - %.2f", idxLayer, rminLayer,
                      rmaxLayer);
 
-    // alternate: even layers consist of tile sequence b, odd layer of tile sequence a
+    // alternate: even layers consist of tile sequence a, odd layer of tile sequence b
     unsigned int sequenceIdx = idxLayer % 2;
 
     dd4hep::Tube tileSequenceShape(rminLayer, rmaxLayer, 0.5 * dzSequence);

--- a/detectorSegmentations/include/detectorSegmentations/FCCSWHCalPhiRow_k4geo.h
+++ b/detectorSegmentations/include/detectorSegmentations/FCCSWHCalPhiRow_k4geo.h
@@ -271,6 +271,14 @@ namespace DDSegmentation {
       return {cellSize0, cellSize1};
     }
 
+    /// Determine the volume ID containing a cellID.
+    virtual VolumeID volumeID(const CellID& cellID) const override;
+
+    /// Return true if this segmentation can have cells that span multiple
+    /// volumes.  That is, points from multiple distinct volumes may
+    /// be assigned to the same cell.
+    virtual bool cellsSpanVolumes() const override { return true; }
+
   private:
     /// the number of bins in phi
     int m_phiBins;
@@ -302,6 +310,12 @@ namespace DDSegmentation {
     std::vector<int> m_numLayers;
     /// dR of the layer
     std::vector<double> m_dRlayer;
+    /// Offset in z of the center of the sensitive volume within a row
+    /// for even layers.  (sequence_a for barrel, sequence_b for endcap.)
+    double m_evenVolOffset;
+    /// Offset in z of the center of the sensitive volume within a row
+    /// for odd layers.  (sequence_b for barrel, sequence_a for endcap.)
+    double m_oddVolOffset;
 
     /// Initialization common to all ctors.
     void commonSetup();
@@ -318,6 +332,9 @@ namespace DDSegmentation {
 
     // Derived geometrical information about each layer.
     struct LayerInfo {
+      /// Type/section of the layer (only relevant for endcap).
+      unsigned int type = 0;
+
       /// Radius of the layer.
       double radius = 1;
 
@@ -327,6 +344,9 @@ namespace DDSegmentation {
       /// z-min and z-max of the layer
       double zmin = 0;
       double zmax = 0;
+
+      /// z-offset between cell centers and volume centers.
+      double zOffset = 0;
 
       /// cell indexes in each layer
       std::vector<int> cellIndexes{};

--- a/detectorSegmentations/include/detectorSegmentations/FCCSWHCalPhiTheta_k4geo.h
+++ b/detectorSegmentations/include/detectorSegmentations/FCCSWHCalPhiTheta_k4geo.h
@@ -31,9 +31,10 @@ namespace DDSegmentation {
     /// Default constructor used by derived classes passing an existing decoder
     FCCSWHCalPhiTheta_k4geo(const BitFieldCoder* decoder);
 
-    /**  Get the postion of the geometric center of the cell based on the cellID
+    /**  Get the position of the geometric center of the cell based on the cellID
      *   @param[in] aCellID
-     *   return the global coordinates of cell center
+     *   return the cell center in the local coordinate system of the
+     *   associated dd4hep volume
      */
     virtual Vector3D position(const CellID& aCellID) const override;
 
@@ -219,6 +220,14 @@ namespace DDSegmentation {
       return {cellSize0, cellSize1};
     }
 
+    /// Determine the volume ID containing a cellID.
+    virtual VolumeID volumeID(const CellID& cellID) const override;
+
+    /// Return true if this segmentation can have cells that span multiple
+    /// volumes.  That is, points from multiple distinct volumes may
+    /// be assigned to the same cell.
+    virtual bool cellsSpanVolumes() const override { return true; }
+
   private:
     /// determine the azimuthal angle phi based on the current cell ID
     double phi() const;
@@ -245,6 +254,8 @@ namespace DDSegmentation {
 
     /// Initialization common to all ctors.
     void commonSetup();
+    /// the field index used for system
+    int m_systemIndex = -1;
     /// the field index used for layer
     int m_layerIndex = -1;
     /// the field index used for row
@@ -271,7 +282,8 @@ namespace DDSegmentation {
       /// theta bins (cells) in the layer
       std::vector<int> thetaBins{};
 
-      /// Information about each theta bin in the layer: z-min and z-max
+      /// Information about each theta bin in the layer: z-min and z-max,
+      // as well as the containing dd4hep volume ID and its z-center.
       // For the barrel, we store this in the m_cellInfo1 vector;
       // the first entry of the vector corresponds to bin number m_ibin1.
       // For the endcap, we have two disjoint bin ranges, corresponding
@@ -291,7 +303,15 @@ namespace DDSegmentation {
 
       struct CellInfo {
         CellInfo(double lo, double hi) : edge{lo, hi} {}
+
+        // Cell edges.
         Edge edge{0, 0};
+
+        // The ID of the dd4hep volume containing this cell.
+        VolumeID volumeID{0};
+
+        // The z-center of the dd4hep volume.
+        double volumeZ{0};
       };
       std::vector<CellInfo> m_cellInfo1{};
       std::vector<CellInfo> m_cellInfo2{};
@@ -340,6 +360,12 @@ namespace DDSegmentation {
      *   @param[in] layer index
      */
     void defineCellEdges(LayerInfo& li, const unsigned int layer) const;
+
+    /**  Define mapping between cells and dd4hep volumes.
+     *
+     *   Fills in the volumeID and volumeZ fields of cellInfo.
+     */
+    void defineVolIDMappings(LayerInfo& li, const unsigned int layer) const;
 
     // Check consistency of input geometric variables.
     bool checkParameters() const;

--- a/detectorSegmentations/src/FCCSWHCalPhiRow_k4geo.cpp
+++ b/detectorSegmentations/src/FCCSWHCalPhiRow_k4geo.cpp
@@ -15,7 +15,7 @@ namespace DDSegmentation {
   void FCCSWHCalPhiRow_k4geo::commonSetup() {
     // define type and description
     _type = "FCCSWHCalPhiRow_k4geo";
-    _description = "Phi-theta segmentation in the global coordinates";
+    _description = "Phi-row segmentation for HCal";
 
     // register all necessary parameters
     registerParameter("phi_bins", "Number of bins phi", m_phiBins, 1);
@@ -73,7 +73,7 @@ namespace DDSegmentation {
     // pseudo-layers. Need to adjust the cell position:
     if (m_detLayout == 1 && !m_groupedRows.empty()) {
       int aidx = std::abs(idx);
-      zpos += 0.5 * m_dz_row * (li.groupedRows[aidx - 1] - m_gridSizeRow.at(layer));
+      zpos += 0.5 * m_dz_row * li.groupedRows[aidx - 1];
     }
 
     if (idx < 0) {
@@ -127,7 +127,9 @@ namespace DDSegmentation {
       // i_section to be grouped in a pseudo-layer.
       auto groupedRows_start = m_groupedRows.begin();
       auto groupedRows_end = m_groupedRows.end();
+      bool grouped = false;
       if (m_detLayout == 1 && !m_groupedRows.empty()) {
+        grouped = true;
         size_t nGroupedRows = m_groupedRows.size() / m_offsetZ.size();
         groupedRows_start = m_groupedRows.begin() + i_section * nGroupedRows;
         groupedRows_end = (i_section == m_offsetZ.size() - 1) ? m_groupedRows.end() : groupedRows_start + nGroupedRows;
@@ -141,7 +143,13 @@ namespace DDSegmentation {
         for (int i_lay = 0; i_lay < m_numLayers.at(i_dR + i_section * N_dR); i_lay++) {
 
           double volOffset = (layerInSection % 2) ? m_oddVolOffset : m_evenVolOffset;
-          double zOffset = m_dz_row * m_gridSizeRow.at(out.size()) * 0.5 - volOffset;
+          double zOffset = - volOffset;
+          if (!grouped) {
+            // Offset to middle of cell for this layer.
+            // But if we're using groupedRows, then this is row-dependent,
+            // and we apply this instead in position().
+            zOffset += m_dz_row * m_gridSizeRow.at(out.size()) * 0.5;
+          }
 
           moduleDepth[i_section] += m_dRlayer.at(i_dR);
           out.push_back(LayerInfo{.type = i_section,
@@ -805,9 +813,10 @@ namespace DDSegmentation {
     // For the endcap, we need to fill in the type field.  For the negative
     // endcap, types are offset by three, and we also need to make the row
     // index positive.
+    const LayerInfo* li = nullptr;
     if (m_detLayout == 1) {
-      const LayerInfo& li = getLayerInfo(layer);
-      int type = li.type;
+      li = &getLayerInfo(layer);
+      int type = li->type;
       if (irow < 0) {
         irow = -irow;
         type += 3;
@@ -819,11 +828,10 @@ namespace DDSegmentation {
     // volume indices start with 0!
     int vrow = 0;
     if (m_detLayout == 1 && !m_groupedRows.empty()) {
-      const LayerInfo& li = getLayerInfo(layer);
-
-      // Rows grouped according to groupedRows rather than by grid_size_row
+      // Rows grouped according to groupedRows rather than by gridSizeRow.
+      // li was fetched in the stanza above.
       for (size_t i = 1; i < static_cast<size_t>(irow); i++)
-        vrow += li.groupedRows[i - 1];
+        vrow += li->groupedRows[i - 1];
     } else {
       // Normal case.
       vrow = (irow - 1) * m_gridSizeRow.at(layer);

--- a/detectorSegmentations/src/FCCSWHCalPhiRow_k4geo.cpp
+++ b/detectorSegmentations/src/FCCSWHCalPhiRow_k4geo.cpp
@@ -143,7 +143,7 @@ namespace DDSegmentation {
         for (int i_lay = 0; i_lay < m_numLayers.at(i_dR + i_section * N_dR); i_lay++) {
 
           double volOffset = (layerInSection % 2) ? m_oddVolOffset : m_evenVolOffset;
-          double zOffset = - volOffset;
+          double zOffset = -volOffset;
           if (!grouped) {
             // Offset to middle of cell for this layer.
             // But if we're using groupedRows, then this is row-dependent,

--- a/detectorSegmentations/src/FCCSWHCalPhiRow_k4geo.cpp
+++ b/detectorSegmentations/src/FCCSWHCalPhiRow_k4geo.cpp
@@ -29,6 +29,12 @@ namespace DDSegmentation {
     registerParameter("numLayers", "Number of layers", m_numLayers, std::vector<int>());
     registerParameter("dRlayer", "dR of the layer", m_dRlayer, std::vector<double>());
     registerParameter("grouped_rows", "Number of rows combined in a pseudo-layer", m_groupedRows, std::vector<int>());
+    registerParameter("even_vol_offset",
+                      "Offset in z of the center of the sensitive volume within a row for even layers", m_evenVolOffset,
+                      0.);
+    registerParameter("odd_vol_offset", "Offset in z of the center of the sensitive volume within a row for odd layers",
+                      m_oddVolOffset, 0.);
+
     registerIdentifier("identifier_phi", "Cell ID identifier for phi", m_phiID, "phi");
     registerIdentifier("identifier_row", "Cell ID identifier for row", m_rowID, "row");
     registerIdentifier("identifier_layer", "Cell ID identifier for layer", m_layerID, "layer");
@@ -56,26 +62,23 @@ namespace DDSegmentation {
     const LayerInfo& li = getLayerInfo(layer);
 
     double radius = li.radius;
-    double minLayerZ = li.zmin;
 
     // get index of the cell in the layer (index starts from 1!)
     int idx = decoder()->get(cID, m_rowIndex);
     // calculate z-coordinate of the cell center
-    double zpos = minLayerZ + (idx - 1) * m_dz_row * m_gridSizeRow[layer] + 0.5 * m_dz_row * m_gridSizeRow[layer];
-
-    // for negative-z Endcap, the index is negative (starts from -1!)
-    if (idx < 0)
-      zpos = -minLayerZ + (idx + 1) * m_dz_row * m_gridSizeRow[layer] - 0.5 * m_dz_row * m_gridSizeRow[layer];
+    // Should be relative to the center of the first volume of the row.
+    double zpos = li.zOffset;
 
     // If this is the Endcap and m_groupedRows is provided from the xml file, then rows are grouped to the
-    // pseudo-layers. Need to recalculate the cell position:
+    // pseudo-layers. Need to adjust the cell position:
     if (m_detLayout == 1 && !m_groupedRows.empty()) {
-      int nrows = 0;
-      for (size_t i = 0; i < static_cast<size_t>(std::abs(idx)); i++)
-        nrows += li.groupedRows[i];
-      zpos = minLayerZ + nrows * m_dz_row - 0.5 * li.groupedRows[abs(idx) - 1] * m_dz_row;
-      if (idx < 0)
-        zpos = -zpos;
+      int aidx = std::abs(idx);
+      zpos += 0.5 * m_dz_row * (li.groupedRows[aidx - 1] - m_gridSizeRow.at(layer));
+    }
+
+    if (idx < 0) {
+      // for negative-z Endcap, the index is negative (starts from -1!)
+      zpos = -zpos;
     }
 
     return Vector3D(radius * std::cos(phi(cID)), radius * std::sin(phi(cID)), zpos);
@@ -130,17 +133,26 @@ namespace DDSegmentation {
         groupedRows_end = (i_section == m_offsetZ.size() - 1) ? m_groupedRows.end() : groupedRows_start + nGroupedRows;
       }
 
+      int layerInSection = 0;
+
       // Loop over groups of layers.
       for (uint i_dR = 0; i_dR < N_dR; i_dR++) {
         // Loop over individual layers.
-        for (int i_lay = 0; i_lay < m_numLayers[i_dR + i_section * N_dR]; i_lay++) {
-          moduleDepth[i_section] += m_dRlayer[i_dR];
-          out.push_back(LayerInfo{.radius = moduleDepth[i_section] - m_dRlayer[i_dR] * 0.5,
-                                  .halfDepth = m_dRlayer[i_dR] / 2,
+        for (int i_lay = 0; i_lay < m_numLayers.at(i_dR + i_section * N_dR); i_lay++) {
+
+          double volOffset = (layerInSection % 2) ? m_oddVolOffset : m_evenVolOffset;
+          double zOffset = m_dz_row * m_gridSizeRow.at(out.size()) * 0.5 - volOffset;
+
+          moduleDepth[i_section] += m_dRlayer.at(i_dR);
+          out.push_back(LayerInfo{.type = i_section,
+                                  .radius = moduleDepth.at(i_section) - m_dRlayer.at(i_dR) * 0.5,
+                                  .halfDepth = m_dRlayer.at(i_dR) / 2,
                                   .zmin = zmin,
                                   .zmax = zmax,
+                                  .zOffset = zOffset,
                                   .groupedRows = std::span<const int>(std::to_address(groupedRows_start),
                                                                       std::to_address(groupedRows_end))});
+          ++layerInSection;
         }
       }
     }
@@ -777,6 +789,48 @@ namespace DDSegmentation {
     double thetaMin = std::atan2(Rmin, zhigh); // theta min
 
     return (M_PI - thetaMin); // theta max
+  }
+
+  // Determine the volume ID containing a cellID.
+  VolumeID FCCSWHCalPhiRow_k4geo::volumeID(const CellID& cID) const {
+    VolumeID vID = cID;
+
+    // Null out the phi index.
+    decoder()->set(vID, m_phiIndex, 0);
+
+    // Get layer and row.
+    uint layer = decoder()->get(cID, m_layerIndex);
+    int irow = decoder()->get(vID, m_rowIndex);
+
+    // For the endcap, we need to fill in the type field.  For the negative
+    // endcap, types are offset by three, and we also need to make the row
+    // index positive.
+    if (m_detLayout == 1) {
+      const LayerInfo& li = getLayerInfo(layer);
+      int type = li.type;
+      if (irow < 0) {
+        irow = -irow;
+        type += 3;
+      }
+      decoder()->set(vID, m_typeIndex, type);
+    }
+
+    // Calculate the volume row.  Careful --- cell indices start with 1,
+    // volume indices start with 0!
+    int vrow = 0;
+    if (m_detLayout == 1 && !m_groupedRows.empty()) {
+      const LayerInfo& li = getLayerInfo(layer);
+
+      // Rows grouped according to groupedRows rather than by grid_size_row
+      for (size_t i = 1; i < static_cast<size_t>(irow); i++)
+        vrow += li.groupedRows[i - 1];
+    } else {
+      // Normal case.
+      vrow = (irow - 1) * m_gridSizeRow.at(layer);
+    }
+    decoder()->set(vID, m_rowIndex, vrow);
+
+    return vID;
   }
 
 } // namespace DDSegmentation

--- a/detectorSegmentations/src/FCCSWHCalPhiTheta_k4geo.cpp
+++ b/detectorSegmentations/src/FCCSWHCalPhiTheta_k4geo.cpp
@@ -21,7 +21,7 @@ namespace DDSegmentation {
   void FCCSWHCalPhiTheta_k4geo::commonSetup() {
     // define type and description
     _type = "FCCSWHCalPhiTheta_k4geo";
-    _description = "Phi-theta segmentation in the global coordinates";
+    _description = "Phi-theta segmentation for HCal";
 
     // register all necessary parameters (additional to those registered in GridTheta_k4geo)
     registerParameter("phi_bins", "Number of bins phi", m_phiBins, 1);

--- a/detectorSegmentations/src/FCCSWHCalPhiTheta_k4geo.cpp
+++ b/detectorSegmentations/src/FCCSWHCalPhiTheta_k4geo.cpp
@@ -1,5 +1,8 @@
 #include "detectorSegmentations/FCCSWHCalPhiTheta_k4geo.h"
+#include "DD4hep/Detector.h"
 #include "DD4hep/Printout.h"
+#include "DD4hep/VolumeManager.h"
+#include "DD4hep/detail/DetectorInterna.h"
 #include <ranges>
 
 namespace dd4hep {
@@ -32,6 +35,7 @@ namespace DDSegmentation {
     registerIdentifier("identifier_phi", "Cell ID identifier for phi", m_phiID, "phi");
     registerIdentifier("identifier_layer", "Cell ID identifier for layer", m_layerID, "layer");
 
+    m_systemIndex = decoder()->index("system");
     m_layerIndex = decoder()->index(m_layerID);
     m_rowIndex = decoder()->index("row");
     m_thetaIndex = decoder()->index(fieldNameTheta());
@@ -47,19 +51,17 @@ namespace DDSegmentation {
   }
 
   /// determine the global position based on the cell ID
-  /// returns the geometric center of the cell
+  /// returns the geometric center of the cell in the local coordinate
+  /// system of the associated dd4hep volume
   Vector3D FCCSWHCalPhiTheta_k4geo::position(const CellID& cID) const {
     uint layer = decoder()->get(cID, m_layerIndex);
     int thetaID = decoder()->get(cID, m_thetaIndex);
 
     const LayerInfo& li = getLayerInfo(layer);
-    double radius = li.radius;
-    const LayerInfo::Edge& edge = li.cellInfo(thetaID).edge;
-    double zpos = (edge.low + edge.high) * 0.5;
+    const LayerInfo::CellInfo& ci = li.cellInfo(thetaID);
+    double zpos = (ci.edge.low + ci.edge.high) * 0.5 - ci.volumeZ;
 
-    auto pos = positionFromRThetaPhi(radius, theta(cID), phi(cID));
-
-    // return the position with corrected z coordinate to match to the geometric center
+    auto pos = positionFromRThetaPhi(li.radius, theta(cID), phi(cID));
     return Vector3D(pos.x(), pos.y(), zpos);
   }
 
@@ -121,11 +123,13 @@ namespace DDSegmentation {
     // determine theta bins and cell edges for each layer
     for (uint i_layer = 0; LayerInfo& li : out) {
       defineCellEdges(li, i_layer);
+      defineVolIDMappings(li, i_layer);
       ++i_layer;
     }
     return out;
   }
 
+  // Define cell edges in z-axis for the given layer.
   void FCCSWHCalPhiTheta_k4geo::defineCellEdges(LayerInfo& li, const unsigned int layer) const {
     // Helper to find the z-coordinate corresponding to a theta bin number.
     auto binToZ = [&](int ibin) {
@@ -137,7 +141,7 @@ namespace DDSegmentation {
     // <--- start from theta bin outside the HCal theta range
     int ibin = positionToBin(0.02, gridSizeTheta(), offsetTheta());
     // Go in increasing theta bin number, which corresponds to a
-    // decreasing z-coordinate.  So we start remembering bin numbesr
+    // decreasing z-coordinate.  So we start remembering bin numbers
     // once the z-coordinate is less than the maximum and stop once the
     // z-coordinate is less than the minimum.
     for (;; ++ibin) {
@@ -208,6 +212,122 @@ namespace DDSegmentation {
       const LayerInfo::Edge& edge = li.cellInfo(bin).edge;
       dd4hep::printout(dd4hep::DEBUG, "FCCSWHCalPhiTheta_k4geo", "Layer %d cell theta bin: %d, edges: %.2f - %.2f cm",
                        layer, bin, edge.low, edge.high);
+    }
+  }
+
+  // Define mapping between cells and dd4hep volumes.
+  void FCCSWHCalPhiTheta_k4geo::defineVolIDMappings(LayerInfo& li, const unsigned int layer) const {
+    // Get information from dd4hep.
+    dd4hep::Detector* dd4hepgeo = &(dd4hep::Detector::getInstance());
+    const DetElementObject& de = *dd4hepgeo->readout(this->name()).segmentation().detector();
+    VolumeManager vman_glob = VolumeManager::getVolumeManager(*dd4hepgeo);
+    VolumeManager vman = vman_glob.subdetector(de.id);
+
+    // Process a contiguous set of theta bins.
+    // zmin is the minimum z-coordinate of the range.
+    // layernum is the dd4hep layer number (different from the layer number
+    // used in the segmentation).
+    // thetaBins is the set of bins to process.
+    auto scanRows = [&](double zmin, int layernum, std::span<const int> thetaBins) {
+      // Find the DetectorElement corresponding to the layer.
+      auto layer_it = de.children.find("layer" + std::to_string(layernum));
+      if (layer_it == de.children.end()) {
+        std::abort();
+      }
+
+      // Number of volumes (rows) to process.
+      size_t nrows = layer_it->second.children().size();
+
+      // Fill in the fields of a VolumeID.
+      VolumeID vID = 0;
+      decoder()->set(vID, m_systemIndex, de.id);
+      dd4hep::PlacedVolume placement = layer_it->second.placement();
+      for (const auto& [name, val] : placement.volIDs()) {
+        decoder()->set(vID, name, val);
+      }
+
+      // We are going to step through each volume in order of increasing z.
+      // In the barrel and positive endcap, this corresponds to increasing
+      // row index, but the other way around in the negative endcap.
+      // We are going to match the volumes with cells.  However, increasing
+      // cell indexes correspond to decreasing
+      // z position, so we step through the cell list in reverse order,
+      // to also get them in order of increasing z.
+      // We keep track of the cell we're looking at in itbin and its edges
+      // in edges.  For each cell, we examine all the rows with center
+      // within the cell and choose the one that's closest to the center
+      // of the cell.
+
+      // Iterator of the cell we're looking at.  Start off of the end.
+      auto itbin = thetaBins.end();
+
+      // Edges of the cell we're looking it.  Start with an empty cell.
+      LayerInfo::Edge edge{zmin, zmin};
+
+      // The z-position of the row which is so far closest to the
+      // center of the cell.
+      double last_zpos = zmin - 100;
+
+      // Step through rows.  In increasing order in the barrel/positive endcap,
+      // in decreasing order in the negative endcap.  In all cases, this
+      // corresponds to increasing z.
+      for (size_t ir0 = 0; ir0 < nrows; ++ir0) {
+        int ir = ir0;
+        if (m_detLayout == 1 && zmin < 0)
+          ir = nrows - 1 - ir;
+
+        // Make the volume ID for this row and find the position of its center.
+        decoder()->set(vID, m_rowIndex, ir);
+        VolumeManagerContext* vc = vman.lookupContext(vID);
+        double zpos = vc->localToWorld({0, 0, 0}).Z();
+
+        if (zpos < edge.low)
+          continue; // We haven't gotten to the current cell yet.
+
+        if (zpos > edge.high) {
+          // We've moved past the current cell.  Stop if we've reached the end;
+          // otherwise move to the next cell.
+          if (itbin == thetaBins.begin())
+            break;
+          --itbin;
+
+          // Check that this cell matches the row.
+          edge = li.cellInfo(*itbin).edge;
+          if (zpos < edge.low)
+            continue;
+          if (zpos > edge.high)
+            break;
+
+          // Initialize the information for this cell from this row.
+          // We'll update later if we find another row closer to the center.
+          li.cellInfo(*itbin).volumeID = vID;
+          li.cellInfo(*itbin).volumeZ = zpos;
+          last_zpos = zpos;
+        } else {
+          // We found another row matching the current cell.
+          // See if it closer to the cell center than the last row we saw.
+          // If so, update.
+          assert(itbin != thetaBins.end());
+          double center = (edge.low + edge.high) / 2;
+          if (std::abs(zpos - center) < std::abs(last_zpos - center)) {
+            li.cellInfo(*itbin).volumeID = vID;
+            li.cellInfo(*itbin).volumeZ = zpos;
+            last_zpos = zpos;
+          }
+        }
+      }
+    };
+
+    // Process the ranges of bins.
+    if (m_detLayout == 0) {
+      // Barrel
+      scanRows(li.zmin, layer, li.thetaBins);
+    } else {
+      // positive endcap
+      scanRows(li.zmin, layer + 1, std::ranges::take_view(li.thetaBins, li.thetaBins.size() / 2));
+
+      // negative endcap
+      scanRows(-li.zmax, -(layer + 1), std::ranges::drop_view(li.thetaBins, li.thetaBins.size() / 2));
     }
   }
 
@@ -781,6 +901,14 @@ namespace DDSegmentation {
     }
 
     return cTheta;
+  }
+
+  // Determine the volume ID containing a cellID.
+  VolumeID FCCSWHCalPhiTheta_k4geo::volumeID(const CellID& cID) const {
+    uint layer = decoder()->get(cID, m_layerIndex);
+    int thetaID = decoder()->get(cID, m_thetaIndex);
+    const LayerInfo& li = getLayerInfo(layer);
+    return li.cellInfo(thetaID).volumeID;
   }
 
 } // namespace DDSegmentation


### PR DESCRIPTION
The position() method for a segmentation should return a position in the
local coordinate system of the associated dd4hep volume in order for ddsim
to set the position properly.  Do this for FCCSWHCalPhi[Theta,Row]_k4geo.
It's a little complicated because the theta cell binning doesn't
correspond in any simple way with the dd4hep volumes; add information
on the correspondence to the CellInfo structure.

Verified that this does not change the reconstructed positions, and with
this change, the positions of the hits output by simulation match
the reconstructed cell positions.

This is similar to what was already done for the Allegro ECal barrel.

BEGINRELEASENOTES
- Fix position calculations for Allegro HCal segmentations so that the positions are correct on the hits output by the simulation.
ENDRELEASENOTES

