### PR TITLE
Added a missing geo in CMakeList for LCIO

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,6 +91,7 @@ if(NOT K4GEO_USE_LCIO)
     TrackerBarrel_o1_v06_geo.cpp
     TrackerEndcap_o1_v05_geo.cpp
     TrackerEndcap_o2_v06_geo.cpp
+    TrackerEndcap_o2_v07_geo.cpp
     StrawTubeTracker_o1_v01_geo.cpp
     VertexBarrel_detailed_o1_v01_geo.cpp
     VertexEndcap_o1_v05_geo.cpp


### PR DESCRIPTION
This PR adds `TrackerEndcap_o2_v07_geo.cpp` to the list of excluded sources when LCIO is disabled in the CMakeLists. The compilation fails otherwise.

BEGINRELEASENOTES
- Exclude `TrackerEndcap_o2_v07_geo.cpp` when LCIO is disabled in the build

ENDRELEASENOTES

