### PR TITLE
Resize ALLEGRO DCH

### DIFF
--- a/FCCee/ALLEGRO/compact/ALLEGRO_o1_v03/DectDimensions.xml
+++ b/FCCee/ALLEGRO/compact/ALLEGRO_o1_v03/DectDimensions.xml
@@ -110,7 +110,9 @@
     <constant name="DCH_outer_cyl_R_total"          value=" 2015   * mm "  />
     <constant name="DCH_gas_outer_cyl_R"          value=" 2000 * mm "  />
     <constant name="DCH_half_length_total"          value=" 3000   * mm "  />
-    <constant name="DCH_gas_Lhalf"                value=" 2750 * mm "  />
+    <constant name="DCH_gas_Lhalf"                value=" 2750 * mm "  /> <!-- Important note: the z extent of the DCH has been enlarged for ALLEGRO to cover the available space but a more thorough re-engineering of the whole layout should be performed (e.g. the cell size should be adapted) to have a realistic implementation -->
+    <!-- Alfa = twistangle/2   -->
+    <constant name="DCH_alpha"                value=" 20.847 * deg "    /> <!-- Tuned to have similar stereo angle than for the IDEA implementation, using eq 2.1 of Hoshina et al, Computer Physics Communications 153 (2003) 3 -->
 
     <!-- End of Drift Chamber parameters    -->
 

--- a/FCCee/ALLEGRO/compact/ALLEGRO_o1_v03/DectDimensions.xml
+++ b/FCCee/ALLEGRO/compact/ALLEGRO_o1_v03/DectDimensions.xml
@@ -117,13 +117,13 @@
     <!-- Silicon wrapper. These values can be changed at will and the geometry will adapt accordingly. For questions contact Armin Ilg -->
     <constant name="SiWrB_inner_radius" value="2040*mm"/>   <!-- Can be freely changed, as long as SiWrB_outer_radius-SiWrB_inner_radius is kept constant. A radius of up to ~3 m is supported with the currently assumed sensor size -->
     <constant name="SiWrB_outer_radius" value="2080*mm"/>   <!-- Can be freely changed, as long as SiWrB_outer_radius-SiWrB_inner_radius is kept constant. A radius of up to ~3 m is supported with the currently assumed sensor size -->
-    <constant name="SiWrB_half_length"  value="2400*mm"/>   <!-- Can be freely changed -->
+    <constant name="SiWrB_half_length"  value="3150*mm"/>   <!-- Can be freely changed -->
     <constant name="SiWrD_inner_radius" value="350.0*mm"/>  <!-- Can be freely changed. Must be smaller than 'SiWrB_inner_radius' -->
     <constant name="SiWrD_outer_radius" value="2040.0*mm"/> <!-- Can be freely changed. Must be larger than 'SiWrD_inner_radius' and SiWrD_outer_radius-SiWrD_inner_radius must be smaller than ~ 2450 mm, otherwise the number of available rings is not large enough to cover the whole area -->
     <constant name="SiWrD_services_opening"  value="30*mm"/><!-- Can be freely changed. -->
     <constant name="SiWr_nLayers"       value="2"/>         <!-- Can be either 1 or 2 -->
-    <constant name="SiWrD_zmin"         value="2270.0*mm"/> <!-- Can be freely changed, as long as SiWrD_zmax-SiWrD_zmin is >7cm (SiWr_nLayers=2) or >=5cm (SiWr_nLayers=1) -->
-    <constant name="SiWrD_zmax"         value="2340.0*mm"/> <!-- Can be freely changed, as long as SiWrD_zmax-SiWrD_zmin is kept constant or is increased -->
+    <constant name="SiWrD_zmin"         value="3020.0*mm"/> <!-- Can be freely changed, as long as SiWrD_zmax-SiWrD_zmin is >7cm (SiWr_nLayers=2) or >=5cm (SiWr_nLayers=1) -->
+    <constant name="SiWrD_zmax"         value="3090.0*mm"/> <!-- Can be freely changed, as long as SiWrD_zmax-SiWrD_zmin is kept constant or is increased -->
     <constant name="SiWrB_pitch_z0"     value="1.000*mm"/>  <!-- The pitches can be freely changed and can be different for the two layers. These pitches here are just an assumption, impact on physics needs to be studied in detail! -->
     <constant name="SiWrB_pitch_z1"     value="0.050*mm"/>
     <constant name="SiWrB_pitch_phi0"   value="0.050*mm"/>

--- a/FCCee/ALLEGRO/compact/ALLEGRO_o1_v03/DectDimensions.xml
+++ b/FCCee/ALLEGRO/compact/ALLEGRO_o1_v03/DectDimensions.xml
@@ -106,8 +106,12 @@
     <!--  Drift Chamber parameters    -->
     <!-- Changing the radius is not enough to resize the detector, please contact the experts-->
     <constant name="DCH_inner_cyl_R_total"          value=" 349.8  * mm "  />
+    <constant name="DCH_gas_inner_cyl_R"          value=" 350 * mm "   />
     <constant name="DCH_outer_cyl_R_total"          value=" 2015   * mm "  />
-    <constant name="DCH_half_length_total"          value=" 2250   * mm "  />
+    <constant name="DCH_gas_outer_cyl_R"          value=" 2000 * mm "  />
+    <constant name="DCH_half_length_total"          value=" 3000   * mm "  />
+    <constant name="DCH_gas_Lhalf"                value=" 2750 * mm "  />
+
     <!-- End of Drift Chamber parameters    -->
 
     <!-- Silicon wrapper. These values can be changed at will and the geometry will adapt accordingly. For questions contact Armin Ilg -->

--- a/FCCee/IDEA/compact/IDEA_o1_v03/DectDimensions_IDEA_o1_v03.xml
+++ b/FCCee/IDEA/compact/IDEA_o1_v03/DectDimensions_IDEA_o1_v03.xml
@@ -106,8 +106,11 @@
     <!--  Drift Chamber parameters    -->
     <!-- Changing the radius is not enough to resize the detector, please contact the experts-->
     <constant name="DCH_inner_cyl_R_total"          value=" 349.8  * mm"  />
+    <constant name="DCH_gas_inner_cyl_R"          value=" 350 * mm "   />
     <constant name="DCH_outer_cyl_R_total"          value=" 2015.   * mm"  />
+    <constant name="DCH_gas_outer_cyl_R"          value=" 2000 * mm "  />
     <constant name="DCH_half_length_total"          value=" 2250.   * mm"  />
+    <constant name="DCH_gas_Lhalf"                value=" 2000 * mm "  />
 
     <constant name="Solenoid_inner_radius" value="2100*mm"/>
     <constant name="Solenoid_outer_radius" value="2400*mm"/>

--- a/FCCee/IDEA/compact/IDEA_o1_v03/DectDimensions_IDEA_o1_v03.xml
+++ b/FCCee/IDEA/compact/IDEA_o1_v03/DectDimensions_IDEA_o1_v03.xml
@@ -111,6 +111,8 @@
     <constant name="DCH_gas_outer_cyl_R"          value=" 2000 * mm "  />
     <constant name="DCH_half_length_total"          value=" 2250.   * mm"  />
     <constant name="DCH_gas_Lhalf"                value=" 2000 * mm "  />
+    <!-- Alfa = twistangle/2   -->
+    <constant name="DCH_alpha"                value=" 15*deg "    />
 
     <constant name="Solenoid_inner_radius" value="2100*mm"/>
     <constant name="Solenoid_outer_radius" value="2400*mm"/>

--- a/FCCee/IDEA/compact/IDEA_o1_v03/DriftChamber_o1_v02.xml
+++ b/FCCee/IDEA/compact/IDEA_o1_v03/DriftChamber_o1_v02.xml
@@ -32,9 +32,6 @@
   <constant name="DCH_nlayersPerSuperlayer" value=" 8 "    />
   <constant name="DCH_ncell_per_sector"     value=" 24 "   />
 
-  <!-- Alfa = twistangle/2   -->
-  <constant name="DCH_alpha"                value=" 15*deg "    />
-
   <!--  Parameters of first layer  -->
   <constant name="DCH_first_sense_r"        value=" DCH_guard_inner_r_at_z0 + 8*mm "        />
   <constant name="DCH_first_width"          value=" 2*pi* DCH_first_sense_r / DCH_ncell"    />

--- a/FCCee/IDEA/compact/IDEA_o1_v03/DriftChamber_o1_v02.xml
+++ b/FCCee/IDEA/compact/IDEA_o1_v03/DriftChamber_o1_v02.xml
@@ -8,11 +8,6 @@
   <!--     <constant name="DCH_outer_cyl_R_total"          value=" 2001 * mm "  /> -->
   <!--     <constant name="DCH_half_length_total"          value=" 2250 * mm "  /> -->
 
-  <!-- Gas (active volume) geometry     -->
-  <constant name="DCH_gas_inner_cyl_R"          value=" 350 * mm "   />
-  <constant name="DCH_gas_outer_cyl_R"          value=" 2000 * mm "  />
-  <constant name="DCH_gas_Lhalf"                value=" 2000 * mm "  />
-
   <!--    Vessel cylinder surrounds the gas cylinder in radius and z     -->
   <!--    Inner wall and outer wall have different thickness-->
   <constant name="DCH_vessel_thickness_innerR"           value=" DCH_gas_inner_cyl_R - DCH_inner_cyl_R_total"      />

--- a/FCCee/IDEA/compact/IDEA_o1_v04/DectDimensions_IDEA_o1_v04.xml
+++ b/FCCee/IDEA/compact/IDEA_o1_v04/DectDimensions_IDEA_o1_v04.xml
@@ -108,8 +108,11 @@
     <!--  Drift Chamber parameters    -->
     <!-- Changing the radius is not enough to resize the detector, please contact the experts-->
     <constant name="DCH_inner_cyl_R_total"          value=" 349.8  * mm"  />
+    <constant name="DCH_gas_inner_cyl_R"          value=" 350 * mm "   />
     <constant name="DCH_outer_cyl_R_total"          value=" 2015.   * mm"  />
+    <constant name="DCH_gas_outer_cyl_R"          value=" 2000 * mm "  />
     <constant name="DCH_half_length_total"          value=" 2250.   * mm"  />
+    <constant name="DCH_gas_Lhalf"                value=" 2000 * mm "  />
 
     <constant name="Solenoid_inner_radius" value="2100*mm"/>
     <constant name="Solenoid_outer_radius" value="2400*mm"/>

--- a/FCCee/IDEA/compact/IDEA_o1_v04/DectDimensions_IDEA_o1_v04.xml
+++ b/FCCee/IDEA/compact/IDEA_o1_v04/DectDimensions_IDEA_o1_v04.xml
@@ -113,6 +113,8 @@
     <constant name="DCH_gas_outer_cyl_R"          value=" 2000 * mm "  />
     <constant name="DCH_half_length_total"          value=" 2250.   * mm"  />
     <constant name="DCH_gas_Lhalf"                value=" 2000 * mm "  />
+    <!-- Alfa = twistangle/2   -->
+    <constant name="DCH_alpha"                value=" 15*deg "    />
 
     <constant name="Solenoid_inner_radius" value="2100*mm"/>
     <constant name="Solenoid_outer_radius" value="2400*mm"/>

--- a/FCCee/IDEA/compact/IDEA_o2_v01/DectDimensions_IDEA_o2_v01.xml
+++ b/FCCee/IDEA/compact/IDEA_o2_v01/DectDimensions_IDEA_o2_v01.xml
@@ -116,8 +116,11 @@
     <!--  Drift Chamber parameters    -->
     <!-- Changing the radius is not enough to resize the detector, please contact the experts-->
     <constant name="DCH_inner_cyl_R_total"          value=" 349.8  * mm"  />
+    <constant name="DCH_gas_inner_cyl_R"          value=" 350 * mm "   />
     <constant name="DCH_outer_cyl_R_total"          value=" 2015.   * mm"  />
+    <constant name="DCH_gas_outer_cyl_R"          value=" 2000 * mm "  />
     <constant name="DCH_half_length_total"          value=" 2250.   * mm"  />
+    <constant name="DCH_gas_Lhalf"                value=" 2000 * mm "  />
     
     <constant name="Solenoid_inner_radius" value="2500*mm"/>
     <constant name="Solenoid_outer_radius" value="2800*mm"/>

--- a/FCCee/IDEA/compact/IDEA_o2_v01/DectDimensions_IDEA_o2_v01.xml
+++ b/FCCee/IDEA/compact/IDEA_o2_v01/DectDimensions_IDEA_o2_v01.xml
@@ -121,6 +121,8 @@
     <constant name="DCH_gas_outer_cyl_R"          value=" 2000 * mm "  />
     <constant name="DCH_half_length_total"          value=" 2250.   * mm"  />
     <constant name="DCH_gas_Lhalf"                value=" 2000 * mm "  />
+    <!-- Alfa = twistangle/2   -->
+    <constant name="DCH_alpha"                value=" 15*deg "    />
     
     <constant name="Solenoid_inner_radius" value="2500*mm"/>
     <constant name="Solenoid_outer_radius" value="2800*mm"/>


### PR DESCRIPTION
BEGINRELEASENOTES
- [FCCee] Put envelope DCH parameters in DectDimensions and resize ALLEGRO DCH

ENDRELEASENOTES

In this version, I put the DCH sensitive length the same as the Straw Tube one, there is enough space to accommodate the DCH services. NB: a more thorough re-engineering would be needed to have a realistic detector layout but this will come later. The goal here is just to have a tracking system covering the available space inside the calorimeters.

Before the change:
<img width="1387" height="946" alt="Screenshot 2026-06-19 at 2 37 02 PM" src="https://github.com/user-attachments/assets/72cff862-3247-4371-a387-0c7b63bbf0eb" />

After the change:
<img width="1412" height="927" alt="Screenshot 2026-06-19 at 2 35 54 PM" src="https://github.com/user-attachments/assets/aa4dc19a-7c64-4f99-bb6c-631d5ff42783" />



