### PR TITLE
fix(sim): use keyed calorimeter hit lookups

### DIFF
--- a/plugins/CaloPreShowerSDAction.cpp
+++ b/plugins/CaloPreShowerSDAction.cpp
@@ -81,7 +81,7 @@ namespace sim {
     Geant4HitCollection* coll = (layer == m_userData._firstLayerNumber ? collection(m_userData._preShowerCollectionID)
                                                                        : collection(m_collectionID));
 
-    Hit* hit = coll->find<Hit>(CellIDCompare<Hit>(cell));
+    Hit* hit = coll->findByKey<Hit>(cell);
     if (h.totalEnergy() < std::numeric_limits<double>::epsilon()) {
       return true;
     } else if (!hit) {
@@ -90,7 +90,7 @@ namespace sim {
       Position global = h.localToGlobal(pos);
       hit = new Hit(global);
       hit->cellID = cell;
-      coll->add(hit);
+      coll->add(cell, hit);
       printM2("%s> CREATE hit with deposit:%e MeV  Pos:%8.2f %8.2f %8.2f  %s", c_name(), contrib.deposit, pos.X, pos.Y,
               pos.Z, handler.path().c_str());
       if (0 == hit->cellID) { // for debugging only!

--- a/plugins/FiberDRCaloSDAction.cpp
+++ b/plugins/FiberDRCaloSDAction.cpp
@@ -225,8 +225,7 @@ namespace sim {
         G4double energy = step->GetTrack()->GetTotalEnergy();
 
         // default hit (optical photon count)
-        Geant4DRCalorimeter::Hit* drHit =
-            coll->find<Geant4DRCalorimeter::Hit>(CellIDCompare<Geant4DRCalorimeter::Hit>(cID));
+        Geant4DRCalorimeter::Hit* drHit = coll->findByKey<Geant4DRCalorimeter::Hit>(cID);
 
         if (!drHit) {
           drHit = new Geant4DRCalorimeter::Hit(m_userData.fWavlenStep, m_userData.fTimeStep);
@@ -267,8 +266,7 @@ namespace sim {
 
         // copy-paste of the dd4hep scintillation calorimeter SD
         Geant4HitCollection* coll_scint = collection(m_collectionID + 1);
-        Geant4Calorimeter::Hit* caloHit =
-            coll_scint->find<Geant4Calorimeter::Hit>(CellIDCompare<Geant4Calorimeter::Hit>(cID));
+        Geant4Calorimeter::Hit* caloHit = coll_scint->findByKey<Geant4Calorimeter::Hit>(cID);
         HitContribution contrib = Geant4Calorimeter::Hit::extractContribution(step, true);
 
         if (!caloHit) {
@@ -310,7 +308,7 @@ namespace sim {
                             global.z() * dd4hep::millimeter / CLHEP::millimeter);
 
       auto cID = m_segmentation->cellID(loc, glob, volID); // This returns cID corresponding to SiPM Wafer
-      Hit* hit = coll->find<Hit>(CellIDCompare<Hit>(cID));
+      Hit* hit = coll->findByKey<Hit>(cID);
 
       G4double hitTime = step->GetPostStepPoint()->GetGlobalTime();
       G4double energy = step->GetTrack()->GetTotalEnergy();


### PR DESCRIPTION
BEGINRELEASENOTES
- Fixed severe simulation slowdowns in DRcalo and pre-shower sensitive detectors by using keyed calorimeter hit lookups.

ENDRELEASENOTES


## Summary

The `IDEA_o1_v03` simulation of the `p8_ee_Zbb_ecm91` sample did not complete even a single event within the configured timeout, as reported in key4hep/k4Bench#83.

Profiling showed that the calorimeter sensitive detectors performed a linear search through the full hit collection for every simulation step. As the collection grows during large hadronic showers, this leads to approximately quadratic runtime scaling.

This PR:

* replaces linear `Geant4HitCollection::find()` searches with keyed `findByKey()` lookups
* uses the existing cell ID as the collection key
* updates `CaloPreShowerSDAction` to use matching keyed insertion
* reduces individual hit lookups from O(N) to O(log N)
* preserves the existing hit creation and accumulation behaviour

With these changes, the previously stuck `Z → bb` event simulation completes successfully.

fyi @BrieucF 