### PR TITLE
Fix flat index in turbine endcap local z lookup

### DIFF
--- a/detectorSegmentations/include/detectorSegmentations/FCCSWEndcapTurbine_k4geo.h
+++ b/detectorSegmentations/include/detectorSegmentations/FCCSWEndcapTurbine_k4geo.h
@@ -18,15 +18,17 @@ namespace DDSegmentation {
   class EndcapTurbineWheelLocalZ {
   public:
     // constructor with number of rho and z cells in wheel
-    EndcapTurbineWheelLocalZ(unsigned numReadoutLayersRho, unsigned numReadoutLayersZ) {
+    EndcapTurbineWheelLocalZ(unsigned numReadoutLayersRho, unsigned numReadoutLayersZ)
+        : m_numReadoutLayersZ(numReadoutLayersZ) {
       m_localZ.resize(numReadoutLayersRho * numReadoutLayersZ);
     }
     // set the value of the local z position for a given rho, z cell index
-    void setLocalZ(unsigned iRho, unsigned iZ, float zpos) { m_localZ[iRho * iZ] = zpos; }
+    void setLocalZ(unsigned iRho, unsigned iZ, float zpos) { m_localZ.at(iRho * m_numReadoutLayersZ + iZ) = zpos; }
     // return the value of the local z position for a given rho, z cell index
-    float getLocalZ(unsigned iRho, unsigned iZ) const { return m_localZ[iRho * iZ]; }
+    float getLocalZ(unsigned iRho, unsigned iZ) const { return m_localZ.at(iRho * m_numReadoutLayersZ + iZ); }
 
   private:
+    unsigned m_numReadoutLayersZ{};
     std::vector<float> m_localZ;
   };
 


### PR DESCRIPTION
BEGINRELEASENOTES
Fix flat index in turbine endcap local z lookup

ENDRELEASENOTES

The local `z` values are stored in a one-dimensional vector, but each value is identified by two indices: the radial layer (`iRho`) and the `z` layer (`iZ`).

The previous calculation, `iRho * iZ`, does not uniquely identify a cell. Different index pairs can produce the same result, for example, `(1, 2)` and `(2, 1)` both map to index `2`. Some values are therefore written to the wrong position or overwrite another cell’s value.

The correct flat index is `iRho * numReadoutLayersZ + iZ`, which assigns every `(iRho, iZ)` pair its own position in the vector.
