### PR TITLE
Fix an out of bounds access in `CaloEndcapDiscs_o1_v01_geo.cpp`

### DIFF
--- a/detector/calorimeter/CaloEndcapDiscs_o1_v01_geo.cpp
+++ b/detector/calorimeter/CaloEndcapDiscs_o1_v01_geo.cpp
@@ -91,8 +91,8 @@ void buildOneSide(dd4hep::Detector& aLcdd, dd4hep::SensitiveDetector& aSensDet, 
   std::vector<double> layerThickness;
   std::vector<dd4hep::Cone> layerEnvelopes;
   std::vector<double> layerRmin;
-  layerThickness.reserve(numLayers);
-  layerRmin.reserve(numLayers + 1);
+  layerThickness.resize(numLayers);
+  layerRmin.resize(numLayers + 1);
   for (uint iLayerSize = 0; iLayerSize < layerHeight.size(); iLayerSize++) {
     if (iLayerSize == 0) {
       layerThickness[0] = unitLayerThicknessFirst + (layerHeight[0] - 1) * unitLayerThickness;

--- a/detector/calorimeter/CaloEndcapDiscs_o1_v01_geo.cpp
+++ b/detector/calorimeter/CaloEndcapDiscs_o1_v01_geo.cpp
@@ -88,11 +88,9 @@ void buildOneSide(dd4hep::Detector& aLcdd, dd4hep::SensitiveDetector& aSensDet, 
   // create envelope layers
   double unitLayerThicknessFirst = marginOutside + readoutThickness + activeThickness / 2.;
   double unitLayerThickness = readoutThickness + activeThickness + passiveThickness;
-  std::vector<double> layerThickness;
+  std::vector<double> layerThickness(numLayers);
   std::vector<dd4hep::Cone> layerEnvelopes;
-  std::vector<double> layerRmin;
-  layerThickness.resize(numLayers);
-  layerRmin.resize(numLayers + 1);
+  std::vector<double> layerRmin(numLayers + 1);
   for (uint iLayerSize = 0; iLayerSize < layerHeight.size(); iLayerSize++) {
     if (iLayerSize == 0) {
       layerThickness[0] = unitLayerThicknessFirst + (layerHeight[0] - 1) * unitLayerThickness;


### PR DESCRIPTION
BEGINRELEASENOTES
- Fix an out of bounds access in `CaloEndcapDiscs_o1_v01_geo.cpp` by creating the vectors with the correct number of elements, to make sure the vector has enough elements.

ENDRELEASENOTES

This has been wrong for several years and in debug builds it triggers an assertion since, for example, the first element of `layerThickness` is being accessed when the vector is empty. I don't know if anything will change. `ALLEGRO_o1_v02` is affected.