### PR TITLE
Fix compiler warnings about an implicit copy constructor

### DIFF
--- a/detectorCommon/include/detectorCommon/WireTracker_info.h
+++ b/detectorCommon/include/detectorCommon/WireTracker_info.h
@@ -41,6 +41,12 @@ namespace rec {
     /// type for angles
     using angle_t = double;
 
+    WireTracker_info_struct() = default;
+    WireTracker_info_struct(const WireTracker_info_struct&) = default;
+    WireTracker_info_struct& operator=(const WireTracker_info_struct&) = default;
+    WireTracker_info_struct(WireTracker_info_struct&&) = default;
+    WireTracker_info_struct& operator=(WireTracker_info_struct&&) = default;
+
     //--------------------------------------------------------------
     // Per-layer geometry record
 


### PR DESCRIPTION
BEGINRELEASENOTES
- Fix compiler warnings about an implicit copy constructor

ENDRELEASENOTES

These are the warnings:

```
/k4geo/detectorCommon/include/detectorCommon/WireTracker_info.h:123:13: warning: definition of implicit copy constructor for 'WireTracker_info_struct' is deprecated because it has a user-provided destructor [-Wdeprecated-copy-with-user-provided-dtor]
  123 |     virtual ~WireTracker_info_struct() {};
      |             ^

```

introduced in https://github.com/key4hep/k4geo/pull/581