### PR TITLE
Properly propagate usage of LCIO to downstream consumers

### DIFF
--- a/cmake/k4geoConfig.cmake.in
+++ b/cmake/k4geoConfig.cmake.in
@@ -1,5 +1,10 @@
 set(k4geo_VERSION @k4geo_VERSION@)
 
+# Whether this k4geo was built against LCIO (K4GEO_USE_LCIO at build time).
+# Consumers can query it to know if the LCIO-dependent detector constructors
+# and plugins are present in this installation.
+set(k4geo_USE_LCIO @K4GEO_USE_LCIO@)
+
 @PACKAGE_INIT@
 
 set_and_check(k4geo_CMAKE_DIR "@PACKAGE_CMAKE_INSTALL_CMAKEDIR@")
@@ -9,7 +14,9 @@ include(CMakeFindDependencyMacro)
 find_dependency(DD4hep REQUIRED)
 find_dependency(Geant4 REQUIRED)
 find_dependency(ROOT REQUIRED COMPONENTS Geom GenVector)
-find_dependency(LCIO REQUIRED)
+if(k4geo_USE_LCIO)
+  find_dependency(LCIO REQUIRED)
+endif()
 
 include(${k4geo_CMAKE_DIR}/k4geoConfig-targets.cmake)
 


### PR DESCRIPTION
To ease the review process, please consider the following before opening a pull request:
- [x] the code is sufficiently well documented (e.g. inline comments)
- [ ] the relevant README(s) were updated. See e.g. https://github.com/key4hep/k4geo/blob/main/detector/calorimeter/README.md or https://github.com/key4hep/k4geo/blob/main/FCCee/IDEA/compact/README.md
- [ ] the code is covered by tests. See https://github.com/key4hep/k4geo/blob/main/test/CMakeLists.txt
- [x] the PR source branch has been rebased (`--ff-only`) to `k4geo/main`
- [x] the PR does not contain any additions or modifications that do not belong to it
- [x] The release notes below contain a succinct and comprehensive description of the changes that are sufficiently self-explanatory

BEGINRELEASENOTES
- Fixed propagation of cmake arguments to turn off lcio dependencies.

ENDRELEASENOTES

This PR fixes an issue where k4geo would look for lcio unconditionally when included as dependency by another package in the stack, even if it was explicitly built without LCIO.