### PR TITLE
Fix the thickness of the sense wires in the drift chamber

### DIFF
--- a/detector/tracker/DriftChamber_o1_v02.cpp
+++ b/detector/tracker/DriftChamber_o1_v02.cpp
@@ -294,7 +294,7 @@ static dd4hep::Ref_t create_DCH_o1_v02(dd4hep::Detector& desc, dd4hep::xml::Hand
       DCH_length_t swlength = 0.5 * DCH_i->WireLength(ilayer, cell_rave_z0) -
                               cell_swire_radius * cos(DCH_i->stereoangle_z0(cell_rave_z0)) - safety_z_interspace;
       if (buildSenseWires) {
-        dd4hep::Tube swire_s(0., dch_SWire_thickness, swlength);
+        dd4hep::Tube swire_s(0., cell_swire_radius, swlength);
         dd4hep::Volume swire_v(cell_name + "_swire", swire_s, dch_SWire_material);
         swire_v.setVisAttributes(wiresVis);
         // Change sign of stereo angle to place properly the wire inside the twisted tube


### PR DESCRIPTION
To ease the review process, please consider the following before opening a pull request:
- [x] the code is sufficiently well documented (e.g. inline comments)
- [x] the relevant README(s) were updated. See e.g. https://github.com/key4hep/k4geo/blob/main/detector/calorimeter/README.md or https://github.com/key4hep/k4geo/blob/main/FCCee/IDEA/compact/README.md
- [x] the code is covered by tests. See https://github.com/key4hep/k4geo/blob/main/test/CMakeLists.txt
- [x] the PR source branch has been rebased (`--ff-only`) to `k4geo/main`
- [x] the PR does not contain any additions or modifications that do not belong to it
- [x] The release notes below contain a succinct and comprehensive description of the changes that are sufficiently self-explanatory

If you are modifying detector dimensions or adding new xml parameters, also consider the following:
- [x] the xml file free parameters that can not be modified without additional prescriptions are well indicated
- [x] the changes in this PR have not introduced any overlaps. You can check so with the following command: `ddsim --compactFile PATH_TO_COMPACT_FILE --runType run --ui.commandsInitialize "/geometry/test/run" > overlapDump.txt`

BEGINRELEASENOTES
- Fix thickness in the sense wires in the drift chamber, where the radius of the tubes is set to the thickness causing them to have a diameter of 2*thickness

ENDRELEASENOTES

All the other tubes seem to have their radius correctly set to thickness / 2, see, for example, https://github.com/key4hep/k4geo/blob/e26121080e1a5f0745c3e690ee0fb357ed808269/detector/tracker/DriftChamber_o1_v02.cpp#L364