### PR TITLE
Backport some multithreading guards from upstream to the EDM4hep DRC output action

### DIFF
--- a/plugins/Geant4Output2EDM4hep_DRC.cpp
+++ b/plugins/Geant4Output2EDM4hep_DRC.cpp
@@ -27,6 +27,8 @@ using ROOTWriter = podio::ROOTFrameWriter;
 }
 #endif
 
+#include <atomic>
+
 #include "FiberDRCaloSDAction.h"
 
 /// Namespace for the AIDA detector description toolkit
@@ -58,6 +60,7 @@ namespace sim {
     using drcaloWavmap_t = std::map<std::string, edm4hep::RawTimeSeriesCollection>;
 
     std::unique_ptr<writer_t> m_file{};
+    std::atomic_size_t m_fileUseCount{0};
     podio::Frame m_frame{};
     edm4hep::MCParticleCollection m_particles{};
     trackermap_t m_trackerHits;
@@ -231,7 +234,6 @@ Geant4Output2EDM4hep_DRC::Geant4Output2EDM4hep_DRC(Geant4Context* ctxt, const st
 /// Default destructor
 Geant4Output2EDM4hep_DRC::~Geant4Output2EDM4hep_DRC() {
   G4AutoLock protection_lock(&action_mutex);
-  m_file.reset();
   InstanceCount::decrement(this);
 }
 
@@ -246,23 +248,31 @@ void Geant4Output2EDM4hep_DRC::beginRun(const G4Run* run) {
       fname = m_output.substr(0, idx) + _toString(m_runNo, ".run%08d") + m_output.substr(idx);
     }
   }
-  if (!fname.empty()) {
+  // Create the file only when it has not yet been created in another thread
+  if (!fname.empty() && !m_file) {
     m_file = std::make_unique<podio::ROOTWriter>(fname);
     if (!m_file) {
       fatal("+++ Failed to open output file: %s", fname.c_str());
     }
     printout(INFO, "Geant4Output2EDM4hep_DRC", "Opened %s for output", fname.c_str());
   }
+  m_fileUseCount++;
 }
 
 /// Callback to store the Geant4 run information
 void Geant4Output2EDM4hep_DRC::endRun(const G4Run* run) {
   saveRun(run);
   saveFileMetaData();
-  if (m_file) {
+
+  // Close the file only when this is the last thread using it.
+  // Note: Although the use count is atomic, the file pointer is not,
+  // and testing it requires locking.
+  G4AutoLock protection_lock(&action_mutex);
+  if (m_file && m_fileUseCount == 1) {
     m_file->finish();
     m_file.reset();
   }
+  m_fileUseCount--;
 }
 
 void Geant4Output2EDM4hep_DRC::saveFileMetaData() {
@@ -270,7 +280,7 @@ void Geant4Output2EDM4hep_DRC::saveFileMetaData() {
   for (const auto& [name, encodingStr] : m_cellIDEncodingStrings) {
     metaFrame.putParameter(name + "__CellIDEncoding", encodingStr);
   }
-
+  G4AutoLock protection_lock(&action_mutex);
   m_file->writeFrame(metaFrame, "metadata");
 }
 
@@ -294,7 +304,7 @@ void Geant4Output2EDM4hep_DRC::commit(OutputContext<G4Event>& /* ctxt */) {
       m_frame.put(std::move(it->second), it->first + "WaveLen");
     }
     m_file->writeFrame(m_frame, m_section_name);
-    m_particles.clear();
+    m_particles = {};
     m_trackerHits.clear();
     m_calorimeterHits.clear();
     m_drcaloHits.clear();
@@ -321,12 +331,15 @@ void Geant4Output2EDM4hep_DRC::saveRun(const G4Run* run) {
   runHeader.putParameter("DD4hepVersion", versionString());
   runHeader.putParameter("detectorName", context()->detectorDescription().header().name());
 
-  RunParameters* parameters = context()->run().extension<RunParameters>(false);
-  if (parameters) {
-    parameters->extractParameters(runHeader);
-  }
+  // In multithreaded running, the run is present in only one of the contexts
+  if (context()->runPtr() != nullptr) {
+    RunParameters* parameters = context()->run().extension<RunParameters>(false);
+    if (parameters) {
+      parameters->extractParameters(runHeader);
+    }
 
-  m_file->writeFrame(runHeader, "runs");
+    m_file->writeFrame(runHeader, "runs");
+  }
 }
 
 void Geant4Output2EDM4hep_DRC::begin(const G4Event* event) {


### PR DESCRIPTION
The DD4hep EDM4hep output action has gained multithreading support in https://github.com/AIDASoft/DD4hep/pull/1417 which was never ported to here. With the merge of https://github.com/AIDASoft/DD4hep/pull/1240 that starts to lead to runtime crashes when using this output action.

To ease the review process, please consider the following before opening a pull request:
- [ ] the code is sufficiently well documented (e.g. inline comments)
- [ ] the relevant README(s) were updated. See e.g. https://github.com/key4hep/k4geo/blob/main/detector/calorimeter/README.md or https://github.com/key4hep/k4geo/blob/main/FCCee/IDEA/compact/README.md
- [ ] the code is covered by tests. See https://github.com/key4hep/k4geo/blob/main/test/CMakeLists.txt
- [ ] the PR source branch has been rebased (`--ff-only`) to `k4geo/main`
- [ ] the PR does not contain any additions or modifications that do not belong to it
- [ ] The release notes below contain a succinct and comprehensive description of the changes that are sufficiently self-explanatory

If you are modifying detector dimensions or adding new xml parameters, also consider the following:
- [ ] the xml file free parameters that can not be modified without additional prescriptions are well indicated
- [ ] the changes in this PR have not introduced any overlaps. You can check so with the following command: `ddsim --compactFile PATH_TO_COMPACT_FILE --runType run --ui.commandsInitialize "/geometry/test/run" > overlapDump.txt`

BEGINRELEASENOTES
- Backport multithreading support to the DRC EDM4hep output action from the upstream EDM4hep output action that have been missing so far.

ENDRELEASENOTES

The DD4hep EDM4hep output action has gained multithreading support in
https://github.com/AIDASoft/DD4hep/pull/1417 which was never ported to
here. With the merge of https://github.com/AIDASoft/DD4hep/pull/1240
that starts to lead to runtime crashes when using this output action.

This should fix the CI failures that we currently see for the Key4hep nightlies.

I suppose this could also be used as a trigger for a discussion of whether it's possible to upstream this version of the action so that we don't run into similar issues / divergences in the future.

