### PR TITLE
Remove dead code to facilitate dropping LCIO as a dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,15 +88,11 @@ if(NOT K4GEO_USE_LCIO)
     TrackerBarrel_o1_v03_geo.cpp
     TrackerBarrel_o1_v04_geo.cpp
     TrackerBarrel_o1_v05_geo.cpp
-    TrackerBarrel_o1_v06_geo.cpp
     TrackerEndcap_o1_v05_geo.cpp
     TrackerEndcap_o2_v06_geo.cpp
     TrackerEndcap_o2_v07_geo.cpp
-    StrawTubeTracker_o1_v01_geo.cpp
-    VertexBarrel_detailed_o1_v01_geo.cpp
     VertexEndcap_o1_v05_geo.cpp
     ZPlanarTracker_geo.cpp
-    ZSegmentedPlanarTracker_geo.cpp
     )
   foreach(lcio_source ${lcio_sources})
     list(FILTER sources EXCLUDE REGEX "${lcio_source}")

--- a/detector/tracker/TrackerBarrel_o1_v06_geo.cpp
+++ b/detector/tracker/TrackerBarrel_o1_v06_geo.cpp
@@ -16,11 +16,6 @@
 #include "XML/DocumentHandler.h"
 #include "XML/Utilities.h"
 
-#include "UTIL/LCTrackerConf.h"
-#include <UTIL/BitField64.h>
-#include <UTIL/BitSet32.h>
-#include <UTIL/ILDConf.h>
-
 using dd4hep::_toString;
 using dd4hep::Assembly;
 using dd4hep::Box;
@@ -88,13 +83,6 @@ static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector s
   std::map<std::string, Volume> volumes;
   std::map<std::string, Placements> sensitives;
   PlacedVolume pv;
-
-  // for encoding
-  std::string cellIDEncoding = sens.readout().idSpec().fieldDescription();
-  UTIL::BitField64 encoder(cellIDEncoding);
-  encoder.reset();
-  encoder[lcio::LCTrackerCellID::subdet()] = det_id;
-  encoder[lcio::LCTrackerCellID::side()] = lcio::ILDDetID::barrel;
 
   // --- create an envelope volume and position it into the world ---------------------
 

--- a/detector/tracker/ZSegmentedPlanarTracker_geo.cpp
+++ b/detector/tracker/ZSegmentedPlanarTracker_geo.cpp
@@ -15,10 +15,6 @@
 #include "DDRec/DetectorData.h"
 #include "DDRec/Surface.h"
 
-#include <UTIL/BitField64.h>
-#include <UTIL/BitSet32.h>
-#include <UTIL/ILDConf.h>
-
 using dd4hep::_toString;
 using dd4hep::Assembly;
 using dd4hep::Box;


### PR DESCRIPTION
To ease the review process, please consider the following before opening a pull request:
- [x] the code is sufficiently well documented (e.g. inline comments)
- [ ] the relevant README(s) were updated. See e.g. https://github.com/key4hep/k4geo/blob/main/detector/calorimeter/README.md or https://github.com/key4hep/k4geo/blob/main/FCCee/IDEA/compact/README.md
- [x] the code is covered by tests. See https://github.com/key4hep/k4geo/blob/main/test/CMakeLists.txt
- [x] the PR source branch has been rebased (`--ff-only`) to `k4geo/main`
- [x] the PR does not contain any additions or modifications that do not belong to it
- [x] The release notes below contain a succinct and comprehensive description of the changes that are sufficiently self-explanatory

BEGINRELEASENOTES
- Removed unused dependencies on LCIO classes from TrackerBarrel_o1_v06 and ZSegmentedPlanarTracker
- Removed drivers not depending on LCIO from K4GEO_USE_LCIO exclusion list in CMakeLists
 
ENDRELEASENOTES

A bit of housekeeping before getting rid of the LCIO dependencies (planned to do by swapping the LCIO encoders with the drop-in dd4hep classes already used in some parts of the repo).
I kept this separate because it's technically unrelated to the port.
