### PR TITLE
Remove unused private fields from FCCSWEndcapTurbine_k4geo

### DIFF
--- a/detectorSegmentations/include/detectorSegmentations/FCCSWEndcapTurbine_k4geo.h
+++ b/detectorSegmentations/include/detectorSegmentations/FCCSWEndcapTurbine_k4geo.h
@@ -208,15 +208,9 @@ namespace DDSegmentation {
     /// the number of readout cells ganged into a single calibration cell
     /// in Z
     std::vector<int> m_gangedZLayers;
-    /// the number of bins in phi
-    int m_phiBins;
-    /// the coordinate offset in phi
-    double m_offsetPhi;
     /// the coordinate offset in theta
     double m_offsetTheta; /// the field name used for phi
     std::string m_phiID;
-    /// the number of bins in rho
-    int m_rhoBins;
     ////grid size in rho
     std::vector<double> m_gridSizeRho;
     /// vector that holds local z positions.


### PR DESCRIPTION
BEGINRELEASENOTES

- Removed unused private fields (m_phiBins, m_offsetPhi, m_rhoBins) from FCCSWEndcapTurbine_k4geo class to eliminate compiler warnings

ENDRELEASENOTES

Compiler warnings (Clang 22):
```
/k4geo/detectorSegmentations/include/detectorSegmentations/FCCSWEndcapTurbine_k4geo.h:212:9: warning: private field 'm_phiBins' is not used [-Wunused-private-field]
  212 |     int m_phiBins;
      |         ^
/k4geo/detectorSegmentations/include/detectorSegmentations/FCCSWEndcapTurbine_k4geo.h:214:12: warning: private field 'm_offsetPhi' is not used [-Wunused-private-field]
  214 |     double m_offsetPhi;
      |            ^
/k4geo/detectorSegmentations/include/detectorSegmentations/FCCSWEndcapTurbine_k4geo.h:219:9: warning: private field 'm_rhoBins' is not used [-Wunused-private-field]
  219 |     int m_rhoBins;
      |         ^
```
